### PR TITLE
Met à jour core à v34 et survey-manager à v0.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.30.0 - [#107](https://github.com/openfisca/openfisca-tunisia/pull/107)
+
+* Migrate to `openfisca-core` v34
+  * Migrate to v32, v33 and v34
+* Update `openfisca-survey-manager` dependency to v0.32
+* Remove the upper bound of children number for `Menage` entity
+
 ## 0.29.0 - [#105](https://github.com/openfisca/openfisca-tunisia/pull/105)
 
 * Migrate tests library and syntax from `nose` to `pytest`

--- a/openfisca_tunisia/entities.py
+++ b/openfisca_tunisia/entities.py
@@ -48,8 +48,7 @@ Menage = build_entity(
         {
             'key': 'enfant',
             'plural': 'enfants',
-            'label': 'Enfants',
-            'max': 2
+            'label': 'Enfants'
             },
         {
             'key': 'autre',

--- a/openfisca_tunisia/model/prestations_familiales.py
+++ b/openfisca_tunisia/model/prestations_familiales.py
@@ -87,7 +87,7 @@ class prestations_familiales_enfant_a_charge(Variable):
     def formula(individu, period, parameters):
         age = individu('age', period)
         invalide = individu('invalide', period)
-        est_enfant = individu.has_role(Menage.enfant)
+        est_enfant = individu.has_role(Menage.ENFANT)
 
         condition_enfant = or_(
             (age_individu <= 16) +

--- a/openfisca_tunisia/reforms/de_net_a_imposable.py
+++ b/openfisca_tunisia/reforms/de_net_a_imposable.py
@@ -52,7 +52,7 @@ class salaire_imposable(Variable):
 
         # List of variables already calculated.
         # We will need it to remove their holders, that might contain undesired cache
-        requested_variable_names = [name for (name, period) in individu.simulation.computation_stack]
+        requested_variable_names = [stack_frame['name'] for stack_frame in individu.simulation.tracer.stack]
 
         def solve_func(net):
             def innerfunc(essai):

--- a/openfisca_tunisia/reforms/de_net_a_salaire_de_base.py
+++ b/openfisca_tunisia/reforms/de_net_a_salaire_de_base.py
@@ -52,7 +52,7 @@ class salaire_de_base(Variable):
 
         # List of variables already calculated.
         # We will need it to remove their holders, that might contain undesired cache
-        requested_variable_names = [variable_period[0] for variable_period in simulation.computation_stack]
+        requested_variable_names = [stack_frame['name'] for stack_frame in simulation.tracer.stack]
 
         def solve_func(net):
             def innerfunc(essai_salaire_de_base):

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
             'pandas >= 0.22.0',
             ],
         survey = [
-            'OpenFisca-Survey-Manager >=0.9.5,<0.31',
+            'OpenFisca-Survey-Manager >=0.9.5,<0.33',
             ]
         ),
     include_package_data = True,  # Will read MANIFEST.in

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         ),
     include_package_data = True,  # Will read MANIFEST.in
     install_requires = [
-        'OpenFisca-Core >=31, <32',
+        'OpenFisca-Core >=32, <33',
         'PyYAML >= 3.10',
         'scipy >= 0.12',
         ],

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         ),
     include_package_data = True,  # Will read MANIFEST.in
     install_requires = [
-        'OpenFisca-Core >=32, <34',
+        'OpenFisca-Core >=34, <35',
         'PyYAML >= 3.10',
         'scipy >= 0.12',
         ],

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         ),
     include_package_data = True,  # Will read MANIFEST.in
     install_requires = [
-        'OpenFisca-Core >=32, <33',
+        'OpenFisca-Core >=32, <34',
         'PyYAML >= 3.10',
         'scipy >= 0.12',
         ],

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
             'pandas >= 0.22.0',
             ],
         survey = [
-            'OpenFisca-Survey-Manager >=0.9.5,<0.19',
+            'OpenFisca-Survey-Manager >=0.9.5,<0.31',
             ]
         ),
     include_package_data = True,  # Will read MANIFEST.in

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ doc_lines = __doc__.split('\n')
 
 setup(
     name = 'OpenFisca-Tunisia',
-    version = '0.29.0',
+    version = '0.30.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.org',
     classifiers = [classifier for classifier in classifiers.split('\n') if classifier],

--- a/tests/reforms/de_net_a_salaire_de_base/ouvriere_2016_02.yaml
+++ b/tests/reforms/de_net_a_salaire_de_base/ouvriere_2016_02.yaml
@@ -10,7 +10,6 @@
     primes: 6.080 + 47.500
     salaire_de_base: 416.624
     assiette_cotisations_sociales: 470.204 # brut
-    salaire_de_base: 416.624
     salaire_imposable: 427.040
     cotisations_salarie: -43.164 # cnss
     irpp_mensuel_salarie: 0 # déduit de ouvriere_2016_02.yaml

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -26,7 +26,7 @@ scenarios_arguments = [
 def check_run(simulation, period):
     assert simulation.calculate('revenu_disponible', period = period) is not None, \
         "Can't compute revenu_disponible on period {}".format(period)
-    assert simulation.calculate_add('salaire_super_brut', options = [ADD], period = period) is not None, \
+    assert simulation.calculate_add('salaire_super_brut', period = period) is not None, \
         "Can't compute salaire_super_brut on period {}".format(period)
 
 

--- a/tests/test_prestations_familiales.py
+++ b/tests/test_prestations_familiales.py
@@ -3,11 +3,6 @@ from openfisca_tunisia.scenarios import init_single_entity
 from tests import base
 
 import datetime
-import logging
-
-
-log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def test_contribution_frais_creche():
@@ -42,7 +37,6 @@ def test_contribution_frais_creche():
     assert age_benjamin <= base.tax_benefit_system.parameters(year).prestations_familiales.creche.age_max
 
     contribution_frais_creche = simulation.calculate('contribution_frais_creche', period = year)
-    log.debug(contribution_frais_creche)
     assert contribution_frais_creche != 0
 
 


### PR DESCRIPTION
- Met à jour la dépendance à core v34
  * Met à jour successivement de la v32 à la v34, dernière version publiée à ce jour
- Met à jour la dépendance à survey-manager v0.32
- Supprime la limitation maximale sur le nombre d'enfants pour les entités `Menage`


> Pour mémoire :
>  * v32 : pas d'impact sur les tests
>  * v33 : suppression de la limitation maximale sur le nombre d'enfants pour les `Menage`
>  * v34 
>    * v34.2.7 : breaking change ici en raison de résidus d'attribut `option` sur les `calculate_add`
>    * v34.2.9 : cas particulier ; breaking change pour `openfisca-tunisia` parce que les réformes emploient les `stack` de simulation