### PR TITLE
Alignement des cotisations maladie sur le décret 2007

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.57 - [#XXX](https://github.com/openfisca/openfisca-tunisia/pull/XXX)
+## 0.57 - [#258](https://github.com/openfisca/openfisca-tunisia/pull/258)
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : à partir du 01/07/2007.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.57 - [#XXX](https://github.com/openfisca/openfisca-tunisia/pull/XXX)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/07/2007.
+* Zones impactées : `parameters/prelevements_sociaux/cotisations_sociales/secteur_prive`.
+* Détails :
+  - Alignement des taux de cotisation maladie pour les régimes du secteur privé (RSNA, RSAA, RTNS, RTTE) sur le décret n°2007-1406 du 18 juin 2007.
+
 ## 0.56 - [#257](https://github.com/openfisca/openfisca-tunisia/pull/257)
 
 * Évolution du système socio-fiscal.
@@ -82,7 +90,7 @@
 * Détails :
   - Introduit `amen_social_revenu`
 
-## 0.46 - [#191](https://github.com/openfisca/openfisca-tunisia/pull/191)
+## 0.46 - [#191](https://github.0.com/openfisca/openfisca-tunisia/pull/191)
 
 * Évolution du système socio-fiscal. .
 * Périodes concernées : toutes.

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_employeur/assurances_sociales/maladie.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_employeur/assurances_sociales/maladie.yaml
@@ -7,13 +7,26 @@ brackets:
     1990-01-01:
       value: 0.0152
     2007-07-01:
-      value: 0.0214
+      value: 0.0219
     2008-07-01:
-      value: 0.0276
+      value: 0.0286
     2009-07-01:
-      value: 0.0338
+      value: 0.0352
     2010-07-01:
-      value: 0.04
+      value: 0.0418
+    2011-07-01:
+      value: 0.0484
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    2007-07-01:
+      - title: Décret n° 2007-1406 du 18 juin 2007
+    2008-07-01:
+      - title: Décret n° 2007-1406 du 18 juin 2007
+    2009-07-01:
+      - title: Décret n° 2007-1406 du 18 juin 2007
+    2010-07-01:
+      - title: Décret n° 2007-1406 du 18 juin 2007
+    2011-07-01:
+      - title: Décret n° 2007-1406 du 18 juin 2007

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_salarie/assurances_sociales/maladie.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_salarie/assurances_sociales/maladie.yaml
@@ -6,12 +6,27 @@ brackets:
   rate:
     1960-01-01:
       value: 0.0076
+    2007-07-01:
+      value: 0.0076
     2008-07-01:
-      value: 0.0143
+      value: 0.0139
     2009-07-01:
-      value: 0.0209
+      value: 0.0202
     2010-07-01:
-      value: 0.0275
+      value: 0.0265
+    2011-07-01:
+      value: 0.0328
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    2007-07-01:
+      - title: Décret n° 2007-1406 du 18 juin 2007
+    2008-07-01:
+      - title: Décret n° 2007-1406 du 18 juin 2007
+    2009-07-01:
+      - title: Décret n° 2007-1406 du 18 juin 2007
+    2010-07-01:
+      - title: Décret n° 2007-1406 du 18 juin 2007
+    2011-07-01:
+      - title: Décret n° 2007-1406 du 18 juin 2007

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/assurances_sociales/maladie.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/assurances_sociales/maladie.yaml
@@ -7,7 +7,18 @@ brackets:
     1960-01-01:
       value: 0.034306
     2007-07-01:
-      value: 0.040006
+      value: 0.04
+    2008-07-01:
+      value: 0.04
+    2009-07-01:
+      value: 0.04
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    2007-07-01:
+      - title: Décret n° 2007-1406 du 18 juin 2007
+    2008-07-01:
+      - title: Décret n° 2007-1406 du 18 juin 2007
+    2009-07-01:
+      - title: Décret n° 2007-1406 du 18 juin 2007

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/assurances_sociales/maladie.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/assurances_sociales/maladie.yaml
@@ -6,6 +6,8 @@ brackets:
   rate:
     1960-01-01:
       value: 0.013194
+    2007-07-01:
+      value: 0.013194
     2008-07-01:
       value: 0.020394
     2009-07-01:
@@ -13,3 +15,10 @@ brackets:
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    2007-07-01:
+      - title: Décret n° 2007-1406 du 18 juin 2007
+    2008-07-01:
+      - title: Décret n° 2007-1406 du 18 juin 2007
+    2009-07-01:
+      - title: Décret n° 2007-1406 du 18 juin 2007

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtns/cotisations_salarie/assurances_sociales/maladie.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtns/cotisations_salarie/assurances_sociales/maladie.yaml
@@ -17,3 +17,12 @@ brackets:
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    2007-07-01:
+      - title: Décret n° 2007-1406 du 18 juin 2007
+    2008-07-01:
+      - title: Décret n° 2007-1406 du 18 juin 2007
+    2009-07-01:
+      - title: Décret n° 2007-1406 du 18 juin 2007
+    2010-07-01:
+      - title: Décret n° 2007-1406 du 18 juin 2007

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtte/cotisations_salarie/assurances_sociales/maladie.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtte/cotisations_salarie/assurances_sociales/maladie.yaml
@@ -15,3 +15,10 @@ brackets:
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    2007-07-01:
+      - title: Décret n° 2007-1406 du 18 juin 2007
+    2008-07-01:
+      - title: Décret n° 2007-1406 du 18 juin 2007
+    2009-07-01:
+      - title: Décret n° 2007-1406 du 18 juin 2007

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-Tunisia"
-version = "0.56"
+version = "0.57.0"
 description = "OpenFisca Rules as Code model for Tunisia."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "tunisia"]


### PR DESCRIPTION
* Évolution du système socio-fiscal.
* Périodes concernées : à partir du 01/07/2007.
* Zones impactées : `parameters/prelevements_sociaux/cotisations_sociales/secteur_prive`.
* Détails :
  - Alignement des taux de cotisation maladie pour les régimes du secteur privé (RSNA, RSAA, RTNS, RTTE) sur le décret n°2007-1406 du 18 juin 2007.