### PR TITLE
Upgrade to core v30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.27.0 - [#101](https://github.com/openfisca/openfisca-tunisia/pull/101)
+
+* Migrate to `openfisca-core` v30
+  * Adapt `de_net_a_imposable` and `de_net_a_salaire_de_base` reforms
+
 ## 0.26.0 - [#90](https://github.com/openfisca/openfisca-tunisia/pull/90)
 
 * Migrate to `openfisca-core` v29
@@ -21,7 +26,7 @@
 ## 0.23.0 - [#85](https://github.com/openfisca/openfisca-tunisia/pull/85)
 
 * Improve `reforms/de_net_a_salaire_de_base.py`
-  * Adapt with`ouvriere_2016_02.yaml` use case
+  * Adapt with `ouvriere_2016_02.yaml` use case
 * Add `reforms/de_net_a_salaire_de_base/ouvriere_2016_02.yaml` test
 
 ### 0.22.1 - [#78](https://github.com/openfisca/openfisca-tunisia/pull/78)

--- a/openfisca_tunisia/reforms/de_net_a_imposable.py
+++ b/openfisca_tunisia/reforms/de_net_a_imposable.py
@@ -1,16 +1,10 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import division
 
 from openfisca_tunisia.model.base import *
 from openfisca_tunisia import entities
 
 from numpy.ma.testutils import assert_not_equal
-
-try:
-    from urllib.request import Request  # python 3.0 and later
-except ImportError:
-    from urllib2 import Request  # python 2
+from urllib.request import Request
 
 try:
     from scipy.optimize import fsolve
@@ -19,7 +13,8 @@ except ImportError:
 
 
 def calculate_net_from(salaire_imposable, individu, period, requested_variable_names):
-    # We're not wanting to calculate salaire_imposable again, but instead manually set it as an input variable
+    # We're not wanting to calculate salaire_imposable again, 
+    # but instead manually set it as an input variable
     individu.get_holder('salaire_imposable').put_in_cache(salaire_imposable, period)
 
     # Work in isolation
@@ -58,7 +53,7 @@ class salaire_imposable(Variable):
         # that might contain undesired cache
         requested_variable_names = [name for (name, period) in individu.simulation.computation_stack]
         if requested_variable_names:
-            requested_variable_names.remove(u'salaire_imposable')
+            requested_variable_names.remove('salaire_imposable')
 
         def solve_func(net):
             def innerfunc(essai):
@@ -76,7 +71,7 @@ class salaire_imposable(Variable):
 
 
 class de_net_a_imposable(Reform):
-    name = u'Inversion du calcul imposable -> net'
+    name = 'Inversion du calcul imposable -> net'
 
     def apply(self):
         self.update_variable(salaire_imposable)

--- a/openfisca_tunisia/reforms/de_net_a_imposable.py
+++ b/openfisca_tunisia/reforms/de_net_a_imposable.py
@@ -56,14 +56,9 @@ class salaire_imposable(Variable):
         simulation.period = period
         # List of variables already calculated. We will need it to remove their holders,
         # that might contain undesired cache
-        requested_variable_names = list(simulation.requested_periods_by_variable_name.keys())
+        requested_variable_names = [name for (name, period) in individu.simulation.computation_stack]
         if requested_variable_names:
             requested_variable_names.remove(u'salaire_imposable')
-        # Clean 'requested_periods_by_variable_name', that is used by -core to check for computation cycles.
-        # This variable, salaire_imposable, might have been called from variable X,
-        # that will be calculated again in our iterations to compute the salaire_net_a_payer requested
-        # as an input variable, hence producing a cycle error
-        simulation.requested_periods_by_variable_name = dict()
 
         def solve_func(net):
             def innerfunc(essai):

--- a/openfisca_tunisia/reforms/de_net_a_salaire_de_base.py
+++ b/openfisca_tunisia/reforms/de_net_a_salaire_de_base.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import division
-
 from openfisca_tunisia.model.base import Reform, Variable, Individu, MONTH, set_input_divide_by_period 
 
 
@@ -10,33 +9,24 @@ try:
 except ImportError:
     fsolve = None
 
-i=0
 
 def calculate_net_from(salaire_de_base, individu, period, requested_variable_names):
-    global i
-    print(">>> ", i)
-    i += 1
-
-    # We're not wanting to calculate salaire_imposable again, 
-    # but instead manually set it as an input variable
-    print('requested_variable_names >>> ', requested_variable_names)
-    
-    ## print('salaire_de_base >>>', individu.get_holder('salaire_de_base').get_array(period))
-    ## print('salaire_de_base', salaire_de_base)
-    ###  individu.get_holder('salaire_de_base').set_input(period, salaire_de_base)
-
     # Work in isolation
     temp_simulation = individu.simulation.clone()
     temp_individu = temp_simulation.individu
-    temp_individu.get_holder('salaire_de_base').delete_arrays(period)
-    temp_individu.get_holder('salaire_de_base').set_input(period, salaire_de_base)
 
     # Calculated variable holders might contain undesired cache
     # (their entity.simulation points to the original simulation above)
     for name in requested_variable_names:
-        temp_individu.get_holder(name).delete_arrays()
-        temp_simulation.computation_stack = temp_simulation.computation_stack[-1:]
-        print(temp_simulation.computation_stack)
+        temp_individu.get_holder(name).delete_arrays(period)
+
+    # Clean 'computation_stack', that is used by -core to check for computation cycles.
+    # The variable 'salaire_imposable' might have been called from variable X,
+    # that will be calculated again in our iterations to compute the 'salaire_net_a_payer'
+    # requested as an input variable, hence producing a cycle error
+    temp_simulation.computation_stack = []
+
+    temp_individu.get_holder('salaire_de_base').set_input(period, salaire_de_base)
 
     # Force recomputing of salaire_net_a_payer
     temp_individu.get_holder('salaire_net_a_payer').delete_arrays()
@@ -53,12 +43,7 @@ class salaire_de_base(Variable):
     set_input = set_input_divide_by_period
 
     def formula(individu, period):
-        # Calcule le salaire de base à partir du salaire net par inversion numérique.
-
-        ### print("salaire_net_a_payer", individu.get_holder('salaire_net_a_payer').get_array(period))
-        # print("assiette_cotisations_sociales", individu.get_holder('assiette_cotisations_sociales').get_array(period))
-        # print("salaire_imposable", individu.get_holder('salaire_imposable').get_array(period))
-        # print("salaire_de_base", individu.get_holder('salaire_de_base').get_array(period))
+        # Use numerical inversion to calculate 'salaire_de_base' from 'salaire_net_a_payer'
         net = individu.get_holder('salaire_net_a_payer').get_array(period)
 
         if net is None:
@@ -66,28 +51,10 @@ class salaire_de_base(Variable):
 
         simulation = individu.simulation
         simulation.period = period
-        # List of variables already calculated. We will need it to remove their holders,
-        # that might contain undesired cache
-        ## requested_variable_names = list(simulation.requested_periods_by_variable_name.keys())
+
+        # List of variables already calculated. 
+        # We will need it to remove their holders, that might contain undesired cache
         requested_variable_names = [variable_period[0] for variable_period in simulation.computation_stack]
-        print("requested_variable_names", requested_variable_names)
-        print("simulation.computation_stack", simulation.computation_stack)
-        if requested_variable_names:
-            # requested_variable_names.remove('assiette_cotisations_sociales')
-            # requested_variable_names.remove('salaire_imposable')
-            requested_variable_names.remove('salaire_de_base')
-            
-        
-        # Clean 'requested_periods_by_variable_name', that is used by -core to check for computation cycles.
-        # avant : requested_periods_by_variable_name = {variable_name: [period1, period2]}
-        # maintenant : computation_stack = [('variable_name', 'period1'), ('variable_name', 'period2')]
-
-
-
-        # This variable, salaire_imposable, might have been called from variable X,
-        # that will be calculated again in our iterations to compute the salaire_net requested
-        # as an input variable, hence producing a cycle error
-        simulation.requested_periods_by_variable_name = dict()
 
         def solve_func(net):
             def innerfunc(essai_salaire_de_base):

--- a/openfisca_tunisia/reforms/de_net_a_salaire_de_base.py
+++ b/openfisca_tunisia/reforms/de_net_a_salaire_de_base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import division
 from openfisca_tunisia.model.base import Reform, Variable, Individu, MONTH, set_input_divide_by_period 
 
@@ -72,7 +70,7 @@ class salaire_de_base(Variable):
 
 
 class de_net_a_salaire_de_base(Reform):
-    name = u'Inversion du calcul brut (salaire_de_base) -> net'
+    name = 'Inversion du calcul brut (salaire_de_base) -> net'
 
     def apply(self):
         self.update_variable(salaire_de_base)

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         ),
     include_package_data = True,  # Will read MANIFEST.in
     install_requires = [
-        'OpenFisca-Core >=29, <30',
+        'OpenFisca-Core >=30, <31',
         'PyYAML >= 3.10',
         'scipy >= 0.12',
         ],

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ doc_lines = __doc__.split('\n')
 
 setup(
     name = 'OpenFisca-Tunisia',
-    version = '0.26.0',
+    version = '0.27.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [classifier for classifier in classifiers.split('\n') if classifier],


### PR DESCRIPTION
Connected to #93 

* Met à jour la dépendance Core à la version `30.0.3`
  * Affecte les réformes `de_net_a_imposable` et `de_net_a_salaire_de_base`.
* Supprime la compatibilité Python 2 des réformes `de_net_a_imposable` et `de_net_a_salaire_de_base`.
