### PR TITLE
Référencer le barème IRPP 2025 au JORT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.63 - [#365](https://github.com/openfisca/openfisca-tunisia/pull/365)
+
+* Changement mineur.
+* Périodes concernées : à partir du 01/01/2025.
+* Zones impactées : `parameters/impot_revenu/bareme`.
+* Détails :
+  - Remplace la référence secondaire du barème IRPP 2025 par une référence JORT précise : article 36 de la loi n° 2024-48 du 9 décembre 2024, JORT n° 149/2024, p. 6429.
+  - Ne change aucune valeur ni aucun calcul.
+
+<!-- -->
+
 ## 0.62 - [#354](https://github.com/openfisca/openfisca-tunisia/pull/354)
 
 * Amélioration technique.

--- a/openfisca_tunisia/parameters/impot_revenu/bareme.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/bareme.yaml
@@ -84,8 +84,7 @@ metadata:
     2017-01-01:
       href: http://doc-fiscale.finances.gov.tn/cimf-internet/page/document/fr/preview?path=/Loi%20de%20Finances/2017/Loi%20de%20finances%202017.pdf#page=4
     2025-01-01:
-      title: Loi 2024-48 du 9 décembre 2024 portant loi de finances pour 2025
-      href: https://facture-tunisie.com/411/fr/38/reglementations/principales-dispositions-du-projet-de-la-loi-de-finances-2025
+      title: Article 36 de la loi n° 2024-48 du 9 décembre 2024 portant loi de finances pour l'année 2025, JORT n° 149/2024, p. 6429
   official_journal_date:
     2025-01-01: "2024-12-10"
   rate_unit: /1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-Tunisia"
-version = "0.62"
+version = "0.63"
 description = "OpenFisca Rules as Code model for Tunisia."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "tunisia"]


### PR DESCRIPTION
## Contexte
Le barème IRPP applicable à partir du 1er janvier 2025 est déjà présent dans le modèle. Sa référence pointait toutefois vers une page de synthèse non officielle, alors que le texte source a été identifié dans le Journal officiel.

## Modifications
- Remplace la référence 2025 du paramètre `impot_revenu.bareme` par l'article 36 de la loi n° 2024-48 du 9 décembre 2024 portant loi de finances pour l'année 2025.
- Ajoute dans le libellé la localisation JORT utilisée pour la vérification : JORT n° 149/2024, p. 6429.

## Impact attendu
- Aucun changement de valeur, de date d'effet ou de formule.
- Cette PR améliore uniquement la traçabilité mainteneur du paramètre 2025 déjà modélisé.

## Points de revue
- Confirmer que le niveau de détail de la référence JORT convient au format attendu dans les paramètres.
- Une PR séparée pourra traiter les autres paramètres IRPP 2025 après validation des dates d'effet et des références article par article.

## Vérification
- `make test` : 117 tests passés.