### PR TITLE
Update cache name and restore git tag in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,12 +39,6 @@ jobs:
           name: Run tests and check notebooks
           command: make test
 
-      - run:
-          name: Check version number has been properly updated
-          command: |
-            git fetch
-            .circleci/is-version-number-acceptable.sh
-
   deploy_python3:
     docker:
       - image: python:3.7
@@ -72,15 +66,28 @@ jobs:
           name: Publish a git tag
           command: .circleci/publish-git-tag.sh
 
+  check_version_and_changelog:
+    docker:
+      - image: python:3.7
+    steps:
+      - checkout
+
+      - run:
+          name: Check version number has been properly updated
+          command: |
+            git fetch
+            .circleci/is-version-number-acceptable.sh
 
 workflows:
   version: 2
   build_and_deploy:
     jobs:
       - build_python3
+      - check_version_and_changelog
       - deploy_python3:
           requires:
             - build_python3
+            - check_version_and_changelog
           filters:
             branches:
               only: master


### PR DESCRIPTION
Met à jour la configuration CircleCI : 
* Rétablit l'étape de git tag automatique de la branche master → bug fix
* Conditionne le cache à la branche en intégrant le nom de la branche au nom du cache 
* Utilise l'image docker employée par openfisca-core
* Fait apparaître l'étape de check de la montée de version dans une étape séparée du build

> Note : 
Espoir de corriger le problème d'accès à la commande `pip` sur CircleCI (bug du build [tn-262](https://circleci.com/gh/openfisca/openfisca-tunisia/262)) par le changement de cache (voire d'image docker)
