### PR TITLE
Supprime la configuration travis

### DIFF
--- a/.circleci/has-functional-changes.sh
+++ b/.circleci/has-functional-changes.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-IGNORE_DIFF_ON="README.md CONTRIBUTING.md Makefile .gitignore .circleci/* .github/*"
+IGNORE_DIFF_ON="README.md CONTRIBUTING.md Makefile .gitignore .travis.yml .circleci/* .github/*"
 
 last_tagged_commit=`git describe --tags --abbrev=0 --first-parent`  # --first-parent ensures we don't follow tags not published in master through an unlikely intermediary merge commit
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: python
-python: "2.7"
-cache: pip
-install:
-  - pip install --upgrade pip wheel  # pip >= 8.0 needed to be compatible with "manylinux" wheels, used by numpy >= 1.11
-  - pip install flake8
-  - pip install -e .[tests,notebook]
-script: make test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenFisca Tunisia - الجباية المفتوحة  تونس
 
-[![Build Status via Travis CI](https://travis-ci.org/openfisca/openfisca-tunisia.svg?branch=master)](https://travis-ci.org/openfisca/openfisca-tunisia)
+[![CircleCI](https://circleci.com/gh/openfisca/openfisca-tunisia/tree/master.svg?style=svg)](https://circleci.com/gh/openfisca/openfisca-tunisia/tree/master)
 
 ## Presentation - التقديم
 


### PR DESCRIPTION
* Supprime la configuration du service travis
* Met à jour le badge de statut de la page d'accueil

> Et service Travis supprimé des [paramètres](https://github.com/openfisca/openfisca-tunisia/settings/hooks/3248802). 