### PR TITLE
fonction_publique : injection indemnités spécifiques + ré-encodage (campagne 2026-06)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.67 - [#369](https://github.com/openfisca/openfisca-tunisia/pull/369)
+
+* Ajout de paramètres.
+* Périodes concernées : toutes.
+* Zones impactées : `parameters/fonction_publique`.
+* Détails :
+  - Injecte les indemnités spécifiques mensuelles reconstruites depuis les sources primaires pour 10 corps (campagne 2026-06) ; retire la note « valeurs 0 nominales » pour les corps concernés.
+  - Ré-encode 4 grades d'`enseignants_lycees` de 16/20 à 25 échelons (concordance identité 2015-1165) et ajoute 2 grades de classe exceptionnelle (2015-1163).
+  - Ajoute 5 corps nouveaux au format master : `cadres_techniques_administration`, `enseignement_secondaire_technique_professionnel`, `maitres_principaux_eps`, `personnel_institutions_formation_sante`, `surveillants_generaux_education`.
+
+<!-- -->
+
 ## 0.66 - [#370](https://github.com/openfisca/openfisca-tunisia/pull/370)
 
 * Amélioration technique.

--- a/openfisca_tunisia/parameters/fonction_publique/agents_affaires_culturelles/administrateur_adjoint_services_culturels/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/agents_affaires_culturelles/administrateur_adjoint_services_culturels/indemnite_specifique_mensuelle.yaml
@@ -1,208 +1,428 @@
 description: Indemnité spécifique mensuelle des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 21
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 22
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_23:
   description: Indemnité spécifique mensuelle de l'échelon 23 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 23
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_24:
   description: Indemnité spécifique mensuelle de l'échelon 24 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 24
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_25:
   description: Indemnité spécifique mensuelle de l'échelon 25 des administrateurs adjoints services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 795.0
+    '2025-01-01':
+      value: 1260.0
   metadata:
     short_label: Échelon 25
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/agents_affaires_culturelles/administrateur_conseiller_services_culturels/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/agents_affaires_culturelles/administrateur_conseiller_services_culturels/indemnite_specifique_mensuelle.yaml
@@ -1,208 +1,428 @@
 description: Indemnité spécifique mensuelle des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 21
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 22
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_23:
   description: Indemnité spécifique mensuelle de l'échelon 23 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 23
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_24:
   description: Indemnité spécifique mensuelle de l'échelon 24 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 24
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_25:
   description: Indemnité spécifique mensuelle de l'échelon 25 des administrateurs conseillers des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 975.5
+    '2025-01-01':
+      value: 1545.5
   metadata:
     short_label: Échelon 25
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/agents_affaires_culturelles/administrateur_en_chef_services_culturels/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/agents_affaires_culturelles/administrateur_en_chef_services_culturels/indemnite_specifique_mensuelle.yaml
@@ -1,168 +1,343 @@
 description: Indemnité spécifique mensuelle des administrateurs en chefs services culturels du corps des agents du ministère des affaires culturelles
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des administrateurs en chefs services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1054.5
+    '2025-01-01':
+      value: 1624.5
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des administrateurs en chefs services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1054.5
+    '2025-01-01':
+      value: 1624.5
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des administrateurs en chefs services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1054.5
+    '2025-01-01':
+      value: 1624.5
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des administrateurs en chefs services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1054.5
+    '2025-01-01':
+      value: 1624.5
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des administrateurs en chefs services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1054.5
+    '2025-01-01':
+      value: 1624.5
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des administrateurs en chefs services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1054.5
+    '2025-01-01':
+      value: 1624.5
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des administrateurs en chefs services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1054.5
+    '2025-01-01':
+      value: 1624.5
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des administrateurs en chefs services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1054.5
+    '2025-01-01':
+      value: 1624.5
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des administrateurs en chefs services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1054.5
+    '2025-01-01':
+      value: 1624.5
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des administrateurs en chefs services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1054.5
+    '2025-01-01':
+      value: 1624.5
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des administrateurs en chefs services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1054.5
+    '2025-01-01':
+      value: 1624.5
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des administrateurs en chefs services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1054.5
+    '2025-01-01':
+      value: 1624.5
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des administrateurs en chefs services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1054.5
+    '2025-01-01':
+      value: 1624.5
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des administrateurs en chefs services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1054.5
+    '2025-01-01':
+      value: 1624.5
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des administrateurs en chefs services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1054.5
+    '2025-01-01':
+      value: 1624.5
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des administrateurs en chefs services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1054.5
+    '2025-01-01':
+      value: 1624.5
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des administrateurs en chefs services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1054.5
+    '2025-01-01':
+      value: 1624.5
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des administrateurs en chefs services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1054.5
+    '2025-01-01':
+      value: 1624.5
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des administrateurs en chefs services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1054.5
+    '2025-01-01':
+      value: 1624.5
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des administrateurs en chefs services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1054.5
+    '2025-01-01':
+      value: 1624.5
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/agents_affaires_culturelles/administrateur_general_services_culturels/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/agents_affaires_culturelles/administrateur_general_services_culturels/indemnite_specifique_mensuelle.yaml
@@ -1,136 +1,275 @@
 description: Indemnité spécifique mensuelle des administrateurs généraux des services culturels du corps des agents du ministère des affaires culturelles
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des administrateurs généraux des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1135.0
+    '2025-01-01':
+      value: 1705.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des administrateurs généraux des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1135.0
+    '2025-01-01':
+      value: 1705.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des administrateurs généraux des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1135.0
+    '2025-01-01':
+      value: 1705.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des administrateurs généraux des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1135.0
+    '2025-01-01':
+      value: 1705.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des administrateurs généraux des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1135.0
+    '2025-01-01':
+      value: 1705.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des administrateurs généraux des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1135.0
+    '2025-01-01':
+      value: 1705.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des administrateurs généraux des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1135.0
+    '2025-01-01':
+      value: 1705.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des administrateurs généraux des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1135.0
+    '2025-01-01':
+      value: 1705.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des administrateurs généraux des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1135.0
+    '2025-01-01':
+      value: 1705.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des administrateurs généraux des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1135.0
+    '2025-01-01':
+      value: 1705.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des administrateurs généraux des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1135.0
+    '2025-01-01':
+      value: 1705.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des administrateurs généraux des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1135.0
+    '2025-01-01':
+      value: 1705.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des administrateurs généraux des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1135.0
+    '2025-01-01':
+      value: 1705.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des administrateurs généraux des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1135.0
+    '2025-01-01':
+      value: 1705.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des administrateurs généraux des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1135.0
+    '2025-01-01':
+      value: 1705.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des administrateurs généraux des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 1135.0
+    '2025-01-01':
+      value: 1705.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/agents_affaires_culturelles/administrateur_services_culturels/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/agents_affaires_culturelles/administrateur_services_culturels/indemnite_specifique_mensuelle.yaml
@@ -1,208 +1,428 @@
 description: Indemnité spécifique mensuelle des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 21
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 22
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_23:
   description: Indemnité spécifique mensuelle de l'échelon 23 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 23
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_24:
   description: Indemnité spécifique mensuelle de l'échelon 24 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 24
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_25:
   description: Indemnité spécifique mensuelle de l'échelon 25 des administrateurs des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 867.0
+    '2025-01-01':
+      value: 1407.0
   metadata:
     short_label: Échelon 25
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/agents_affaires_culturelles/agent_accueil_services_culturels/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/agents_affaires_culturelles/agent_accueil_services_culturels/indemnite_specifique_mensuelle.yaml
@@ -1,208 +1,428 @@
 description: Indemnité spécifique mensuelle des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 21
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 22
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_23:
   description: Indemnité spécifique mensuelle de l'échelon 23 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 23
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_24:
   description: Indemnité spécifique mensuelle de l'échelon 24 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 24
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_25:
   description: Indemnité spécifique mensuelle de l'échelon 25 des agents d’accueil des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 631.25
+    '2025-01-01':
+      value: 1031.25
   metadata:
     short_label: Échelon 25
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/agents_affaires_culturelles/commis_administration_services_culturels/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/agents_affaires_culturelles/commis_administration_services_culturels/indemnite_specifique_mensuelle.yaml
@@ -1,208 +1,428 @@
 description: Indemnité spécifique mensuelle des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 21
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 22
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_23:
   description: Indemnité spécifique mensuelle de l'échelon 23 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 23
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_24:
   description: Indemnité spécifique mensuelle de l'échelon 24 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 24
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_25:
   description: Indemnité spécifique mensuelle de l'échelon 25 des commis d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 652.0
+    '2025-01-01':
+      value: 1052.0
   metadata:
     short_label: Échelon 25
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/agents_affaires_culturelles/secretaire_administration_services_culturels/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/agents_affaires_culturelles/secretaire_administration_services_culturels/indemnite_specifique_mensuelle.yaml
@@ -1,208 +1,428 @@
 description: Indemnité spécifique mensuelle des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 21
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 22
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_23:
   description: Indemnité spécifique mensuelle de l'échelon 23 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 23
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_24:
   description: Indemnité spécifique mensuelle de l'échelon 24 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 24
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797
 echelon_25:
   description: Indemnité spécifique mensuelle de l'échelon 25 des secrétaires d’administration des services culturels du corps des agents du ministère des affaires culturelles
   values:
     '2019-05-21':
       value: 0.0
+    '2022-01-01':
+      value: 722.5
+    '2025-01-01':
+      value: 1157.5
   metadata:
     short_label: Échelon 25
     unit: currency
+    reference:
+      '2022-01-01':
+        title: Décret 2019-433
+      '2025-01-01':
+        title: Décret 2019-433+2019-209+2019-1133+2020-767+2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/agents_bibliotheques_documentation/agent_accueil_bibliotheques/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/agents_bibliotheques_documentation/agent_accueil_bibliotheques/indemnite_specifique_mensuelle.yaml
@@ -1,208 +1,428 @@
 description: Indemnité spécifique mensuelle des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 21
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 22
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_23:
   description: Indemnité spécifique mensuelle de l'échelon 23 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 23
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_24:
   description: Indemnité spécifique mensuelle de l'échelon 24 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 24
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_25:
   description: Indemnité spécifique mensuelle de l'échelon 25 des agents accueils bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 631.25
+    '2025-01-01':
+      value: 826.25
   metadata:
     short_label: Échelon 25
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/agents_bibliotheques_documentation/aide_bibliothecaire_aide_documentaliste/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/agents_bibliotheques_documentation/aide_bibliothecaire_aide_documentaliste/indemnite_specifique_mensuelle.yaml
@@ -1,208 +1,428 @@
 description: Indemnité spécifique mensuelle des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 21
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 22
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_23:
   description: Indemnité spécifique mensuelle de l'échelon 23 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 23
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_24:
   description: Indemnité spécifique mensuelle de l'échelon 24 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 24
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_25:
   description: Indemnité spécifique mensuelle de l'échelon 25 des aides bibliothecaires aides documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 722.5
+    '2025-01-01':
+      value: 932.5
   metadata:
     short_label: Échelon 25
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/agents_bibliotheques_documentation/bibliothecaire_adjoint_documentaliste_adjoint/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/agents_bibliotheques_documentation/bibliothecaire_adjoint_documentaliste_adjoint/indemnite_specifique_mensuelle.yaml
@@ -1,208 +1,428 @@
 description: Indemnité spécifique mensuelle des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 21
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 22
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_23:
   description: Indemnité spécifique mensuelle de l'échelon 23 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 23
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_24:
   description: Indemnité spécifique mensuelle de l'échelon 24 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 24
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_25:
   description: Indemnité spécifique mensuelle de l'échelon 25 des bibliothecaires adjoints documentalistes adjoints du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 795.0
+    '2025-01-01':
+      value: 1015.0
   metadata:
     short_label: Échelon 25
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/agents_bibliotheques_documentation/bibliothecaire_documentaliste/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/agents_bibliotheques_documentation/bibliothecaire_documentaliste/indemnite_specifique_mensuelle.yaml
@@ -1,208 +1,428 @@
 description: Indemnité spécifique mensuelle des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 21
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 22
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_23:
   description: Indemnité spécifique mensuelle de l'échelon 23 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 23
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_24:
   description: Indemnité spécifique mensuelle de l'échelon 24 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 24
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_25:
   description: Indemnité spécifique mensuelle de l'échelon 25 des bibliothecaires documentalistes du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 867.0
+    '2025-01-01':
+      value: 1137.0
   metadata:
     short_label: Échelon 25
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/agents_bibliotheques_documentation/commis_bibliotheques/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/agents_bibliotheques_documentation/commis_bibliotheques/indemnite_specifique_mensuelle.yaml
@@ -1,208 +1,428 @@
 description: Indemnité spécifique mensuelle des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 21
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 22
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_23:
   description: Indemnité spécifique mensuelle de l'échelon 23 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 23
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_24:
   description: Indemnité spécifique mensuelle de l'échelon 24 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 24
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_25:
   description: Indemnité spécifique mensuelle de l'échelon 25 des commis bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 652.0
+    '2025-01-01':
+      value: 847.0
   metadata:
     short_label: Échelon 25
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/agents_bibliotheques_documentation/conservateur_bibliotheques/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/agents_bibliotheques_documentation/conservateur_bibliotheques/indemnite_specifique_mensuelle.yaml
@@ -1,208 +1,428 @@
 description: Indemnité spécifique mensuelle des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 21
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 22
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_23:
   description: Indemnité spécifique mensuelle de l'échelon 23 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 23
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_24:
   description: Indemnité spécifique mensuelle de l'échelon 24 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 24
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_25:
   description: Indemnité spécifique mensuelle de l'échelon 25 des conservateurs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 975.5
+    '2025-01-01':
+      value: 1275.5
   metadata:
     short_label: Échelon 25
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/agents_bibliotheques_documentation/conservateur_en_chef_bibliotheques/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/agents_bibliotheques_documentation/conservateur_en_chef_bibliotheques/indemnite_specifique_mensuelle.yaml
@@ -1,168 +1,343 @@
 description: Indemnité spécifique mensuelle des conservateurs en chefs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des conservateurs en chefs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1054.5
+    '2025-01-01':
+      value: 1354.5
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des conservateurs en chefs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1054.5
+    '2025-01-01':
+      value: 1354.5
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des conservateurs en chefs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1054.5
+    '2025-01-01':
+      value: 1354.5
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des conservateurs en chefs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1054.5
+    '2025-01-01':
+      value: 1354.5
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des conservateurs en chefs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1054.5
+    '2025-01-01':
+      value: 1354.5
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des conservateurs en chefs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1054.5
+    '2025-01-01':
+      value: 1354.5
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des conservateurs en chefs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1054.5
+    '2025-01-01':
+      value: 1354.5
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des conservateurs en chefs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1054.5
+    '2025-01-01':
+      value: 1354.5
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des conservateurs en chefs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1054.5
+    '2025-01-01':
+      value: 1354.5
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des conservateurs en chefs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1054.5
+    '2025-01-01':
+      value: 1354.5
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des conservateurs en chefs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1054.5
+    '2025-01-01':
+      value: 1354.5
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des conservateurs en chefs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1054.5
+    '2025-01-01':
+      value: 1354.5
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des conservateurs en chefs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1054.5
+    '2025-01-01':
+      value: 1354.5
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des conservateurs en chefs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1054.5
+    '2025-01-01':
+      value: 1354.5
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des conservateurs en chefs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1054.5
+    '2025-01-01':
+      value: 1354.5
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des conservateurs en chefs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1054.5
+    '2025-01-01':
+      value: 1354.5
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des conservateurs en chefs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1054.5
+    '2025-01-01':
+      value: 1354.5
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des conservateurs en chefs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1054.5
+    '2025-01-01':
+      value: 1354.5
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des conservateurs en chefs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1054.5
+    '2025-01-01':
+      value: 1354.5
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des conservateurs en chefs bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1054.5
+    '2025-01-01':
+      value: 1354.5
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/agents_bibliotheques_documentation/conservateur_general_bibliotheques/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/agents_bibliotheques_documentation/conservateur_general_bibliotheques/indemnite_specifique_mensuelle.yaml
@@ -1,136 +1,275 @@
 description: Indemnité spécifique mensuelle des conservateurs généraux bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des conservateurs généraux bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1135.0
+    '2025-01-01':
+      value: 1435.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des conservateurs généraux bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1135.0
+    '2025-01-01':
+      value: 1435.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des conservateurs généraux bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1135.0
+    '2025-01-01':
+      value: 1435.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des conservateurs généraux bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1135.0
+    '2025-01-01':
+      value: 1435.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des conservateurs généraux bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1135.0
+    '2025-01-01':
+      value: 1435.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des conservateurs généraux bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1135.0
+    '2025-01-01':
+      value: 1435.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des conservateurs généraux bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1135.0
+    '2025-01-01':
+      value: 1435.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des conservateurs généraux bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1135.0
+    '2025-01-01':
+      value: 1435.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des conservateurs généraux bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1135.0
+    '2025-01-01':
+      value: 1435.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des conservateurs généraux bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1135.0
+    '2025-01-01':
+      value: 1435.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des conservateurs généraux bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1135.0
+    '2025-01-01':
+      value: 1435.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des conservateurs généraux bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1135.0
+    '2025-01-01':
+      value: 1435.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des conservateurs généraux bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1135.0
+    '2025-01-01':
+      value: 1435.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des conservateurs généraux bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1135.0
+    '2025-01-01':
+      value: 1435.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des conservateurs généraux bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1135.0
+    '2025-01-01':
+      value: 1435.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des conservateurs généraux bibliothèques du corps des agents des bibliothèques et de la documentation dans les administrations publiques
   values:
     '1999-12-17':
       value: 0.0
+    '2019-05-21':
+      value: 1135.0
+    '2025-01-01':
+      value: 1435.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2019-05-21':
+        title: Décret 2019-436
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/agents_de_conciliation/conciliateur/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/agents_de_conciliation/conciliateur/indemnite_specifique_mensuelle.yaml
@@ -1,208 +1,678 @@
 description: Indemnité spécifique mensuelle des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 21
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 22
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_23:
   description: Indemnité spécifique mensuelle de l'échelon 23 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 23
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_24:
   description: Indemnité spécifique mensuelle de l'échelon 24 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 24
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_25:
   description: Indemnité spécifique mensuelle de l'échelon 25 des conciliateurs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 25
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)

--- a/openfisca_tunisia/parameters/fonction_publique/agents_de_conciliation/conciliateur_en_chef/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/agents_de_conciliation/conciliateur_en_chef/indemnite_specifique_mensuelle.yaml
@@ -1,168 +1,543 @@
 description: Indemnité spécifique mensuelle des conciliateurs en chefs du corps des agents de conciliation du ministère des affaires sociales
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des conciliateurs en chefs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des conciliateurs en chefs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des conciliateurs en chefs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des conciliateurs en chefs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des conciliateurs en chefs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des conciliateurs en chefs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des conciliateurs en chefs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des conciliateurs en chefs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des conciliateurs en chefs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des conciliateurs en chefs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des conciliateurs en chefs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des conciliateurs en chefs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des conciliateurs en chefs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des conciliateurs en chefs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des conciliateurs en chefs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des conciliateurs en chefs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des conciliateurs en chefs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des conciliateurs en chefs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des conciliateurs en chefs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des conciliateurs en chefs du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 265.0
+    '2001-07-01':
+      value: 360.0
+    '2004-07-01':
+      value: 452.0
+    '2007-07-01':
+      value: 544.0
+    '2010-07-01':
+      value: 683.0
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)

--- a/openfisca_tunisia/parameters/fonction_publique/agents_de_conciliation/conciliateur_general/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/agents_de_conciliation/conciliateur_general/indemnite_specifique_mensuelle.yaml
@@ -1,136 +1,435 @@
 description: Indemnité spécifique mensuelle des conciliateurs généraux du corps des agents de conciliation du ministère des affaires sociales
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des conciliateurs généraux du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 275.0
+    '2001-07-01':
+      value: 370.0
+    '2004-07-01':
+      value: 462.0
+    '2007-07-01':
+      value: 554.0
+    '2010-07-01':
+      value: 693.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des conciliateurs généraux du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 275.0
+    '2001-07-01':
+      value: 370.0
+    '2004-07-01':
+      value: 462.0
+    '2007-07-01':
+      value: 554.0
+    '2010-07-01':
+      value: 693.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des conciliateurs généraux du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 275.0
+    '2001-07-01':
+      value: 370.0
+    '2004-07-01':
+      value: 462.0
+    '2007-07-01':
+      value: 554.0
+    '2010-07-01':
+      value: 693.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des conciliateurs généraux du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 275.0
+    '2001-07-01':
+      value: 370.0
+    '2004-07-01':
+      value: 462.0
+    '2007-07-01':
+      value: 554.0
+    '2010-07-01':
+      value: 693.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des conciliateurs généraux du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 275.0
+    '2001-07-01':
+      value: 370.0
+    '2004-07-01':
+      value: 462.0
+    '2007-07-01':
+      value: 554.0
+    '2010-07-01':
+      value: 693.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des conciliateurs généraux du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 275.0
+    '2001-07-01':
+      value: 370.0
+    '2004-07-01':
+      value: 462.0
+    '2007-07-01':
+      value: 554.0
+    '2010-07-01':
+      value: 693.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des conciliateurs généraux du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 275.0
+    '2001-07-01':
+      value: 370.0
+    '2004-07-01':
+      value: 462.0
+    '2007-07-01':
+      value: 554.0
+    '2010-07-01':
+      value: 693.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des conciliateurs généraux du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 275.0
+    '2001-07-01':
+      value: 370.0
+    '2004-07-01':
+      value: 462.0
+    '2007-07-01':
+      value: 554.0
+    '2010-07-01':
+      value: 693.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des conciliateurs généraux du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 275.0
+    '2001-07-01':
+      value: 370.0
+    '2004-07-01':
+      value: 462.0
+    '2007-07-01':
+      value: 554.0
+    '2010-07-01':
+      value: 693.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des conciliateurs généraux du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 275.0
+    '2001-07-01':
+      value: 370.0
+    '2004-07-01':
+      value: 462.0
+    '2007-07-01':
+      value: 554.0
+    '2010-07-01':
+      value: 693.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des conciliateurs généraux du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 275.0
+    '2001-07-01':
+      value: 370.0
+    '2004-07-01':
+      value: 462.0
+    '2007-07-01':
+      value: 554.0
+    '2010-07-01':
+      value: 693.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des conciliateurs généraux du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 275.0
+    '2001-07-01':
+      value: 370.0
+    '2004-07-01':
+      value: 462.0
+    '2007-07-01':
+      value: 554.0
+    '2010-07-01':
+      value: 693.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des conciliateurs généraux du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 275.0
+    '2001-07-01':
+      value: 370.0
+    '2004-07-01':
+      value: 462.0
+    '2007-07-01':
+      value: 554.0
+    '2010-07-01':
+      value: 693.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des conciliateurs généraux du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 275.0
+    '2001-07-01':
+      value: 370.0
+    '2004-07-01':
+      value: 462.0
+    '2007-07-01':
+      value: 554.0
+    '2010-07-01':
+      value: 693.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des conciliateurs généraux du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 275.0
+    '2001-07-01':
+      value: 370.0
+    '2004-07-01':
+      value: 462.0
+    '2007-07-01':
+      value: 554.0
+    '2010-07-01':
+      value: 693.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des conciliateurs généraux du corps des agents de conciliation du ministère des affaires sociales
   values:
     '1999-10-08':
-      value: 0.0
+      value: 275.0
+    '2001-07-01':
+      value: 370.0
+    '2004-07-01':
+      value: 462.0
+    '2007-07-01':
+      value: 554.0
+    '2010-07-01':
+      value: 693.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret décret 96-2000 (global période 1996-1998 = +90 ; tranches 97-910, 98-1534)
+      '2001-07-01':
+        title: Décret décret 99-2432 (global période 1999-2001 = +95 ; tranches 2000-1040, 2001-878)
+      '2004-07-01':
+        title: Décret décret 2002-2941 (global période 2002-2004 = +92 ; tranches 2003-1214, 2005-126)
+      '2007-07-01':
+        title: Décret décret 2005-3210 (global période 2005-2007 = +92 ; tranches 2006-2136, 2007-1509)
+      '2010-07-01':
+        title: Décret décret 2008-4069 (global période 2008-2010 = +139, JORT 2009 n°3 p.102 ; tranche 2009-2377)

--- a/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/adjoint_technique/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/adjoint_technique/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,528 @@
+description: Indemnité spécifique mensuelle du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 727.0
+    '2020-08-01':
+      value: 797.0
+    '2025-01-01':
+      value: 1007.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/adjoint_technique/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/adjoint_technique/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+metadata:
+  short_label: Adjoint technique
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie B

--- a/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/adjoint_technique/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/adjoint_technique/traitement_de_base.yaml
@@ -1,0 +1,378 @@
+description: Traitement de base mensuel du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 128.25
+    '2007-04-01':
+      value: 360.25
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 133.75
+    '2007-04-01':
+      value: 365.75
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 139.25
+    '2007-04-01':
+      value: 371.25
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 144.75
+    '2007-04-01':
+      value: 376.75
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 150.25
+    '2007-04-01':
+      value: 382.25
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 155.75
+    '2007-04-01':
+      value: 387.75
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 161.25
+    '2007-04-01':
+      value: 393.25
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 166.75
+    '2007-04-01':
+      value: 398.75
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 172.25
+    '2007-04-01':
+      value: 404.25
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 177.75
+    '2007-04-01':
+      value: 409.75
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 183.25
+    '2007-04-01':
+      value: 415.25
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 188.75
+    '2007-04-01':
+      value: 420.75
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 194.25
+    '2007-04-01':
+      value: 426.25
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 199.75
+    '2007-04-01':
+      value: 431.75
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 205.25
+    '2007-04-01':
+      value: 437.25
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 210.75
+    '2007-04-01':
+      value: 442.75
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 216.25
+    '2007-04-01':
+      value: 448.25
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 221.75
+    '2007-04-01':
+      value: 453.75
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 227.25
+    '2007-04-01':
+      value: 459.25
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 232.75
+    '2007-04-01':
+      value: 464.75
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 238.25
+    '2007-04-01':
+      value: 470.25
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 243.75
+    '2007-04-01':
+      value: 475.75
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 249.25
+    '2007-04-01':
+      value: 481.25
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 254.75
+    '2007-04-01':
+      value: 486.75
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 du grade « adjoint technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 260.25
+    '2007-04-01':
+      value: 492.25
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/agent_technique/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/agent_technique/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,528 @@
+description: Indemnité spécifique mensuelle du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 649.5
+    '2020-08-01':
+      value: 719.5
+    '2025-01-01':
+      value: 914.5
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/agent_technique/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/agent_technique/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « agent technique » du corps « Corps technique commun des administrations publiques »
+metadata:
+  short_label: Agent technique
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie C

--- a/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/agent_technique/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/agent_technique/traitement_de_base.yaml
@@ -1,0 +1,378 @@
+description: Traitement de base mensuel du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 111.5
+    '2007-04-01':
+      value: 300.75
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 115.5
+    '2007-04-01':
+      value: 304.75
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 119.5
+    '2007-04-01':
+      value: 308.75
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 123.5
+    '2007-04-01':
+      value: 312.75
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 127.5
+    '2007-04-01':
+      value: 316.75
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 131.5
+    '2007-04-01':
+      value: 320.75
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 135.5
+    '2007-04-01':
+      value: 324.75
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 139.5
+    '2007-04-01':
+      value: 328.75
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 143.5
+    '2007-04-01':
+      value: 332.75
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 147.5
+    '2007-04-01':
+      value: 336.75
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 151.5
+    '2007-04-01':
+      value: 340.75
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 155.5
+    '2007-04-01':
+      value: 344.75
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 159.5
+    '2007-04-01':
+      value: 348.75
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 163.5
+    '2007-04-01':
+      value: 352.75
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 167.5
+    '2007-04-01':
+      value: 356.75
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 171.5
+    '2007-04-01':
+      value: 360.75
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 175.5
+    '2007-04-01':
+      value: 364.75
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 179.5
+    '2007-04-01':
+      value: 368.75
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 183.5
+    '2007-04-01':
+      value: 372.75
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 187.5
+    '2007-04-01':
+      value: 376.75
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 191.5
+    '2007-04-01':
+      value: 380.75
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 195.5
+    '2007-04-01':
+      value: 384.75
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 199.5
+    '2007-04-01':
+      value: 388.75
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 203.5
+    '2007-04-01':
+      value: 392.75
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 du grade « agent technique » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 207.5
+    '2007-04-01':
+      value: 396.75
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/index.yaml
@@ -1,0 +1,3 @@
+description: Corps technique commun des administrations publiques
+metadata:
+  short_label: Corps technique commun des administrations publiques

--- a/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,528 @@
+description: Indemnité spécifique mensuelle du grade « technicien » du corps « Corps technique commun des administrations publiques »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 813.0
+    '2020-08-01':
+      value: 888.0
+    '2025-01-01':
+      value: 1108.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « technicien » du corps « Corps technique commun des administrations publiques »
+metadata:
+  short_label: Technicien
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A3

--- a/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien/traitement_de_base.yaml
@@ -1,0 +1,378 @@
+description: Traitement de base mensuel du grade « technicien » du corps « Corps technique commun des administrations publiques »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 146.0
+    '2007-04-01':
+      value: 443.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 154.25
+    '2007-04-01':
+      value: 451.25
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 162.5
+    '2007-04-01':
+      value: 459.5
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 170.75
+    '2007-04-01':
+      value: 467.75
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 179.0
+    '2007-04-01':
+      value: 476.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 187.25
+    '2007-04-01':
+      value: 484.25
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 195.5
+    '2007-04-01':
+      value: 492.5
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 203.75
+    '2007-04-01':
+      value: 500.75
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 212.0
+    '2007-04-01':
+      value: 509.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 220.25
+    '2007-04-01':
+      value: 517.25
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 228.5
+    '2007-04-01':
+      value: 525.5
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 236.75
+    '2007-04-01':
+      value: 533.75
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 245.0
+    '2007-04-01':
+      value: 542.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 253.25
+    '2007-04-01':
+      value: 550.25
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 261.5
+    '2007-04-01':
+      value: 558.5
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 269.75
+    '2007-04-01':
+      value: 566.75
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 278.0
+    '2007-04-01':
+      value: 575.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 286.25
+    '2007-04-01':
+      value: 583.25
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 294.5
+    '2007-04-01':
+      value: 591.5
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 302.75
+    '2007-04-01':
+      value: 599.75
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 311.0
+    '2007-04-01':
+      value: 608.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 319.25
+    '2007-04-01':
+      value: 616.25
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 327.5
+    '2007-04-01':
+      value: 624.5
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 335.75
+    '2007-04-01':
+      value: 632.75
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 du grade « technicien » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 344.0
+    '2007-04-01':
+      value: 641.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_en_chef/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_en_chef/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,528 @@
+description: Indemnité spécifique mensuelle du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 931.0
+    '2020-08-01':
+      value: 1021.0
+    '2025-01-01':
+      value: 1321.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_en_chef/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_en_chef/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+metadata:
+  short_label: Technicien en chef
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A1

--- a/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_en_chef/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_en_chef/traitement_de_base.yaml
@@ -1,0 +1,378 @@
+description: Traitement de base mensuel du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 203.0
+    '2007-04-01':
+      value: 611.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 214.5
+    '2007-04-01':
+      value: 622.5
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 226.0
+    '2007-04-01':
+      value: 634.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 237.5
+    '2007-04-01':
+      value: 645.5
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 249.0
+    '2007-04-01':
+      value: 657.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 260.5
+    '2007-04-01':
+      value: 668.5
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 272.0
+    '2007-04-01':
+      value: 680.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 283.5
+    '2007-04-01':
+      value: 691.5
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 295.0
+    '2007-04-01':
+      value: 703.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 306.5
+    '2007-04-01':
+      value: 714.5
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 318.0
+    '2007-04-01':
+      value: 726.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 329.5
+    '2007-04-01':
+      value: 737.5
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 341.0
+    '2007-04-01':
+      value: 749.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 352.5
+    '2007-04-01':
+      value: 760.5
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 364.0
+    '2007-04-01':
+      value: 772.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 375.5
+    '2007-04-01':
+      value: 783.5
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 387.0
+    '2007-04-01':
+      value: 795.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 398.5
+    '2007-04-01':
+      value: 806.5
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 410.0
+    '2007-04-01':
+      value: 818.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 421.5
+    '2007-04-01':
+      value: 829.5
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 433.0
+    '2007-04-01':
+      value: 841.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 444.5
+    '2007-04-01':
+      value: 852.5
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 456.0
+    '2007-04-01':
+      value: 864.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 467.5
+    '2007-04-01':
+      value: 875.5
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 du grade « technicien en chef » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 479.0
+    '2007-04-01':
+      value: 887.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_en_chef_principal/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_en_chef_principal/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,383 @@
+description: Indemnité spécifique mensuelle du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 979.5
+    '2020-08-01':
+      value: 1069.5
+    '2025-01-01':
+      value: 1369.5
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 979.5
+    '2020-08-01':
+      value: 1069.5
+    '2025-01-01':
+      value: 1369.5
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 979.5
+    '2020-08-01':
+      value: 1069.5
+    '2025-01-01':
+      value: 1369.5
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 979.5
+    '2020-08-01':
+      value: 1069.5
+    '2025-01-01':
+      value: 1369.5
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 979.5
+    '2020-08-01':
+      value: 1069.5
+    '2025-01-01':
+      value: 1369.5
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 979.5
+    '2020-08-01':
+      value: 1069.5
+    '2025-01-01':
+      value: 1369.5
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 979.5
+    '2020-08-01':
+      value: 1069.5
+    '2025-01-01':
+      value: 1369.5
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 979.5
+    '2020-08-01':
+      value: 1069.5
+    '2025-01-01':
+      value: 1369.5
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 979.5
+    '2020-08-01':
+      value: 1069.5
+    '2025-01-01':
+      value: 1369.5
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 979.5
+    '2020-08-01':
+      value: 1069.5
+    '2025-01-01':
+      value: 1369.5
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 979.5
+    '2020-08-01':
+      value: 1069.5
+    '2025-01-01':
+      value: 1369.5
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 979.5
+    '2020-08-01':
+      value: 1069.5
+    '2025-01-01':
+      value: 1369.5
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 979.5
+    '2020-08-01':
+      value: 1069.5
+    '2025-01-01':
+      value: 1369.5
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 979.5
+    '2020-08-01':
+      value: 1069.5
+    '2025-01-01':
+      value: 1369.5
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 979.5
+    '2020-08-01':
+      value: 1069.5
+    '2025-01-01':
+      value: 1369.5
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 979.5
+    '2020-08-01':
+      value: 1069.5
+    '2025-01-01':
+      value: 1369.5
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 979.5
+    '2020-08-01':
+      value: 1069.5
+    '2025-01-01':
+      value: 1369.5
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 979.5
+    '2020-08-01':
+      value: 1069.5
+    '2025-01-01':
+      value: 1369.5
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 979.5
+    '2020-08-01':
+      value: 1069.5
+    '2025-01-01':
+      value: 1369.5
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 979.5
+    '2020-08-01':
+      value: 1069.5
+    '2025-01-01':
+      value: 1369.5
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_en_chef_principal/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_en_chef_principal/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+metadata:
+  short_label: Technicien en chef principal
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A1

--- a/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_en_chef_principal/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_en_chef_principal/traitement_de_base.yaml
@@ -1,0 +1,223 @@
+description: Traitement de base mensuel du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 668.5
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 680.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 691.5
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 703.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 714.5
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 726.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 737.5
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 749.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 760.5
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 772.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 783.5
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 795.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 806.5
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 818.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 829.5
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 841.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 852.5
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 864.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 875.5
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « technicien en chef principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 887.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_general/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_general/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,307 @@
+description: Indemnité spécifique mensuelle du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 1038.0
+    '2020-08-01':
+      value: 1128.0
+    '2025-01-01':
+      value: 1428.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 1038.0
+    '2020-08-01':
+      value: 1128.0
+    '2025-01-01':
+      value: 1428.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 1038.0
+    '2020-08-01':
+      value: 1128.0
+    '2025-01-01':
+      value: 1428.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 1038.0
+    '2020-08-01':
+      value: 1128.0
+    '2025-01-01':
+      value: 1428.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 1038.0
+    '2020-08-01':
+      value: 1128.0
+    '2025-01-01':
+      value: 1428.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 1038.0
+    '2020-08-01':
+      value: 1128.0
+    '2025-01-01':
+      value: 1428.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 1038.0
+    '2020-08-01':
+      value: 1128.0
+    '2025-01-01':
+      value: 1428.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 1038.0
+    '2020-08-01':
+      value: 1128.0
+    '2025-01-01':
+      value: 1428.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 1038.0
+    '2020-08-01':
+      value: 1128.0
+    '2025-01-01':
+      value: 1428.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 1038.0
+    '2020-08-01':
+      value: 1128.0
+    '2025-01-01':
+      value: 1428.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 1038.0
+    '2020-08-01':
+      value: 1128.0
+    '2025-01-01':
+      value: 1428.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 1038.0
+    '2020-08-01':
+      value: 1128.0
+    '2025-01-01':
+      value: 1428.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 1038.0
+    '2020-08-01':
+      value: 1128.0
+    '2025-01-01':
+      value: 1428.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 1038.0
+    '2020-08-01':
+      value: 1128.0
+    '2025-01-01':
+      value: 1428.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 1038.0
+    '2020-08-01':
+      value: 1128.0
+    '2025-01-01':
+      value: 1428.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 1038.0
+    '2020-08-01':
+      value: 1128.0
+    '2025-01-01':
+      value: 1428.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_general/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_general/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « technicien général » du corps « Corps technique commun des administrations publiques »
+metadata:
+  short_label: Technicien général
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A1

--- a/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_general/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_general/traitement_de_base.yaml
@@ -1,0 +1,179 @@
+description: Traitement de base mensuel du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 714.5
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 726.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 737.5
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 749.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 760.5
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 772.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 783.5
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 795.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 806.5
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 818.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 829.5
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 841.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 852.5
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 864.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 875.5
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « technicien général » du corps « Corps technique commun des administrations publiques »
+  values:
+    '2020-01-10':
+      value: 887.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_principal/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_principal/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,528 @@
+description: Indemnité spécifique mensuelle du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 0.0
+    '2020-01-10':
+      value: 902.5
+    '2020-08-01':
+      value: 992.5
+    '2025-01-01':
+      value: 1262.5
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2020-01-10':
+        title: Décret 2019-1241
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_principal/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_principal/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+metadata:
+  short_label: Technicien principal
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A2

--- a/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_principal/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/cadres_techniques_administration/technicien_principal/traitement_de_base.yaml
@@ -1,0 +1,378 @@
+description: Traitement de base mensuel du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 181.25
+    '2007-04-01':
+      value: 521.25
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 190.25
+    '2007-04-01':
+      value: 530.25
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 199.25
+    '2007-04-01':
+      value: 539.25
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 208.25
+    '2007-04-01':
+      value: 548.25
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 217.25
+    '2007-04-01':
+      value: 557.25
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 226.25
+    '2007-04-01':
+      value: 566.25
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 235.25
+    '2007-04-01':
+      value: 575.25
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 244.25
+    '2007-04-01':
+      value: 584.25
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 253.25
+    '2007-04-01':
+      value: 593.25
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 262.25
+    '2007-04-01':
+      value: 602.25
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 271.25
+    '2007-04-01':
+      value: 611.25
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 280.25
+    '2007-04-01':
+      value: 620.25
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 289.25
+    '2007-04-01':
+      value: 629.25
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 298.25
+    '2007-04-01':
+      value: 638.25
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 307.25
+    '2007-04-01':
+      value: 647.25
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 316.25
+    '2007-04-01':
+      value: 656.25
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 325.25
+    '2007-04-01':
+      value: 665.25
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 334.25
+    '2007-04-01':
+      value: 674.25
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 343.25
+    '2007-04-01':
+      value: 683.25
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 352.25
+    '2007-04-01':
+      value: 692.25
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 361.25
+    '2007-04-01':
+      value: 701.25
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 370.25
+    '2007-04-01':
+      value: 710.25
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 379.25
+    '2007-04-01':
+      value: 719.25
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 388.25
+    '2007-04-01':
+      value: 728.25
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 du grade « technicien principal » du corps « Corps technique commun des administrations publiques »
+  values:
+    '1999-04-23':
+      value: 397.25
+    '2007-04-01':
+      value: 737.25
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '1999-04-23':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/conseillers_educatifs/conseiller_educatif/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/conseillers_educatifs/conseiller_educatif/indemnite_specifique_mensuelle.yaml
@@ -14,8 +14,14 @@ echelon_1:
       value: 756.0
     '2013-01-01':
       value: 826.0
-    '2025-01-01':
+    '2019-03-01':
+      value: 916.0
+    '2020-01-01':
+      value: 1006.0
+    '2020-08-01':
       value: 1096.0
+    '2025-01-01':
+      value: 1366.0
   metadata:
     short_label: Échelon 1
     unit: currency
@@ -30,6 +36,12 @@ echelon_1:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_2:
@@ -45,8 +57,14 @@ echelon_2:
       value: 756.0
     '2013-01-01':
       value: 826.0
-    '2025-01-01':
+    '2019-03-01':
+      value: 916.0
+    '2020-01-01':
+      value: 1006.0
+    '2020-08-01':
       value: 1096.0
+    '2025-01-01':
+      value: 1366.0
   metadata:
     short_label: Échelon 2
     unit: currency
@@ -61,6 +79,12 @@ echelon_2:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_3:
@@ -76,8 +100,14 @@ echelon_3:
       value: 756.0
     '2013-01-01':
       value: 826.0
-    '2025-01-01':
+    '2019-03-01':
+      value: 916.0
+    '2020-01-01':
+      value: 1006.0
+    '2020-08-01':
       value: 1096.0
+    '2025-01-01':
+      value: 1366.0
   metadata:
     short_label: Échelon 3
     unit: currency
@@ -92,6 +122,12 @@ echelon_3:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_4:
@@ -107,8 +143,14 @@ echelon_4:
       value: 756.0
     '2013-01-01':
       value: 826.0
-    '2025-01-01':
+    '2019-03-01':
+      value: 916.0
+    '2020-01-01':
+      value: 1006.0
+    '2020-08-01':
       value: 1096.0
+    '2025-01-01':
+      value: 1366.0
   metadata:
     short_label: Échelon 4
     unit: currency
@@ -123,6 +165,12 @@ echelon_4:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_5:
@@ -138,8 +186,14 @@ echelon_5:
       value: 756.0
     '2013-01-01':
       value: 826.0
-    '2025-01-01':
+    '2019-03-01':
+      value: 916.0
+    '2020-01-01':
+      value: 1006.0
+    '2020-08-01':
       value: 1096.0
+    '2025-01-01':
+      value: 1366.0
   metadata:
     short_label: Échelon 5
     unit: currency
@@ -154,6 +208,12 @@ echelon_5:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_6:
@@ -169,8 +229,14 @@ echelon_6:
       value: 756.0
     '2013-01-01':
       value: 826.0
-    '2025-01-01':
+    '2019-03-01':
+      value: 916.0
+    '2020-01-01':
+      value: 1006.0
+    '2020-08-01':
       value: 1096.0
+    '2025-01-01':
+      value: 1366.0
   metadata:
     short_label: Échelon 6
     unit: currency
@@ -185,6 +251,12 @@ echelon_6:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_7:
@@ -200,8 +272,14 @@ echelon_7:
       value: 756.0
     '2013-01-01':
       value: 826.0
-    '2025-01-01':
+    '2019-03-01':
+      value: 916.0
+    '2020-01-01':
+      value: 1006.0
+    '2020-08-01':
       value: 1096.0
+    '2025-01-01':
+      value: 1366.0
   metadata:
     short_label: Échelon 7
     unit: currency
@@ -216,6 +294,12 @@ echelon_7:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_8:
@@ -231,8 +315,14 @@ echelon_8:
       value: 756.0
     '2013-01-01':
       value: 826.0
-    '2025-01-01':
+    '2019-03-01':
+      value: 916.0
+    '2020-01-01':
+      value: 1006.0
+    '2020-08-01':
       value: 1096.0
+    '2025-01-01':
+      value: 1366.0
   metadata:
     short_label: Échelon 8
     unit: currency
@@ -247,6 +337,12 @@ echelon_8:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_9:
@@ -262,8 +358,14 @@ echelon_9:
       value: 756.0
     '2013-01-01':
       value: 826.0
-    '2025-01-01':
+    '2019-03-01':
+      value: 916.0
+    '2020-01-01':
+      value: 1006.0
+    '2020-08-01':
       value: 1096.0
+    '2025-01-01':
+      value: 1366.0
   metadata:
     short_label: Échelon 9
     unit: currency
@@ -278,6 +380,12 @@ echelon_9:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_10:
@@ -293,8 +401,14 @@ echelon_10:
       value: 756.0
     '2013-01-01':
       value: 826.0
-    '2025-01-01':
+    '2019-03-01':
+      value: 916.0
+    '2020-01-01':
+      value: 1006.0
+    '2020-08-01':
       value: 1096.0
+    '2025-01-01':
+      value: 1366.0
   metadata:
     short_label: Échelon 10
     unit: currency
@@ -309,6 +423,12 @@ echelon_10:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_11:
@@ -324,8 +444,14 @@ echelon_11:
       value: 756.0
     '2013-01-01':
       value: 826.0
-    '2025-01-01':
+    '2019-03-01':
+      value: 916.0
+    '2020-01-01':
+      value: 1006.0
+    '2020-08-01':
       value: 1096.0
+    '2025-01-01':
+      value: 1366.0
   metadata:
     short_label: Échelon 11
     unit: currency
@@ -340,6 +466,12 @@ echelon_11:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_12:
@@ -355,8 +487,14 @@ echelon_12:
       value: 756.0
     '2013-01-01':
       value: 826.0
-    '2025-01-01':
+    '2019-03-01':
+      value: 916.0
+    '2020-01-01':
+      value: 1006.0
+    '2020-08-01':
       value: 1096.0
+    '2025-01-01':
+      value: 1366.0
   metadata:
     short_label: Échelon 12
     unit: currency
@@ -371,6 +509,12 @@ echelon_12:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_13:
@@ -386,8 +530,14 @@ echelon_13:
       value: 756.0
     '2013-01-01':
       value: 826.0
-    '2025-01-01':
+    '2019-03-01':
+      value: 916.0
+    '2020-01-01':
+      value: 1006.0
+    '2020-08-01':
       value: 1096.0
+    '2025-01-01':
+      value: 1366.0
   metadata:
     short_label: Échelon 13
     unit: currency
@@ -402,6 +552,12 @@ echelon_13:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_14:
@@ -417,8 +573,14 @@ echelon_14:
       value: 756.0
     '2013-01-01':
       value: 826.0
-    '2025-01-01':
+    '2019-03-01':
+      value: 916.0
+    '2020-01-01':
+      value: 1006.0
+    '2020-08-01':
       value: 1096.0
+    '2025-01-01':
+      value: 1366.0
   metadata:
     short_label: Échelon 14
     unit: currency
@@ -433,6 +595,12 @@ echelon_14:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_15:
@@ -448,8 +616,14 @@ echelon_15:
       value: 756.0
     '2013-01-01':
       value: 826.0
-    '2025-01-01':
+    '2019-03-01':
+      value: 916.0
+    '2020-01-01':
+      value: 1006.0
+    '2020-08-01':
       value: 1096.0
+    '2025-01-01':
+      value: 1366.0
   metadata:
     short_label: Échelon 15
     unit: currency
@@ -464,6 +638,12 @@ echelon_15:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_16:
@@ -479,8 +659,14 @@ echelon_16:
       value: 756.0
     '2013-01-01':
       value: 826.0
-    '2025-01-01':
+    '2019-03-01':
+      value: 916.0
+    '2020-01-01':
+      value: 1006.0
+    '2020-08-01':
       value: 1096.0
+    '2025-01-01':
+      value: 1366.0
   metadata:
     short_label: Échelon 16
     unit: currency
@@ -495,6 +681,12 @@ echelon_16:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_17:
@@ -510,8 +702,14 @@ echelon_17:
       value: 756.0
     '2013-01-01':
       value: 826.0
-    '2025-01-01':
+    '2019-03-01':
+      value: 916.0
+    '2020-01-01':
+      value: 1006.0
+    '2020-08-01':
       value: 1096.0
+    '2025-01-01':
+      value: 1366.0
   metadata:
     short_label: Échelon 17
     unit: currency
@@ -526,6 +724,12 @@ echelon_17:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_18:
@@ -541,8 +745,14 @@ echelon_18:
       value: 756.0
     '2013-01-01':
       value: 826.0
-    '2025-01-01':
+    '2019-03-01':
+      value: 916.0
+    '2020-01-01':
+      value: 1006.0
+    '2020-08-01':
       value: 1096.0
+    '2025-01-01':
+      value: 1366.0
   metadata:
     short_label: Échelon 18
     unit: currency
@@ -557,6 +767,12 @@ echelon_18:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_19:
@@ -572,8 +788,14 @@ echelon_19:
       value: 756.0
     '2013-01-01':
       value: 826.0
-    '2025-01-01':
+    '2019-03-01':
+      value: 916.0
+    '2020-01-01':
+      value: 1006.0
+    '2020-08-01':
       value: 1096.0
+    '2025-01-01':
+      value: 1366.0
   metadata:
     short_label: Échelon 19
     unit: currency
@@ -588,6 +810,12 @@ echelon_19:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_20:
@@ -603,8 +831,14 @@ echelon_20:
       value: 756.0
     '2013-01-01':
       value: 826.0
-    '2025-01-01':
+    '2019-03-01':
+      value: 916.0
+    '2020-01-01':
+      value: 1006.0
+    '2020-08-01':
       value: 1096.0
+    '2025-01-01':
+      value: 1366.0
   metadata:
     short_label: Échelon 20
     unit: currency
@@ -619,5 +853,11 @@ echelon_20:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/conseillers_educatifs/conseiller_educatif_adjoint/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/conseillers_educatifs/conseiller_educatif_adjoint/indemnite_specifique_mensuelle.yaml
@@ -14,8 +14,14 @@ echelon_1:
       value: 665.0
     '2013-01-01':
       value: 735.0
+    '2019-03-01':
+      value: 815.0
+    '2020-01-01':
+      value: 905.0
+    '2020-08-01':
+      value: 980.0
     '2025-01-01':
-      value: 955.0
+      value: 1200.0
   metadata:
     short_label: Échelon 1
     unit: currency
@@ -30,6 +36,12 @@ echelon_1:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_2:
@@ -45,8 +57,14 @@ echelon_2:
       value: 665.0
     '2013-01-01':
       value: 735.0
+    '2019-03-01':
+      value: 815.0
+    '2020-01-01':
+      value: 905.0
+    '2020-08-01':
+      value: 980.0
     '2025-01-01':
-      value: 955.0
+      value: 1200.0
   metadata:
     short_label: Échelon 2
     unit: currency
@@ -61,6 +79,12 @@ echelon_2:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_3:
@@ -76,8 +100,14 @@ echelon_3:
       value: 665.0
     '2013-01-01':
       value: 735.0
+    '2019-03-01':
+      value: 815.0
+    '2020-01-01':
+      value: 905.0
+    '2020-08-01':
+      value: 980.0
     '2025-01-01':
-      value: 955.0
+      value: 1200.0
   metadata:
     short_label: Échelon 3
     unit: currency
@@ -92,6 +122,12 @@ echelon_3:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_4:
@@ -107,8 +143,14 @@ echelon_4:
       value: 665.0
     '2013-01-01':
       value: 735.0
+    '2019-03-01':
+      value: 815.0
+    '2020-01-01':
+      value: 905.0
+    '2020-08-01':
+      value: 980.0
     '2025-01-01':
-      value: 955.0
+      value: 1200.0
   metadata:
     short_label: Échelon 4
     unit: currency
@@ -123,6 +165,12 @@ echelon_4:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_5:
@@ -138,8 +186,14 @@ echelon_5:
       value: 665.0
     '2013-01-01':
       value: 735.0
+    '2019-03-01':
+      value: 815.0
+    '2020-01-01':
+      value: 905.0
+    '2020-08-01':
+      value: 980.0
     '2025-01-01':
-      value: 955.0
+      value: 1200.0
   metadata:
     short_label: Échelon 5
     unit: currency
@@ -154,6 +208,12 @@ echelon_5:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_6:
@@ -169,8 +229,14 @@ echelon_6:
       value: 665.0
     '2013-01-01':
       value: 735.0
+    '2019-03-01':
+      value: 815.0
+    '2020-01-01':
+      value: 905.0
+    '2020-08-01':
+      value: 980.0
     '2025-01-01':
-      value: 955.0
+      value: 1200.0
   metadata:
     short_label: Échelon 6
     unit: currency
@@ -185,6 +251,12 @@ echelon_6:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_7:
@@ -200,8 +272,14 @@ echelon_7:
       value: 665.0
     '2013-01-01':
       value: 735.0
+    '2019-03-01':
+      value: 815.0
+    '2020-01-01':
+      value: 905.0
+    '2020-08-01':
+      value: 980.0
     '2025-01-01':
-      value: 955.0
+      value: 1200.0
   metadata:
     short_label: Échelon 7
     unit: currency
@@ -216,6 +294,12 @@ echelon_7:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_8:
@@ -231,8 +315,14 @@ echelon_8:
       value: 665.0
     '2013-01-01':
       value: 735.0
+    '2019-03-01':
+      value: 815.0
+    '2020-01-01':
+      value: 905.0
+    '2020-08-01':
+      value: 980.0
     '2025-01-01':
-      value: 955.0
+      value: 1200.0
   metadata:
     short_label: Échelon 8
     unit: currency
@@ -247,6 +337,12 @@ echelon_8:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_9:
@@ -262,8 +358,14 @@ echelon_9:
       value: 665.0
     '2013-01-01':
       value: 735.0
+    '2019-03-01':
+      value: 815.0
+    '2020-01-01':
+      value: 905.0
+    '2020-08-01':
+      value: 980.0
     '2025-01-01':
-      value: 955.0
+      value: 1200.0
   metadata:
     short_label: Échelon 9
     unit: currency
@@ -278,6 +380,12 @@ echelon_9:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_10:
@@ -293,8 +401,14 @@ echelon_10:
       value: 665.0
     '2013-01-01':
       value: 735.0
+    '2019-03-01':
+      value: 815.0
+    '2020-01-01':
+      value: 905.0
+    '2020-08-01':
+      value: 980.0
     '2025-01-01':
-      value: 955.0
+      value: 1200.0
   metadata:
     short_label: Échelon 10
     unit: currency
@@ -309,6 +423,12 @@ echelon_10:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_11:
@@ -324,8 +444,14 @@ echelon_11:
       value: 665.0
     '2013-01-01':
       value: 735.0
+    '2019-03-01':
+      value: 815.0
+    '2020-01-01':
+      value: 905.0
+    '2020-08-01':
+      value: 980.0
     '2025-01-01':
-      value: 955.0
+      value: 1200.0
   metadata:
     short_label: Échelon 11
     unit: currency
@@ -340,6 +466,12 @@ echelon_11:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_12:
@@ -355,8 +487,14 @@ echelon_12:
       value: 665.0
     '2013-01-01':
       value: 735.0
+    '2019-03-01':
+      value: 815.0
+    '2020-01-01':
+      value: 905.0
+    '2020-08-01':
+      value: 980.0
     '2025-01-01':
-      value: 955.0
+      value: 1200.0
   metadata:
     short_label: Échelon 12
     unit: currency
@@ -371,6 +509,12 @@ echelon_12:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_13:
@@ -386,8 +530,14 @@ echelon_13:
       value: 665.0
     '2013-01-01':
       value: 735.0
+    '2019-03-01':
+      value: 815.0
+    '2020-01-01':
+      value: 905.0
+    '2020-08-01':
+      value: 980.0
     '2025-01-01':
-      value: 955.0
+      value: 1200.0
   metadata:
     short_label: Échelon 13
     unit: currency
@@ -402,6 +552,12 @@ echelon_13:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_14:
@@ -417,8 +573,14 @@ echelon_14:
       value: 665.0
     '2013-01-01':
       value: 735.0
+    '2019-03-01':
+      value: 815.0
+    '2020-01-01':
+      value: 905.0
+    '2020-08-01':
+      value: 980.0
     '2025-01-01':
-      value: 955.0
+      value: 1200.0
   metadata:
     short_label: Échelon 14
     unit: currency
@@ -433,6 +595,12 @@ echelon_14:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_15:
@@ -448,8 +616,14 @@ echelon_15:
       value: 665.0
     '2013-01-01':
       value: 735.0
+    '2019-03-01':
+      value: 815.0
+    '2020-01-01':
+      value: 905.0
+    '2020-08-01':
+      value: 980.0
     '2025-01-01':
-      value: 955.0
+      value: 1200.0
   metadata:
     short_label: Échelon 15
     unit: currency
@@ -464,6 +638,12 @@ echelon_15:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_16:
@@ -479,8 +659,14 @@ echelon_16:
       value: 665.0
     '2013-01-01':
       value: 735.0
+    '2019-03-01':
+      value: 815.0
+    '2020-01-01':
+      value: 905.0
+    '2020-08-01':
+      value: 980.0
     '2025-01-01':
-      value: 955.0
+      value: 1200.0
   metadata:
     short_label: Échelon 16
     unit: currency
@@ -495,6 +681,12 @@ echelon_16:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_17:
@@ -510,8 +702,14 @@ echelon_17:
       value: 665.0
     '2013-01-01':
       value: 735.0
+    '2019-03-01':
+      value: 815.0
+    '2020-01-01':
+      value: 905.0
+    '2020-08-01':
+      value: 980.0
     '2025-01-01':
-      value: 955.0
+      value: 1200.0
   metadata:
     short_label: Échelon 17
     unit: currency
@@ -526,6 +724,12 @@ echelon_17:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_18:
@@ -541,8 +745,14 @@ echelon_18:
       value: 665.0
     '2013-01-01':
       value: 735.0
+    '2019-03-01':
+      value: 815.0
+    '2020-01-01':
+      value: 905.0
+    '2020-08-01':
+      value: 980.0
     '2025-01-01':
-      value: 955.0
+      value: 1200.0
   metadata:
     short_label: Échelon 18
     unit: currency
@@ -557,6 +767,12 @@ echelon_18:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_19:
@@ -572,8 +788,14 @@ echelon_19:
       value: 665.0
     '2013-01-01':
       value: 735.0
+    '2019-03-01':
+      value: 815.0
+    '2020-01-01':
+      value: 905.0
+    '2020-08-01':
+      value: 980.0
     '2025-01-01':
-      value: 955.0
+      value: 1200.0
   metadata:
     short_label: Échelon 19
     unit: currency
@@ -588,6 +810,12 @@ echelon_19:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_20:
@@ -603,8 +831,14 @@ echelon_20:
       value: 665.0
     '2013-01-01':
       value: 735.0
+    '2019-03-01':
+      value: 815.0
+    '2020-01-01':
+      value: 905.0
+    '2020-08-01':
+      value: 980.0
     '2025-01-01':
-      value: 955.0
+      value: 1200.0
   metadata:
     short_label: Échelon 20
     unit: currency
@@ -619,6 +853,12 @@ echelon_20:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_21:
@@ -634,8 +874,14 @@ echelon_21:
       value: 665.0
     '2013-01-01':
       value: 735.0
+    '2019-03-01':
+      value: 815.0
+    '2020-01-01':
+      value: 905.0
+    '2020-08-01':
+      value: 980.0
     '2025-01-01':
-      value: 955.0
+      value: 1200.0
   metadata:
     short_label: Échelon 21
     unit: currency
@@ -650,6 +896,12 @@ echelon_21:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_22:
@@ -665,8 +917,14 @@ echelon_22:
       value: 665.0
     '2013-01-01':
       value: 735.0
+    '2019-03-01':
+      value: 815.0
+    '2020-01-01':
+      value: 905.0
+    '2020-08-01':
+      value: 980.0
     '2025-01-01':
-      value: 955.0
+      value: 1200.0
   metadata:
     short_label: Échelon 22
     unit: currency
@@ -681,6 +939,12 @@ echelon_22:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_23:
@@ -696,8 +960,14 @@ echelon_23:
       value: 665.0
     '2013-01-01':
       value: 735.0
+    '2019-03-01':
+      value: 815.0
+    '2020-01-01':
+      value: 905.0
+    '2020-08-01':
+      value: 980.0
     '2025-01-01':
-      value: 955.0
+      value: 1200.0
   metadata:
     short_label: Échelon 23
     unit: currency
@@ -712,5 +982,11 @@ echelon_23:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/conseillers_educatifs/conseiller_educatif_principal/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/conseillers_educatifs/conseiller_educatif_principal/indemnite_specifique_mensuelle.yaml
@@ -14,8 +14,14 @@ echelon_1:
       value: 886.0
     '2013-01-01':
       value: 956.0
+    '2019-03-01':
+      value: 1046.0
+    '2020-01-01':
+      value: 1136.0
+    '2020-08-01':
+      value: 1226.0
     '2025-01-01':
-      value: 1256.0
+      value: 1526.0
   metadata:
     short_label: Échelon 1
     unit: currency
@@ -30,6 +36,12 @@ echelon_1:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_2:
@@ -45,8 +57,14 @@ echelon_2:
       value: 886.0
     '2013-01-01':
       value: 956.0
+    '2019-03-01':
+      value: 1046.0
+    '2020-01-01':
+      value: 1136.0
+    '2020-08-01':
+      value: 1226.0
     '2025-01-01':
-      value: 1256.0
+      value: 1526.0
   metadata:
     short_label: Échelon 2
     unit: currency
@@ -61,6 +79,12 @@ echelon_2:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_3:
@@ -76,8 +100,14 @@ echelon_3:
       value: 886.0
     '2013-01-01':
       value: 956.0
+    '2019-03-01':
+      value: 1046.0
+    '2020-01-01':
+      value: 1136.0
+    '2020-08-01':
+      value: 1226.0
     '2025-01-01':
-      value: 1256.0
+      value: 1526.0
   metadata:
     short_label: Échelon 3
     unit: currency
@@ -92,6 +122,12 @@ echelon_3:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_4:
@@ -107,8 +143,14 @@ echelon_4:
       value: 886.0
     '2013-01-01':
       value: 956.0
+    '2019-03-01':
+      value: 1046.0
+    '2020-01-01':
+      value: 1136.0
+    '2020-08-01':
+      value: 1226.0
     '2025-01-01':
-      value: 1256.0
+      value: 1526.0
   metadata:
     short_label: Échelon 4
     unit: currency
@@ -123,6 +165,12 @@ echelon_4:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_5:
@@ -138,8 +186,14 @@ echelon_5:
       value: 886.0
     '2013-01-01':
       value: 956.0
+    '2019-03-01':
+      value: 1046.0
+    '2020-01-01':
+      value: 1136.0
+    '2020-08-01':
+      value: 1226.0
     '2025-01-01':
-      value: 1256.0
+      value: 1526.0
   metadata:
     short_label: Échelon 5
     unit: currency
@@ -154,6 +208,12 @@ echelon_5:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_6:
@@ -169,8 +229,14 @@ echelon_6:
       value: 886.0
     '2013-01-01':
       value: 956.0
+    '2019-03-01':
+      value: 1046.0
+    '2020-01-01':
+      value: 1136.0
+    '2020-08-01':
+      value: 1226.0
     '2025-01-01':
-      value: 1256.0
+      value: 1526.0
   metadata:
     short_label: Échelon 6
     unit: currency
@@ -185,6 +251,12 @@ echelon_6:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_7:
@@ -200,8 +272,14 @@ echelon_7:
       value: 886.0
     '2013-01-01':
       value: 956.0
+    '2019-03-01':
+      value: 1046.0
+    '2020-01-01':
+      value: 1136.0
+    '2020-08-01':
+      value: 1226.0
     '2025-01-01':
-      value: 1256.0
+      value: 1526.0
   metadata:
     short_label: Échelon 7
     unit: currency
@@ -216,6 +294,12 @@ echelon_7:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_8:
@@ -231,8 +315,14 @@ echelon_8:
       value: 886.0
     '2013-01-01':
       value: 956.0
+    '2019-03-01':
+      value: 1046.0
+    '2020-01-01':
+      value: 1136.0
+    '2020-08-01':
+      value: 1226.0
     '2025-01-01':
-      value: 1256.0
+      value: 1526.0
   metadata:
     short_label: Échelon 8
     unit: currency
@@ -247,6 +337,12 @@ echelon_8:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_9:
@@ -262,8 +358,14 @@ echelon_9:
       value: 886.0
     '2013-01-01':
       value: 956.0
+    '2019-03-01':
+      value: 1046.0
+    '2020-01-01':
+      value: 1136.0
+    '2020-08-01':
+      value: 1226.0
     '2025-01-01':
-      value: 1256.0
+      value: 1526.0
   metadata:
     short_label: Échelon 9
     unit: currency
@@ -278,6 +380,12 @@ echelon_9:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_10:
@@ -293,8 +401,14 @@ echelon_10:
       value: 886.0
     '2013-01-01':
       value: 956.0
+    '2019-03-01':
+      value: 1046.0
+    '2020-01-01':
+      value: 1136.0
+    '2020-08-01':
+      value: 1226.0
     '2025-01-01':
-      value: 1256.0
+      value: 1526.0
   metadata:
     short_label: Échelon 10
     unit: currency
@@ -309,6 +423,12 @@ echelon_10:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_11:
@@ -324,8 +444,14 @@ echelon_11:
       value: 886.0
     '2013-01-01':
       value: 956.0
+    '2019-03-01':
+      value: 1046.0
+    '2020-01-01':
+      value: 1136.0
+    '2020-08-01':
+      value: 1226.0
     '2025-01-01':
-      value: 1256.0
+      value: 1526.0
   metadata:
     short_label: Échelon 11
     unit: currency
@@ -340,6 +466,12 @@ echelon_11:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_12:
@@ -355,8 +487,14 @@ echelon_12:
       value: 886.0
     '2013-01-01':
       value: 956.0
+    '2019-03-01':
+      value: 1046.0
+    '2020-01-01':
+      value: 1136.0
+    '2020-08-01':
+      value: 1226.0
     '2025-01-01':
-      value: 1256.0
+      value: 1526.0
   metadata:
     short_label: Échelon 12
     unit: currency
@@ -371,6 +509,12 @@ echelon_12:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_13:
@@ -386,8 +530,14 @@ echelon_13:
       value: 886.0
     '2013-01-01':
       value: 956.0
+    '2019-03-01':
+      value: 1046.0
+    '2020-01-01':
+      value: 1136.0
+    '2020-08-01':
+      value: 1226.0
     '2025-01-01':
-      value: 1256.0
+      value: 1526.0
   metadata:
     short_label: Échelon 13
     unit: currency
@@ -402,6 +552,12 @@ echelon_13:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_14:
@@ -417,8 +573,14 @@ echelon_14:
       value: 886.0
     '2013-01-01':
       value: 956.0
+    '2019-03-01':
+      value: 1046.0
+    '2020-01-01':
+      value: 1136.0
+    '2020-08-01':
+      value: 1226.0
     '2025-01-01':
-      value: 1256.0
+      value: 1526.0
   metadata:
     short_label: Échelon 14
     unit: currency
@@ -433,6 +595,12 @@ echelon_14:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_15:
@@ -448,8 +616,14 @@ echelon_15:
       value: 886.0
     '2013-01-01':
       value: 956.0
+    '2019-03-01':
+      value: 1046.0
+    '2020-01-01':
+      value: 1136.0
+    '2020-08-01':
+      value: 1226.0
     '2025-01-01':
-      value: 1256.0
+      value: 1526.0
   metadata:
     short_label: Échelon 15
     unit: currency
@@ -464,6 +638,12 @@ echelon_15:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_16:
@@ -479,8 +659,14 @@ echelon_16:
       value: 886.0
     '2013-01-01':
       value: 956.0
+    '2019-03-01':
+      value: 1046.0
+    '2020-01-01':
+      value: 1136.0
+    '2020-08-01':
+      value: 1226.0
     '2025-01-01':
-      value: 1256.0
+      value: 1526.0
   metadata:
     short_label: Échelon 16
     unit: currency
@@ -495,6 +681,12 @@ echelon_16:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_17:
@@ -510,8 +702,14 @@ echelon_17:
       value: 886.0
     '2013-01-01':
       value: 956.0
+    '2019-03-01':
+      value: 1046.0
+    '2020-01-01':
+      value: 1136.0
+    '2020-08-01':
+      value: 1226.0
     '2025-01-01':
-      value: 1256.0
+      value: 1526.0
   metadata:
     short_label: Échelon 17
     unit: currency
@@ -526,6 +724,12 @@ echelon_17:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_18:
@@ -541,8 +745,14 @@ echelon_18:
       value: 886.0
     '2013-01-01':
       value: 956.0
+    '2019-03-01':
+      value: 1046.0
+    '2020-01-01':
+      value: 1136.0
+    '2020-08-01':
+      value: 1226.0
     '2025-01-01':
-      value: 1256.0
+      value: 1526.0
   metadata:
     short_label: Échelon 18
     unit: currency
@@ -557,6 +767,12 @@ echelon_18:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_19:
@@ -572,8 +788,14 @@ echelon_19:
       value: 886.0
     '2013-01-01':
       value: 956.0
+    '2019-03-01':
+      value: 1046.0
+    '2020-01-01':
+      value: 1136.0
+    '2020-08-01':
+      value: 1226.0
     '2025-01-01':
-      value: 1256.0
+      value: 1526.0
   metadata:
     short_label: Échelon 19
     unit: currency
@@ -588,6 +810,12 @@ echelon_19:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797
 echelon_20:
@@ -603,8 +831,14 @@ echelon_20:
       value: 886.0
     '2013-01-01':
       value: 956.0
+    '2019-03-01':
+      value: 1046.0
+    '2020-01-01':
+      value: 1136.0
+    '2020-08-01':
+      value: 1226.0
     '2025-01-01':
-      value: 1256.0
+      value: 1526.0
   metadata:
     short_label: Échelon 20
     unit: currency
@@ -619,5 +853,11 @@ echelon_20:
         title: Décret 2008-4102
       '2013-01-01':
         title: Décret 2012-2972
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
       '2025-01-01':
         title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/corps_administratif_commun/administrateur/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/corps_administratif_commun/administrateur/indemnite_specifique_mensuelle.yaml
@@ -1,11 +1,6 @@
 description: Indemnité spécifique mensuelle des administrateurs du corps des corps administratif commun des administrations publiques
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des administrateurs du corps des corps administratif commun des administrations publiques
   values:

--- a/openfisca_tunisia/parameters/fonction_publique/corps_administratif_commun/administrateur_adjoint/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/corps_administratif_commun/administrateur_adjoint/indemnite_specifique_mensuelle.yaml
@@ -1,11 +1,6 @@
 description: Indemnité spécifique mensuelle des administrateurs adjoints du corps des corps administratif commun des administrations publiques
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des administrateurs adjoints du corps des corps administratif commun des administrations publiques
   values:

--- a/openfisca_tunisia/parameters/fonction_publique/corps_administratif_commun/administrateur_conseiller/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/corps_administratif_commun/administrateur_conseiller/indemnite_specifique_mensuelle.yaml
@@ -1,11 +1,6 @@
 description: Indemnité spécifique mensuelle des administrateurs conseillers du corps des corps administratif commun des administrations publiques
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des administrateurs conseillers du corps des corps administratif commun des administrations publiques
   values:

--- a/openfisca_tunisia/parameters/fonction_publique/corps_administratif_commun/administrateur_en_chef/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/corps_administratif_commun/administrateur_en_chef/indemnite_specifique_mensuelle.yaml
@@ -1,11 +1,6 @@
 description: Indemnité spécifique mensuelle des administrateurs en chefs du corps des corps administratif commun des administrations publiques
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des administrateurs en chefs du corps des corps administratif commun des administrations publiques
   values:

--- a/openfisca_tunisia/parameters/fonction_publique/corps_administratif_commun/administrateur_general/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/corps_administratif_commun/administrateur_general/indemnite_specifique_mensuelle.yaml
@@ -1,11 +1,6 @@
 description: Indemnité spécifique mensuelle des administrateurs généraux du corps des corps administratif commun des administrations publiques
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des administrateurs généraux du corps des corps administratif commun des administrations publiques
   values:

--- a/openfisca_tunisia/parameters/fonction_publique/corps_administratif_commun/administrateur_general_classe_superieure/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/corps_administratif_commun/administrateur_general_classe_superieure/indemnite_specifique_mensuelle.yaml
@@ -1,136 +1,307 @@
 description: Indemnité spécifique mensuelle des administrateurs généraux classes supérieures du corps des corps administratif commun des administrations publiques
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des administrateurs généraux classes supérieures du corps des corps administratif commun des administrations publiques
   values:
     '2020-02-28':
-      value: 0.0
+      value: 1432.0
+    '2020-08-01':
+      value: 1522.0
+    '2025-01-01':
+      value: 1822.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2020-02-28':
+        title: Décret 2021-59
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des administrateurs généraux classes supérieures du corps des corps administratif commun des administrations publiques
   values:
     '2020-02-28':
-      value: 0.0
+      value: 1432.0
+    '2020-08-01':
+      value: 1522.0
+    '2025-01-01':
+      value: 1822.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2020-02-28':
+        title: Décret 2021-59
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des administrateurs généraux classes supérieures du corps des corps administratif commun des administrations publiques
   values:
     '2020-02-28':
-      value: 0.0
+      value: 1432.0
+    '2020-08-01':
+      value: 1522.0
+    '2025-01-01':
+      value: 1822.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2020-02-28':
+        title: Décret 2021-59
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des administrateurs généraux classes supérieures du corps des corps administratif commun des administrations publiques
   values:
     '2020-02-28':
-      value: 0.0
+      value: 1432.0
+    '2020-08-01':
+      value: 1522.0
+    '2025-01-01':
+      value: 1822.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2020-02-28':
+        title: Décret 2021-59
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des administrateurs généraux classes supérieures du corps des corps administratif commun des administrations publiques
   values:
     '2020-02-28':
-      value: 0.0
+      value: 1432.0
+    '2020-08-01':
+      value: 1522.0
+    '2025-01-01':
+      value: 1822.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2020-02-28':
+        title: Décret 2021-59
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des administrateurs généraux classes supérieures du corps des corps administratif commun des administrations publiques
   values:
     '2020-02-28':
-      value: 0.0
+      value: 1432.0
+    '2020-08-01':
+      value: 1522.0
+    '2025-01-01':
+      value: 1822.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2020-02-28':
+        title: Décret 2021-59
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des administrateurs généraux classes supérieures du corps des corps administratif commun des administrations publiques
   values:
     '2020-02-28':
-      value: 0.0
+      value: 1432.0
+    '2020-08-01':
+      value: 1522.0
+    '2025-01-01':
+      value: 1822.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2020-02-28':
+        title: Décret 2021-59
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des administrateurs généraux classes supérieures du corps des corps administratif commun des administrations publiques
   values:
     '2020-02-28':
-      value: 0.0
+      value: 1432.0
+    '2020-08-01':
+      value: 1522.0
+    '2025-01-01':
+      value: 1822.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2020-02-28':
+        title: Décret 2021-59
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des administrateurs généraux classes supérieures du corps des corps administratif commun des administrations publiques
   values:
     '2020-02-28':
-      value: 0.0
+      value: 1432.0
+    '2020-08-01':
+      value: 1522.0
+    '2025-01-01':
+      value: 1822.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2020-02-28':
+        title: Décret 2021-59
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des administrateurs généraux classes supérieures du corps des corps administratif commun des administrations publiques
   values:
     '2020-02-28':
-      value: 0.0
+      value: 1432.0
+    '2020-08-01':
+      value: 1522.0
+    '2025-01-01':
+      value: 1822.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2020-02-28':
+        title: Décret 2021-59
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des administrateurs généraux classes supérieures du corps des corps administratif commun des administrations publiques
   values:
     '2020-02-28':
-      value: 0.0
+      value: 1432.0
+    '2020-08-01':
+      value: 1522.0
+    '2025-01-01':
+      value: 1822.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2020-02-28':
+        title: Décret 2021-59
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des administrateurs généraux classes supérieures du corps des corps administratif commun des administrations publiques
   values:
     '2020-02-28':
-      value: 0.0
+      value: 1432.0
+    '2020-08-01':
+      value: 1522.0
+    '2025-01-01':
+      value: 1822.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2020-02-28':
+        title: Décret 2021-59
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des administrateurs généraux classes supérieures du corps des corps administratif commun des administrations publiques
   values:
     '2020-02-28':
-      value: 0.0
+      value: 1432.0
+    '2020-08-01':
+      value: 1522.0
+    '2025-01-01':
+      value: 1822.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2020-02-28':
+        title: Décret 2021-59
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des administrateurs généraux classes supérieures du corps des corps administratif commun des administrations publiques
   values:
     '2020-02-28':
-      value: 0.0
+      value: 1432.0
+    '2020-08-01':
+      value: 1522.0
+    '2025-01-01':
+      value: 1822.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2020-02-28':
+        title: Décret 2021-59
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des administrateurs généraux classes supérieures du corps des corps administratif commun des administrations publiques
   values:
     '2020-02-28':
-      value: 0.0
+      value: 1432.0
+    '2020-08-01':
+      value: 1522.0
+    '2025-01-01':
+      value: 1822.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2020-02-28':
+        title: Décret 2021-59
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des administrateurs généraux classes supérieures du corps des corps administratif commun des administrations publiques
   values:
     '2020-02-28':
-      value: 0.0
+      value: 1432.0
+    '2020-08-01':
+      value: 1522.0
+    '2025-01-01':
+      value: 1822.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2020-02-28':
+        title: Décret 2021-59
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/corps_administratif_commun/agent_accueil/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/corps_administratif_commun/agent_accueil/indemnite_specifique_mensuelle.yaml
@@ -1,11 +1,6 @@
 description: Indemnité spécifique mensuelle des agents accueils du corps des corps administratif commun des administrations publiques
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des agents accueils du corps des corps administratif commun des administrations publiques
   values:

--- a/openfisca_tunisia/parameters/fonction_publique/corps_administratif_commun/commis_administration/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/corps_administratif_commun/commis_administration/indemnite_specifique_mensuelle.yaml
@@ -1,11 +1,6 @@
 description: Indemnité spécifique mensuelle des commis administrations du corps des corps administratif commun des administrations publiques
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des commis administrations du corps des corps administratif commun des administrations publiques
   values:

--- a/openfisca_tunisia/parameters/fonction_publique/corps_administratif_commun/secretaire_administration/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/corps_administratif_commun/secretaire_administration/indemnite_specifique_mensuelle.yaml
@@ -1,11 +1,6 @@
 description: Indemnité spécifique mensuelle des secrétaires administrations du corps des corps administratif commun des administrations publiques
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des secrétaires administrations du corps des corps administratif commun des administrations publiques
   values:

--- a/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_de_l_enseignement_hors_classe/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_de_l_enseignement_hors_classe/indemnite_specifique_mensuelle.yaml
@@ -6,218 +6,673 @@ echelon_1:
   values:
     '2013-02-05':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 1
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 2
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 3
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 4
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 5
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 6
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 7
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 8
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 9
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 10
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 11
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 12
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 13
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 14
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 15
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 16
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 17
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 18
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 19
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 20
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_de_l_enseignement_hors_classe/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_de_l_enseignement_hors_classe/traitement_de_base.yaml
@@ -6,6 +6,8 @@ echelon_1:
   values:
     '2013-02-05':
       value: 566.25
+    '2015-09-04':
+      value: 521.25
   metadata:
     short_label: Échelon 1
     unit: currency
@@ -17,6 +19,8 @@ echelon_2:
   values:
     '2013-02-05':
       value: 575.25
+    '2015-09-04':
+      value: 530.25
   metadata:
     short_label: Échelon 2
     unit: currency
@@ -28,6 +32,8 @@ echelon_3:
   values:
     '2013-02-05':
       value: 584.25
+    '2015-09-04':
+      value: 539.25
   metadata:
     short_label: Échelon 3
     unit: currency
@@ -39,6 +45,8 @@ echelon_4:
   values:
     '2013-02-05':
       value: 593.25
+    '2015-09-04':
+      value: 548.25
   metadata:
     short_label: Échelon 4
     unit: currency
@@ -50,6 +58,8 @@ echelon_5:
   values:
     '2013-02-05':
       value: 602.25
+    '2015-09-04':
+      value: 557.25
   metadata:
     short_label: Échelon 5
     unit: currency
@@ -61,6 +71,8 @@ echelon_6:
   values:
     '2013-02-05':
       value: 611.25
+    '2015-09-04':
+      value: 566.25
   metadata:
     short_label: Échelon 6
     unit: currency
@@ -72,6 +84,8 @@ echelon_7:
   values:
     '2013-02-05':
       value: 620.25
+    '2015-09-04':
+      value: 575.25
   metadata:
     short_label: Échelon 7
     unit: currency
@@ -83,6 +97,8 @@ echelon_8:
   values:
     '2013-02-05':
       value: 629.25
+    '2015-09-04':
+      value: 584.25
   metadata:
     short_label: Échelon 8
     unit: currency
@@ -94,6 +110,8 @@ echelon_9:
   values:
     '2013-02-05':
       value: 638.25
+    '2015-09-04':
+      value: 593.25
   metadata:
     short_label: Échelon 9
     unit: currency
@@ -105,6 +123,8 @@ echelon_10:
   values:
     '2013-02-05':
       value: 647.25
+    '2015-09-04':
+      value: 602.25
   metadata:
     short_label: Échelon 10
     unit: currency
@@ -116,6 +136,8 @@ echelon_11:
   values:
     '2013-02-05':
       value: 656.25
+    '2015-09-04':
+      value: 611.25
   metadata:
     short_label: Échelon 11
     unit: currency
@@ -127,6 +149,8 @@ echelon_12:
   values:
     '2013-02-05':
       value: 665.25
+    '2015-09-04':
+      value: 620.25
   metadata:
     short_label: Échelon 12
     unit: currency
@@ -138,6 +162,8 @@ echelon_13:
   values:
     '2013-02-05':
       value: 674.25
+    '2015-09-04':
+      value: 629.25
   metadata:
     short_label: Échelon 13
     unit: currency
@@ -149,6 +175,8 @@ echelon_14:
   values:
     '2013-02-05':
       value: 683.25
+    '2015-09-04':
+      value: 638.25
   metadata:
     short_label: Échelon 14
     unit: currency
@@ -160,6 +188,8 @@ echelon_15:
   values:
     '2013-02-05':
       value: 692.25
+    '2015-09-04':
+      value: 647.25
   metadata:
     short_label: Échelon 15
     unit: currency
@@ -171,6 +201,8 @@ echelon_16:
   values:
     '2013-02-05':
       value: 701.25
+    '2015-09-04':
+      value: 656.25
   metadata:
     short_label: Échelon 16
     unit: currency
@@ -182,6 +214,8 @@ echelon_17:
   values:
     '2013-02-05':
       value: 710.25
+    '2015-09-04':
+      value: 665.25
   metadata:
     short_label: Échelon 17
     unit: currency
@@ -193,6 +227,8 @@ echelon_18:
   values:
     '2013-02-05':
       value: 719.25
+    '2015-09-04':
+      value: 674.25
   metadata:
     short_label: Échelon 18
     unit: currency
@@ -204,6 +240,8 @@ echelon_19:
   values:
     '2013-02-05':
       value: 728.25
+    '2015-09-04':
+      value: 683.25
   metadata:
     short_label: Échelon 19
     unit: currency
@@ -215,9 +253,66 @@ echelon_20:
   values:
     '2013-02-05':
       value: 737.25
+    '2015-09-04':
+      value: 692.25
   metadata:
     short_label: Échelon 20
     unit: currency
     reference:
       '2013-02-05':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 701.25
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 710.25
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 719.25
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 728.25
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 des professeurs de l'enseignements hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 737.25
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2015-09-04':
         title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_de_l_enseignement_principal_hors_classe/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_de_l_enseignement_principal_hors_classe/indemnite_specifique_mensuelle.yaml
@@ -6,218 +6,673 @@ echelon_1:
   values:
     '2013-02-05':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 1
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 2
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 3
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 4
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 5
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 6
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 7
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 8
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 9
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 10
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 11
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 12
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 13
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 14
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 15
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 16
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 17
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 18
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 19
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 20
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_de_l_enseignement_principal_hors_classe/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_de_l_enseignement_principal_hors_classe/traitement_de_base.yaml
@@ -6,6 +6,8 @@ echelon_1:
   values:
     '2013-02-05':
       value: 668.5
+    '2015-09-04':
+      value: 611.0
   metadata:
     short_label: Échelon 1
     unit: currency
@@ -17,6 +19,8 @@ echelon_2:
   values:
     '2013-02-05':
       value: 680.0
+    '2015-09-04':
+      value: 622.5
   metadata:
     short_label: Échelon 2
     unit: currency
@@ -28,6 +32,8 @@ echelon_3:
   values:
     '2013-02-05':
       value: 691.5
+    '2015-09-04':
+      value: 634.0
   metadata:
     short_label: Échelon 3
     unit: currency
@@ -39,6 +45,8 @@ echelon_4:
   values:
     '2013-02-05':
       value: 703.0
+    '2015-09-04':
+      value: 645.5
   metadata:
     short_label: Échelon 4
     unit: currency
@@ -50,6 +58,8 @@ echelon_5:
   values:
     '2013-02-05':
       value: 714.5
+    '2015-09-04':
+      value: 657.0
   metadata:
     short_label: Échelon 5
     unit: currency
@@ -61,6 +71,8 @@ echelon_6:
   values:
     '2013-02-05':
       value: 726.0
+    '2015-09-04':
+      value: 668.5
   metadata:
     short_label: Échelon 6
     unit: currency
@@ -72,6 +84,8 @@ echelon_7:
   values:
     '2013-02-05':
       value: 737.5
+    '2015-09-04':
+      value: 680.0
   metadata:
     short_label: Échelon 7
     unit: currency
@@ -83,6 +97,8 @@ echelon_8:
   values:
     '2013-02-05':
       value: 749.0
+    '2015-09-04':
+      value: 691.5
   metadata:
     short_label: Échelon 8
     unit: currency
@@ -94,6 +110,8 @@ echelon_9:
   values:
     '2013-02-05':
       value: 760.5
+    '2015-09-04':
+      value: 703.0
   metadata:
     short_label: Échelon 9
     unit: currency
@@ -105,6 +123,8 @@ echelon_10:
   values:
     '2013-02-05':
       value: 772.0
+    '2015-09-04':
+      value: 714.5
   metadata:
     short_label: Échelon 10
     unit: currency
@@ -116,6 +136,8 @@ echelon_11:
   values:
     '2013-02-05':
       value: 783.5
+    '2015-09-04':
+      value: 726.0
   metadata:
     short_label: Échelon 11
     unit: currency
@@ -127,6 +149,8 @@ echelon_12:
   values:
     '2013-02-05':
       value: 795.0
+    '2015-09-04':
+      value: 737.5
   metadata:
     short_label: Échelon 12
     unit: currency
@@ -138,6 +162,8 @@ echelon_13:
   values:
     '2013-02-05':
       value: 806.5
+    '2015-09-04':
+      value: 749.0
   metadata:
     short_label: Échelon 13
     unit: currency
@@ -149,6 +175,8 @@ echelon_14:
   values:
     '2013-02-05':
       value: 818.0
+    '2015-09-04':
+      value: 760.5
   metadata:
     short_label: Échelon 14
     unit: currency
@@ -160,6 +188,8 @@ echelon_15:
   values:
     '2013-02-05':
       value: 829.5
+    '2015-09-04':
+      value: 772.0
   metadata:
     short_label: Échelon 15
     unit: currency
@@ -171,6 +201,8 @@ echelon_16:
   values:
     '2013-02-05':
       value: 841.0
+    '2015-09-04':
+      value: 783.5
   metadata:
     short_label: Échelon 16
     unit: currency
@@ -182,6 +214,8 @@ echelon_17:
   values:
     '2013-02-05':
       value: 852.5
+    '2015-09-04':
+      value: 795.0
   metadata:
     short_label: Échelon 17
     unit: currency
@@ -193,6 +227,8 @@ echelon_18:
   values:
     '2013-02-05':
       value: 864.0
+    '2015-09-04':
+      value: 806.5
   metadata:
     short_label: Échelon 18
     unit: currency
@@ -204,6 +240,8 @@ echelon_19:
   values:
     '2013-02-05':
       value: 875.5
+    '2015-09-04':
+      value: 818.0
   metadata:
     short_label: Échelon 19
     unit: currency
@@ -215,9 +253,66 @@ echelon_20:
   values:
     '2013-02-05':
       value: 887.0
+    '2015-09-04':
+      value: 829.5
   metadata:
     short_label: Échelon 20
     unit: currency
     reference:
       '2013-02-05':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 841.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 852.5
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 864.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 875.5
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 des professeurs de l'enseignements principaux hors classes du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 887.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2015-09-04':
         title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_de_l_enseignement_secondaire_emerite/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_de_l_enseignement_secondaire_emerite/indemnite_specifique_mensuelle.yaml
@@ -6,218 +6,673 @@ echelon_1:
   values:
     '2013-02-05':
       value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
   metadata:
     short_label: Échelon 1
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
   metadata:
     short_label: Échelon 2
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
   metadata:
     short_label: Échelon 3
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
   metadata:
     short_label: Échelon 4
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
   metadata:
     short_label: Échelon 5
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
   metadata:
     short_label: Échelon 6
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
   metadata:
     short_label: Échelon 7
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
   metadata:
     short_label: Échelon 8
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
   metadata:
     short_label: Échelon 9
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
   metadata:
     short_label: Échelon 10
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
   metadata:
     short_label: Échelon 11
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
   metadata:
     short_label: Échelon 12
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
   metadata:
     short_label: Échelon 13
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
   metadata:
     short_label: Échelon 14
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
   metadata:
     short_label: Échelon 15
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
   metadata:
     short_label: Échelon 16
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
   metadata:
     short_label: Échelon 17
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
   metadata:
     short_label: Échelon 18
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
   metadata:
     short_label: Échelon 19
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
   metadata:
     short_label: Échelon 20
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_de_l_enseignement_secondaire_emerite/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_de_l_enseignement_secondaire_emerite/traitement_de_base.yaml
@@ -6,6 +6,8 @@ echelon_1:
   values:
     '2013-02-05':
       value: 566.25
+    '2015-09-04':
+      value: 521.25
   metadata:
     short_label: Échelon 1
     unit: currency
@@ -17,6 +19,8 @@ echelon_2:
   values:
     '2013-02-05':
       value: 575.25
+    '2015-09-04':
+      value: 530.25
   metadata:
     short_label: Échelon 2
     unit: currency
@@ -28,6 +32,8 @@ echelon_3:
   values:
     '2013-02-05':
       value: 584.25
+    '2015-09-04':
+      value: 539.25
   metadata:
     short_label: Échelon 3
     unit: currency
@@ -39,6 +45,8 @@ echelon_4:
   values:
     '2013-02-05':
       value: 593.25
+    '2015-09-04':
+      value: 548.25
   metadata:
     short_label: Échelon 4
     unit: currency
@@ -50,6 +58,8 @@ echelon_5:
   values:
     '2013-02-05':
       value: 602.25
+    '2015-09-04':
+      value: 557.25
   metadata:
     short_label: Échelon 5
     unit: currency
@@ -61,6 +71,8 @@ echelon_6:
   values:
     '2013-02-05':
       value: 611.25
+    '2015-09-04':
+      value: 566.25
   metadata:
     short_label: Échelon 6
     unit: currency
@@ -72,6 +84,8 @@ echelon_7:
   values:
     '2013-02-05':
       value: 620.25
+    '2015-09-04':
+      value: 575.25
   metadata:
     short_label: Échelon 7
     unit: currency
@@ -83,6 +97,8 @@ echelon_8:
   values:
     '2013-02-05':
       value: 629.25
+    '2015-09-04':
+      value: 584.25
   metadata:
     short_label: Échelon 8
     unit: currency
@@ -94,6 +110,8 @@ echelon_9:
   values:
     '2013-02-05':
       value: 638.25
+    '2015-09-04':
+      value: 593.25
   metadata:
     short_label: Échelon 9
     unit: currency
@@ -105,6 +123,8 @@ echelon_10:
   values:
     '2013-02-05':
       value: 647.25
+    '2015-09-04':
+      value: 602.25
   metadata:
     short_label: Échelon 10
     unit: currency
@@ -116,6 +136,8 @@ echelon_11:
   values:
     '2013-02-05':
       value: 656.25
+    '2015-09-04':
+      value: 611.25
   metadata:
     short_label: Échelon 11
     unit: currency
@@ -127,6 +149,8 @@ echelon_12:
   values:
     '2013-02-05':
       value: 665.25
+    '2015-09-04':
+      value: 620.25
   metadata:
     short_label: Échelon 12
     unit: currency
@@ -138,6 +162,8 @@ echelon_13:
   values:
     '2013-02-05':
       value: 674.25
+    '2015-09-04':
+      value: 629.25
   metadata:
     short_label: Échelon 13
     unit: currency
@@ -149,6 +175,8 @@ echelon_14:
   values:
     '2013-02-05':
       value: 683.25
+    '2015-09-04':
+      value: 638.25
   metadata:
     short_label: Échelon 14
     unit: currency
@@ -160,6 +188,8 @@ echelon_15:
   values:
     '2013-02-05':
       value: 692.25
+    '2015-09-04':
+      value: 647.25
   metadata:
     short_label: Échelon 15
     unit: currency
@@ -171,6 +201,8 @@ echelon_16:
   values:
     '2013-02-05':
       value: 701.25
+    '2015-09-04':
+      value: 656.25
   metadata:
     short_label: Échelon 16
     unit: currency
@@ -182,6 +214,8 @@ echelon_17:
   values:
     '2013-02-05':
       value: 710.25
+    '2015-09-04':
+      value: 665.25
   metadata:
     short_label: Échelon 17
     unit: currency
@@ -193,6 +227,8 @@ echelon_18:
   values:
     '2013-02-05':
       value: 719.25
+    '2015-09-04':
+      value: 674.25
   metadata:
     short_label: Échelon 18
     unit: currency
@@ -204,6 +240,8 @@ echelon_19:
   values:
     '2013-02-05':
       value: 728.25
+    '2015-09-04':
+      value: 683.25
   metadata:
     short_label: Échelon 19
     unit: currency
@@ -215,9 +253,66 @@ echelon_20:
   values:
     '2013-02-05':
       value: 737.25
+    '2015-09-04':
+      value: 692.25
   metadata:
     short_label: Échelon 20
     unit: currency
     reference:
       '2013-02-05':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 701.25
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 710.25
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 719.25
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 728.25
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 des professeurs de l'enseignements secondaires emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 737.25
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2015-09-04':
         title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_de_l_enseignement_secondaire_emerite_classe_exceptionnelle/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_de_l_enseignement_secondaire_emerite_classe_exceptionnelle/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,678 @@
+description: Indemnité spécifique mensuelle du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.0
+    '2019-03-01':
+      value: 873.0
+    '2020-01-01':
+      value: 963.0
+    '2020-08-01':
+      value: 1053.0
+    '2025-01-01':
+      value: 1323.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_de_l_enseignement_secondaire_emerite_classe_exceptionnelle/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_de_l_enseignement_secondaire_emerite_classe_exceptionnelle/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+metadata:
+  short_label: Professeur de l'enseignement secondaire émérite classe exceptionnelle
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A2

--- a/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_de_l_enseignement_secondaire_emerite_classe_exceptionnelle/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_de_l_enseignement_secondaire_emerite_classe_exceptionnelle/traitement_de_base.yaml
@@ -1,0 +1,278 @@
+description: Traitement de base mensuel du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 521.25
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 530.25
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 539.25
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 548.25
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 557.25
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 566.25
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 575.25
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 584.25
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 593.25
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 602.25
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 611.25
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 620.25
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 629.25
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 638.25
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 647.25
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 656.25
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 665.25
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 674.25
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 683.25
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 692.25
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 701.25
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 710.25
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 719.25
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 728.25
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 du grade « professeur de l'enseignement secondaire émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 737.25
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_principal_emerite/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_principal_emerite/indemnite_specifique_mensuelle.yaml
@@ -6,174 +6,673 @@ echelon_1:
   values:
     '2013-02-05':
       value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
   metadata:
     short_label: Échelon 1
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
   metadata:
     short_label: Échelon 2
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
   metadata:
     short_label: Échelon 3
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
   metadata:
     short_label: Échelon 4
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
   metadata:
     short_label: Échelon 5
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
   metadata:
     short_label: Échelon 6
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
   metadata:
     short_label: Échelon 7
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
   metadata:
     short_label: Échelon 8
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
   metadata:
     short_label: Échelon 9
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
   metadata:
     short_label: Échelon 10
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
   metadata:
     short_label: Échelon 11
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
   metadata:
     short_label: Échelon 12
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
   metadata:
     short_label: Échelon 13
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
   metadata:
     short_label: Échelon 14
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
   metadata:
     short_label: Échelon 15
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-02-05':
       value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
   metadata:
     short_label: Échelon 16
     unit: currency
     reference:
       '2013-02-05':
         title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2013-667
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_principal_emerite/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_principal_emerite/traitement_de_base.yaml
@@ -6,6 +6,8 @@ echelon_1:
   values:
     '2013-02-05':
       value: 714.5
+    '2015-09-04':
+      value: 611.0
   metadata:
     short_label: Échelon 1
     unit: currency
@@ -17,6 +19,8 @@ echelon_2:
   values:
     '2013-02-05':
       value: 726.0
+    '2015-09-04':
+      value: 622.5
   metadata:
     short_label: Échelon 2
     unit: currency
@@ -28,6 +32,8 @@ echelon_3:
   values:
     '2013-02-05':
       value: 737.5
+    '2015-09-04':
+      value: 634.0
   metadata:
     short_label: Échelon 3
     unit: currency
@@ -39,6 +45,8 @@ echelon_4:
   values:
     '2013-02-05':
       value: 749.0
+    '2015-09-04':
+      value: 645.5
   metadata:
     short_label: Échelon 4
     unit: currency
@@ -50,6 +58,8 @@ echelon_5:
   values:
     '2013-02-05':
       value: 760.5
+    '2015-09-04':
+      value: 657.0
   metadata:
     short_label: Échelon 5
     unit: currency
@@ -61,6 +71,8 @@ echelon_6:
   values:
     '2013-02-05':
       value: 772.0
+    '2015-09-04':
+      value: 668.5
   metadata:
     short_label: Échelon 6
     unit: currency
@@ -72,6 +84,8 @@ echelon_7:
   values:
     '2013-02-05':
       value: 783.5
+    '2015-09-04':
+      value: 680.0
   metadata:
     short_label: Échelon 7
     unit: currency
@@ -83,6 +97,8 @@ echelon_8:
   values:
     '2013-02-05':
       value: 795.0
+    '2015-09-04':
+      value: 691.5
   metadata:
     short_label: Échelon 8
     unit: currency
@@ -94,6 +110,8 @@ echelon_9:
   values:
     '2013-02-05':
       value: 806.5
+    '2015-09-04':
+      value: 703.0
   metadata:
     short_label: Échelon 9
     unit: currency
@@ -105,6 +123,8 @@ echelon_10:
   values:
     '2013-02-05':
       value: 818.0
+    '2015-09-04':
+      value: 714.5
   metadata:
     short_label: Échelon 10
     unit: currency
@@ -116,6 +136,8 @@ echelon_11:
   values:
     '2013-02-05':
       value: 829.5
+    '2015-09-04':
+      value: 726.0
   metadata:
     short_label: Échelon 11
     unit: currency
@@ -127,6 +149,8 @@ echelon_12:
   values:
     '2013-02-05':
       value: 841.0
+    '2015-09-04':
+      value: 737.5
   metadata:
     short_label: Échelon 12
     unit: currency
@@ -138,6 +162,8 @@ echelon_13:
   values:
     '2013-02-05':
       value: 852.5
+    '2015-09-04':
+      value: 749.0
   metadata:
     short_label: Échelon 13
     unit: currency
@@ -149,6 +175,8 @@ echelon_14:
   values:
     '2013-02-05':
       value: 864.0
+    '2015-09-04':
+      value: 760.5
   metadata:
     short_label: Échelon 14
     unit: currency
@@ -160,6 +188,8 @@ echelon_15:
   values:
     '2013-02-05':
       value: 875.5
+    '2015-09-04':
+      value: 772.0
   metadata:
     short_label: Échelon 15
     unit: currency
@@ -171,9 +201,110 @@ echelon_16:
   values:
     '2013-02-05':
       value: 887.0
+    '2015-09-04':
+      value: 783.5
   metadata:
     short_label: Échelon 16
     unit: currency
     reference:
       '2013-02-05':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 795.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 806.5
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 818.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 829.5
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 841.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 852.5
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 864.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 875.5
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 des professeurs principaux emerites du corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées
+  values:
+    '2015-09-04':
+      value: 887.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2015-09-04':
         title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_principal_emerite_classe_exceptionnelle/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_principal_emerite_classe_exceptionnelle/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,678 @@
+description: Indemnité spécifique mensuelle du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 927.0
+    '2019-03-01':
+      value: 1017.0
+    '2020-01-01':
+      value: 1107.0
+    '2020-08-01':
+      value: 1197.0
+    '2025-01-01':
+      value: 1497.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2015-1164
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_principal_emerite_classe_exceptionnelle/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_principal_emerite_classe_exceptionnelle/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+metadata:
+  short_label: Professeur principal émérite classe exceptionnelle
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A1

--- a/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_principal_emerite_classe_exceptionnelle/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignants_lycees/professeur_principal_emerite_classe_exceptionnelle/traitement_de_base.yaml
@@ -1,0 +1,278 @@
+description: Traitement de base mensuel du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 611.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 622.5
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 634.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 645.5
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 657.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 668.5
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 680.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 691.5
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 703.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 714.5
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 726.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 737.5
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 749.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 760.5
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 772.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 783.5
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 795.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 806.5
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 818.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 829.5
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 841.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 852.5
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 864.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 875.5
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 du grade « professeur principal émérite classe exceptionnelle » du corps « Corps des personnels enseignants exerçant dans les écoles préparatoires et les lycées »
+  values:
+    '2015-09-04':
+      value: 887.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2015-09-04':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/chef_travaux_enseignement_technique_1er_cycle/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/chef_travaux_enseignement_technique_1er_cycle/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,728 @@
+description: Indemnité spécifique mensuelle du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/chef_travaux_enseignement_technique_1er_cycle/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/chef_travaux_enseignement_technique_1er_cycle/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+metadata:
+  short_label: Chef de travaux d'enseignement technique du 1er cycle
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A3

--- a/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/chef_travaux_enseignement_technique_1er_cycle/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/chef_travaux_enseignement_technique_1er_cycle/traitement_de_base.yaml
@@ -1,0 +1,378 @@
+description: Traitement de base mensuel du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 146.0
+    '2007-04-01':
+      value: 443.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 154.25
+    '2007-04-01':
+      value: 451.25
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 162.5
+    '2007-04-01':
+      value: 459.5
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 170.75
+    '2007-04-01':
+      value: 467.75
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 179.0
+    '2007-04-01':
+      value: 476.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 187.25
+    '2007-04-01':
+      value: 484.25
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 195.5
+    '2007-04-01':
+      value: 492.5
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 203.75
+    '2007-04-01':
+      value: 500.75
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 212.0
+    '2007-04-01':
+      value: 509.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 220.25
+    '2007-04-01':
+      value: 517.25
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 228.5
+    '2007-04-01':
+      value: 525.5
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 236.75
+    '2007-04-01':
+      value: 533.75
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 245.0
+    '2007-04-01':
+      value: 542.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 253.25
+    '2007-04-01':
+      value: 550.25
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 261.5
+    '2007-04-01':
+      value: 558.5
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 269.75
+    '2007-04-01':
+      value: 566.75
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 278.0
+    '2007-04-01':
+      value: 575.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 286.25
+    '2007-04-01':
+      value: 583.25
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 294.5
+    '2007-04-01':
+      value: 591.5
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 302.75
+    '2007-04-01':
+      value: 599.75
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 311.0
+    '2007-04-01':
+      value: 608.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 319.25
+    '2007-04-01':
+      value: 616.25
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 327.5
+    '2007-04-01':
+      value: 624.5
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 335.75
+    '2007-04-01':
+      value: 632.75
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 du grade « chef de travaux d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 344.0
+    '2007-04-01':
+      value: 641.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/index.yaml
@@ -1,0 +1,3 @@
+description: Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation
+metadata:
+  short_label: Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation

--- a/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/instructeur_technique/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/instructeur_technique/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,728 @@
+description: Indemnité spécifique mensuelle du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 356.125
+    '2019-03-01':
+      value: 426.125
+    '2020-01-01':
+      value: 491.125
+    '2020-08-01':
+      value: 561.125
+    '2025-01-01':
+      value: 756.125
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/instructeur_technique/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/instructeur_technique/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+metadata:
+  short_label: Instructeur technique
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie C

--- a/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/instructeur_technique/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/instructeur_technique/traitement_de_base.yaml
@@ -1,0 +1,378 @@
+description: Traitement de base mensuel du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 111.5
+    '2007-04-01':
+      value: 300.75
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 115.5
+    '2007-04-01':
+      value: 304.75
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 119.5
+    '2007-04-01':
+      value: 308.75
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 123.5
+    '2007-04-01':
+      value: 312.75
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 127.5
+    '2007-04-01':
+      value: 316.75
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 131.5
+    '2007-04-01':
+      value: 320.75
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 135.5
+    '2007-04-01':
+      value: 324.75
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 139.5
+    '2007-04-01':
+      value: 328.75
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 143.5
+    '2007-04-01':
+      value: 332.75
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 147.5
+    '2007-04-01':
+      value: 336.75
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 151.5
+    '2007-04-01':
+      value: 340.75
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 155.5
+    '2007-04-01':
+      value: 344.75
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 159.5
+    '2007-04-01':
+      value: 348.75
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 163.5
+    '2007-04-01':
+      value: 352.75
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 167.5
+    '2007-04-01':
+      value: 356.75
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 171.5
+    '2007-04-01':
+      value: 360.75
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 175.5
+    '2007-04-01':
+      value: 364.75
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 179.5
+    '2007-04-01':
+      value: 368.75
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 183.5
+    '2007-04-01':
+      value: 372.75
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 187.5
+    '2007-04-01':
+      value: 376.75
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 191.5
+    '2007-04-01':
+      value: 380.75
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 195.5
+    '2007-04-01':
+      value: 384.75
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 199.5
+    '2007-04-01':
+      value: 388.75
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 203.5
+    '2007-04-01':
+      value: 392.75
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 du grade « instructeur technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 207.5
+    '2007-04-01':
+      value: 396.75
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/maitre_enseignement_technique/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/maitre_enseignement_technique/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,728 @@
+description: Indemnité spécifique mensuelle du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 459.0
+    '2019-03-01':
+      value: 534.0
+    '2020-01-01':
+      value: 614.0
+    '2020-08-01':
+      value: 684.0
+    '2025-01-01':
+      value: 894.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/maitre_enseignement_technique/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/maitre_enseignement_technique/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+metadata:
+  short_label: Maître d'enseignement technique
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie B

--- a/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/maitre_enseignement_technique/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/maitre_enseignement_technique/traitement_de_base.yaml
@@ -1,0 +1,378 @@
+description: Traitement de base mensuel du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 128.25
+    '2007-04-01':
+      value: 360.25
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 133.75
+    '2007-04-01':
+      value: 365.75
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 139.25
+    '2007-04-01':
+      value: 371.25
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 144.75
+    '2007-04-01':
+      value: 376.75
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 150.25
+    '2007-04-01':
+      value: 382.25
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 155.75
+    '2007-04-01':
+      value: 387.75
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 161.25
+    '2007-04-01':
+      value: 393.25
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 166.75
+    '2007-04-01':
+      value: 398.75
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 172.25
+    '2007-04-01':
+      value: 404.25
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 177.75
+    '2007-04-01':
+      value: 409.75
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 183.25
+    '2007-04-01':
+      value: 415.25
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 188.75
+    '2007-04-01':
+      value: 420.75
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 194.25
+    '2007-04-01':
+      value: 426.25
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 199.75
+    '2007-04-01':
+      value: 431.75
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 205.25
+    '2007-04-01':
+      value: 437.25
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 210.75
+    '2007-04-01':
+      value: 442.75
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 216.25
+    '2007-04-01':
+      value: 448.25
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 221.75
+    '2007-04-01':
+      value: 453.75
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 227.25
+    '2007-04-01':
+      value: 459.25
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 232.75
+    '2007-04-01':
+      value: 464.75
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 238.25
+    '2007-04-01':
+      value: 470.25
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 243.75
+    '2007-04-01':
+      value: 475.75
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 249.25
+    '2007-04-01':
+      value: 481.25
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 254.75
+    '2007-04-01':
+      value: 486.75
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 du grade « maître d'enseignement technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 260.25
+    '2007-04-01':
+      value: 492.25
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/professeur_enseignement_secondaire_technique/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/professeur_enseignement_secondaire_technique/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,728 @@
+description: Indemnité spécifique mensuelle du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 636.0
+    '2019-03-01':
+      value: 726.0
+    '2020-01-01':
+      value: 816.0
+    '2020-08-01':
+      value: 906.0
+    '2025-01-01':
+      value: 1176.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/professeur_enseignement_secondaire_technique/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/professeur_enseignement_secondaire_technique/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+metadata:
+  short_label: Professeur d'enseignement secondaire technique
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A2

--- a/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/professeur_enseignement_secondaire_technique/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/professeur_enseignement_secondaire_technique/traitement_de_base.yaml
@@ -1,0 +1,378 @@
+description: Traitement de base mensuel du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 181.25
+    '2007-04-01':
+      value: 521.25
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 190.25
+    '2007-04-01':
+      value: 530.25
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 199.25
+    '2007-04-01':
+      value: 539.25
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 208.25
+    '2007-04-01':
+      value: 548.25
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 217.25
+    '2007-04-01':
+      value: 557.25
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 226.25
+    '2007-04-01':
+      value: 566.25
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 235.25
+    '2007-04-01':
+      value: 575.25
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 244.25
+    '2007-04-01':
+      value: 584.25
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 253.25
+    '2007-04-01':
+      value: 593.25
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 262.25
+    '2007-04-01':
+      value: 602.25
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 271.25
+    '2007-04-01':
+      value: 611.25
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 280.25
+    '2007-04-01':
+      value: 620.25
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 289.25
+    '2007-04-01':
+      value: 629.25
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 298.25
+    '2007-04-01':
+      value: 638.25
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 307.25
+    '2007-04-01':
+      value: 647.25
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 316.25
+    '2007-04-01':
+      value: 656.25
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 325.25
+    '2007-04-01':
+      value: 665.25
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 334.25
+    '2007-04-01':
+      value: 674.25
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 343.25
+    '2007-04-01':
+      value: 683.25
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 352.25
+    '2007-04-01':
+      value: 692.25
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 361.25
+    '2007-04-01':
+      value: 701.25
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 370.25
+    '2007-04-01':
+      value: 710.25
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 379.25
+    '2007-04-01':
+      value: 719.25
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 388.25
+    '2007-04-01':
+      value: 728.25
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 du grade « professeur d'enseignement secondaire technique » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 397.25
+    '2007-04-01':
+      value: 737.25
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/professeur_enseignement_technique_1er_cycle/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/professeur_enseignement_technique_1er_cycle/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,728 @@
+description: Indemnité spécifique mensuelle du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 0.0
+    '2013-01-01':
+      value: 530.5
+    '2019-03-01':
+      value: 610.5
+    '2020-01-01':
+      value: 700.5
+    '2020-08-01':
+      value: 775.5
+    '2025-01-01':
+      value: 995.5
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2013-01-01':
+        title: Décret 2012-2973
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/professeur_enseignement_technique_1er_cycle/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/professeur_enseignement_technique_1er_cycle/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+metadata:
+  short_label: Professeur d'enseignement technique du 1er cycle
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A3

--- a/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/professeur_enseignement_technique_1er_cycle/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/enseignement_secondaire_technique_professionnel/professeur_enseignement_technique_1er_cycle/traitement_de_base.yaml
@@ -1,0 +1,378 @@
+description: Traitement de base mensuel du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 146.0
+    '2007-04-01':
+      value: 443.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 154.25
+    '2007-04-01':
+      value: 451.25
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 162.5
+    '2007-04-01':
+      value: 459.5
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 170.75
+    '2007-04-01':
+      value: 467.75
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 179.0
+    '2007-04-01':
+      value: 476.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 187.25
+    '2007-04-01':
+      value: 484.25
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 195.5
+    '2007-04-01':
+      value: 492.5
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 203.75
+    '2007-04-01':
+      value: 500.75
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 212.0
+    '2007-04-01':
+      value: 509.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 220.25
+    '2007-04-01':
+      value: 517.25
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 228.5
+    '2007-04-01':
+      value: 525.5
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 236.75
+    '2007-04-01':
+      value: 533.75
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 245.0
+    '2007-04-01':
+      value: 542.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 253.25
+    '2007-04-01':
+      value: 550.25
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 261.5
+    '2007-04-01':
+      value: 558.5
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 269.75
+    '2007-04-01':
+      value: 566.75
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 278.0
+    '2007-04-01':
+      value: 575.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 286.25
+    '2007-04-01':
+      value: 583.25
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 294.5
+    '2007-04-01':
+      value: 591.5
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 302.75
+    '2007-04-01':
+      value: 599.75
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 311.0
+    '2007-04-01':
+      value: 608.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 319.25
+    '2007-04-01':
+      value: 616.25
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 327.5
+    '2007-04-01':
+      value: 624.5
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 335.75
+    '2007-04-01':
+      value: 632.75
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 du grade « professeur d'enseignement technique du 1er cycle » du corps « Corps des personnels d'enseignement exerçant aux établissements d'enseignement secondaire technique et professionnel du ministère de l'éducation »
+  values:
+    '1999-10-08':
+      value: 344.0
+    '2007-04-01':
+      value: 641.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '1999-10-08':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/maitres_principaux_eps/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/maitres_principaux_eps/index.yaml
@@ -1,0 +1,3 @@
+description: Corps des maîtres principaux de l'éducation physique et sportive
+metadata:
+  short_label: Corps des maîtres principaux de l'éducation physique et sportive

--- a/openfisca_tunisia/parameters/fonction_publique/maitres_principaux_eps/maitre_principal_education_physique_sportive/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/maitres_principaux_eps/maitre_principal_education_physique_sportive/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,728 @@
+description: Indemnité spécifique mensuelle du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 0.0
+    '2016-01-26':
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2016-01-26':
+        title: Décret 2016-153
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/maitres_principaux_eps/maitre_principal_education_physique_sportive/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/maitres_principaux_eps/maitre_principal_education_physique_sportive/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+metadata:
+  short_label: Maître principal de l'éducation physique et sportive
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A3

--- a/openfisca_tunisia/parameters/fonction_publique/maitres_principaux_eps/maitre_principal_education_physique_sportive/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/maitres_principaux_eps/maitre_principal_education_physique_sportive/traitement_de_base.yaml
@@ -1,0 +1,378 @@
+description: Traitement de base mensuel du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 146.0
+    '2007-04-01':
+      value: 443.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 154.25
+    '2007-04-01':
+      value: 451.25
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 162.5
+    '2007-04-01':
+      value: 459.5
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 170.75
+    '2007-04-01':
+      value: 467.75
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 179.0
+    '2007-04-01':
+      value: 476.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 187.25
+    '2007-04-01':
+      value: 484.25
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 195.5
+    '2007-04-01':
+      value: 492.5
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 203.75
+    '2007-04-01':
+      value: 500.75
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 212.0
+    '2007-04-01':
+      value: 509.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 220.25
+    '2007-04-01':
+      value: 517.25
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 228.5
+    '2007-04-01':
+      value: 525.5
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 236.75
+    '2007-04-01':
+      value: 533.75
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 245.0
+    '2007-04-01':
+      value: 542.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 253.25
+    '2007-04-01':
+      value: 550.25
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 261.5
+    '2007-04-01':
+      value: 558.5
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 269.75
+    '2007-04-01':
+      value: 566.75
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 278.0
+    '2007-04-01':
+      value: 575.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 286.25
+    '2007-04-01':
+      value: 583.25
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 294.5
+    '2007-04-01':
+      value: 591.5
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 302.75
+    '2007-04-01':
+      value: 599.75
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 311.0
+    '2007-04-01':
+      value: 608.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 319.25
+    '2007-04-01':
+      value: 616.25
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 327.5
+    '2007-04-01':
+      value: 624.5
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 335.75
+    '2007-04-01':
+      value: 632.75
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 du grade « maître principal de l'éducation physique et sportive » du corps « Corps des maîtres principaux de l'éducation physique et sportive »
+  values:
+    '1999-11-05':
+      value: 344.0
+    '2007-04-01':
+      value: 641.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '1999-11-05':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/index.yaml
@@ -1,0 +1,3 @@
+description: Corps du personnel des institutions de formation du ministère de la santé publique
+metadata:
+  short_label: Corps du personnel des institutions de formation du ministère de la santé publique

--- a/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/inspecteur_de_l_enseignement_para_medical/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/inspecteur_de_l_enseignement_para_medical/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,187 @@
+description: Indemnité spécifique mensuelle du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency

--- a/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/inspecteur_de_l_enseignement_para_medical/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/inspecteur_de_l_enseignement_para_medical/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+metadata:
+  short_label: Inspecteur de l'enseignement para-médical
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A1

--- a/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/inspecteur_de_l_enseignement_para_medical/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/inspecteur_de_l_enseignement_para_medical/traitement_de_base.yaml
@@ -1,0 +1,348 @@
+description: Traitement de base mensuel du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 226.0
+    '2007-04-01':
+      value: 634.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 237.5
+    '2007-04-01':
+      value: 645.5
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 249.0
+    '2007-04-01':
+      value: 657.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 260.5
+    '2007-04-01':
+      value: 668.5
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 272.0
+    '2007-04-01':
+      value: 680.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 283.5
+    '2007-04-01':
+      value: 691.5
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 295.0
+    '2007-04-01':
+      value: 703.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 306.5
+    '2007-04-01':
+      value: 714.5
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 318.0
+    '2007-04-01':
+      value: 726.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 329.5
+    '2007-04-01':
+      value: 737.5
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 341.0
+    '2007-04-01':
+      value: 749.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 352.5
+    '2007-04-01':
+      value: 760.5
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 364.0
+    '2007-04-01':
+      value: 772.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 375.5
+    '2007-04-01':
+      value: 783.5
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 387.0
+    '2007-04-01':
+      value: 795.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 398.5
+    '2007-04-01':
+      value: 806.5
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 410.0
+    '2007-04-01':
+      value: 818.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 421.5
+    '2007-04-01':
+      value: 829.5
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 433.0
+    '2007-04-01':
+      value: 841.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 444.5
+    '2007-04-01':
+      value: 852.5
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 456.0
+    '2007-04-01':
+      value: 864.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 467.5
+    '2007-04-01':
+      value: 875.5
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « inspecteur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 479.0
+    '2007-04-01':
+      value: 887.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/professeur_de_l_enseignement_para_medical/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/professeur_de_l_enseignement_para_medical/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,203 @@
+description: Indemnité spécifique mensuelle du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency

--- a/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/professeur_de_l_enseignement_para_medical/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/professeur_de_l_enseignement_para_medical/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+metadata:
+  short_label: Professeur de l'enseignement para-médical
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A2

--- a/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/professeur_de_l_enseignement_para_medical/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/professeur_de_l_enseignement_para_medical/traitement_de_base.yaml
@@ -1,0 +1,378 @@
+description: Traitement de base mensuel du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 181.25
+    '2007-04-01':
+      value: 521.25
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 190.25
+    '2007-04-01':
+      value: 530.25
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 199.25
+    '2007-04-01':
+      value: 539.25
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 208.25
+    '2007-04-01':
+      value: 548.25
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 217.25
+    '2007-04-01':
+      value: 557.25
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 226.25
+    '2007-04-01':
+      value: 566.25
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 235.25
+    '2007-04-01':
+      value: 575.25
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 244.25
+    '2007-04-01':
+      value: 584.25
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 253.25
+    '2007-04-01':
+      value: 593.25
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 262.25
+    '2007-04-01':
+      value: 602.25
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 271.25
+    '2007-04-01':
+      value: 611.25
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 280.25
+    '2007-04-01':
+      value: 620.25
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 289.25
+    '2007-04-01':
+      value: 629.25
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 298.25
+    '2007-04-01':
+      value: 638.25
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 307.25
+    '2007-04-01':
+      value: 647.25
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 316.25
+    '2007-04-01':
+      value: 656.25
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 325.25
+    '2007-04-01':
+      value: 665.25
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 334.25
+    '2007-04-01':
+      value: 674.25
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 343.25
+    '2007-04-01':
+      value: 683.25
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 352.25
+    '2007-04-01':
+      value: 692.25
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 361.25
+    '2007-04-01':
+      value: 701.25
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 370.25
+    '2007-04-01':
+      value: 710.25
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 379.25
+    '2007-04-01':
+      value: 719.25
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 388.25
+    '2007-04-01':
+      value: 728.25
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 du grade « professeur de l'enseignement para-médical » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 397.25
+    '2007-04-01':
+      value: 737.25
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/professeur_de_l_enseignement_para_medical_du_1er_cycle/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/professeur_de_l_enseignement_para_medical_du_1er_cycle/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,203 @@
+description: Indemnité spécifique mensuelle du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency

--- a/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/professeur_de_l_enseignement_para_medical_du_1er_cycle/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/professeur_de_l_enseignement_para_medical_du_1er_cycle/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+metadata:
+  short_label: Professeur de l'enseignement para-médical du 1er cycle
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A3

--- a/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/professeur_de_l_enseignement_para_medical_du_1er_cycle/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/professeur_de_l_enseignement_para_medical_du_1er_cycle/traitement_de_base.yaml
@@ -1,0 +1,378 @@
+description: Traitement de base mensuel du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 146.0
+    '2007-04-01':
+      value: 443.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 154.25
+    '2007-04-01':
+      value: 451.25
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 162.5
+    '2007-04-01':
+      value: 459.5
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 170.75
+    '2007-04-01':
+      value: 467.75
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 179.0
+    '2007-04-01':
+      value: 476.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 187.25
+    '2007-04-01':
+      value: 484.25
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 195.5
+    '2007-04-01':
+      value: 492.5
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 203.75
+    '2007-04-01':
+      value: 500.75
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 212.0
+    '2007-04-01':
+      value: 509.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 220.25
+    '2007-04-01':
+      value: 517.25
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 228.5
+    '2007-04-01':
+      value: 525.5
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 236.75
+    '2007-04-01':
+      value: 533.75
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 245.0
+    '2007-04-01':
+      value: 542.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 253.25
+    '2007-04-01':
+      value: 550.25
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 261.5
+    '2007-04-01':
+      value: 558.5
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 269.75
+    '2007-04-01':
+      value: 566.75
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 278.0
+    '2007-04-01':
+      value: 575.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 286.25
+    '2007-04-01':
+      value: 583.25
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 294.5
+    '2007-04-01':
+      value: 591.5
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 302.75
+    '2007-04-01':
+      value: 599.75
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 311.0
+    '2007-04-01':
+      value: 608.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 319.25
+    '2007-04-01':
+      value: 616.25
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 327.5
+    '2007-04-01':
+      value: 624.5
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 335.75
+    '2007-04-01':
+      value: 632.75
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 du grade « professeur de l'enseignement para-médical du 1er cycle » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 344.0
+    '2007-04-01':
+      value: 641.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/surveillant/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/surveillant/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,203 @@
+description: Indemnité spécifique mensuelle du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency

--- a/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/surveillant/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/surveillant/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+metadata:
+  short_label: Surveillant
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie B

--- a/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/surveillant/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/surveillant/traitement_de_base.yaml
@@ -1,0 +1,378 @@
+description: Traitement de base mensuel du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 128.25
+    '2007-04-01':
+      value: 360.25
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 133.75
+    '2007-04-01':
+      value: 365.75
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 139.25
+    '2007-04-01':
+      value: 371.25
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 144.75
+    '2007-04-01':
+      value: 376.75
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 150.25
+    '2007-04-01':
+      value: 382.25
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 155.75
+    '2007-04-01':
+      value: 387.75
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 161.25
+    '2007-04-01':
+      value: 393.25
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 166.75
+    '2007-04-01':
+      value: 398.75
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 172.25
+    '2007-04-01':
+      value: 404.25
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 177.75
+    '2007-04-01':
+      value: 409.75
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 183.25
+    '2007-04-01':
+      value: 415.25
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 188.75
+    '2007-04-01':
+      value: 420.75
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 194.25
+    '2007-04-01':
+      value: 426.25
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 199.75
+    '2007-04-01':
+      value: 431.75
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 205.25
+    '2007-04-01':
+      value: 437.25
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 210.75
+    '2007-04-01':
+      value: 442.75
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 216.25
+    '2007-04-01':
+      value: 448.25
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 221.75
+    '2007-04-01':
+      value: 453.75
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 227.25
+    '2007-04-01':
+      value: 459.25
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 232.75
+    '2007-04-01':
+      value: 464.75
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 238.25
+    '2007-04-01':
+      value: 470.25
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 243.75
+    '2007-04-01':
+      value: 475.75
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 249.25
+    '2007-04-01':
+      value: 481.25
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 254.75
+    '2007-04-01':
+      value: 486.75
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 du grade « surveillant » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 260.25
+    '2007-04-01':
+      value: 492.25
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/surveillant_general_de_deuxieme_categorie/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/surveillant_general_de_deuxieme_categorie/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,195 @@
+description: Indemnité spécifique mensuelle du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 24
+    unit: currency

--- a/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/surveillant_general_de_deuxieme_categorie/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/surveillant_general_de_deuxieme_categorie/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+metadata:
+  short_label: Surveillant général de deuxième catégorie
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A3

--- a/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/surveillant_general_de_deuxieme_categorie/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/surveillant_general_de_deuxieme_categorie/traitement_de_base.yaml
@@ -1,0 +1,363 @@
+description: Traitement de base mensuel du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 154.25
+    '2007-04-01':
+      value: 451.25
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 162.5
+    '2007-04-01':
+      value: 459.5
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 170.75
+    '2007-04-01':
+      value: 467.75
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 179.0
+    '2007-04-01':
+      value: 476.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 187.25
+    '2007-04-01':
+      value: 484.25
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 195.5
+    '2007-04-01':
+      value: 492.5
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 203.75
+    '2007-04-01':
+      value: 500.75
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 212.0
+    '2007-04-01':
+      value: 509.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 220.25
+    '2007-04-01':
+      value: 517.25
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 228.5
+    '2007-04-01':
+      value: 525.5
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 236.75
+    '2007-04-01':
+      value: 533.75
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 245.0
+    '2007-04-01':
+      value: 542.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 253.25
+    '2007-04-01':
+      value: 550.25
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 261.5
+    '2007-04-01':
+      value: 558.5
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 269.75
+    '2007-04-01':
+      value: 566.75
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 278.0
+    '2007-04-01':
+      value: 575.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 286.25
+    '2007-04-01':
+      value: 583.25
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 294.5
+    '2007-04-01':
+      value: 591.5
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 302.75
+    '2007-04-01':
+      value: 599.75
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 311.0
+    '2007-04-01':
+      value: 608.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 319.25
+    '2007-04-01':
+      value: 616.25
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 327.5
+    '2007-04-01':
+      value: 624.5
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 335.75
+    '2007-04-01':
+      value: 632.75
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 du grade « surveillant général de deuxième catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 344.0
+    '2007-04-01':
+      value: 641.0
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/surveillant_general_de_premiere_categorie/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/surveillant_general_de_premiere_categorie/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,179 @@
+description: Indemnité spécifique mensuelle du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 0.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency

--- a/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/surveillant_general_de_premiere_categorie/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/surveillant_general_de_premiere_categorie/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+metadata:
+  short_label: Surveillant général de première catégorie
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A3

--- a/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/surveillant_general_de_premiere_categorie/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/personnel_institutions_formation_sante/surveillant_general_de_premiere_categorie/traitement_de_base.yaml
@@ -1,0 +1,333 @@
+description: Traitement de base mensuel du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 170.75
+    '2007-04-01':
+      value: 467.75
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 179.0
+    '2007-04-01':
+      value: 476.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 187.25
+    '2007-04-01':
+      value: 484.25
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 195.5
+    '2007-04-01':
+      value: 492.5
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 203.75
+    '2007-04-01':
+      value: 500.75
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 212.0
+    '2007-04-01':
+      value: 509.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 220.25
+    '2007-04-01':
+      value: 517.25
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 228.5
+    '2007-04-01':
+      value: 525.5
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 236.75
+    '2007-04-01':
+      value: 533.75
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 245.0
+    '2007-04-01':
+      value: 542.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 253.25
+    '2007-04-01':
+      value: 550.25
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 261.5
+    '2007-04-01':
+      value: 558.5
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 269.75
+    '2007-04-01':
+      value: 566.75
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 278.0
+    '2007-04-01':
+      value: 575.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 286.25
+    '2007-04-01':
+      value: 583.25
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 294.5
+    '2007-04-01':
+      value: 591.5
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 302.75
+    '2007-04-01':
+      value: 599.75
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 311.0
+    '2007-04-01':
+      value: 608.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 319.25
+    '2007-04-01':
+      value: 616.25
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 327.5
+    '2007-04-01':
+      value: 624.5
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 335.75
+    '2007-04-01':
+      value: 632.75
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « surveillant général de première catégorie » du corps « Corps du personnel des institutions de formation du ministère de la santé publique »
+  values:
+    '1999-10-22':
+      value: 344.0
+    '2007-04-01':
+      value: 641.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 97-1832
+      '2007-04-01':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/pharmaciens_de_la_sante_publique/pharmacien_biologiste_de_la_sante_publique/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/pharmaciens_de_la_sante_publique/pharmacien_biologiste_de_la_sante_publique/indemnite_specifique_mensuelle.yaml
@@ -1,208 +1,578 @@
 description: Indemnité spécifique mensuelle des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 21
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 22
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_23:
   description: Indemnité spécifique mensuelle de l'échelon 23 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 23
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_24:
   description: Indemnité spécifique mensuelle de l'échelon 24 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 24
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_25:
   description: Indemnité spécifique mensuelle de l'échelon 25 des pharmaciens biologistes de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 545.0
+    '2013-01-01':
+      value: 1365.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 25
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)

--- a/openfisca_tunisia/parameters/fonction_publique/pharmaciens_de_la_sante_publique/pharmacien_biologiste_major_de_la_sante_publique/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/pharmaciens_de_la_sante_publique/pharmacien_biologiste_major_de_la_sante_publique/indemnite_specifique_mensuelle.yaml
@@ -1,160 +1,440 @@
 description: Indemnité spécifique mensuelle des pharmaciens biologistes majors de la santes publiques du corps des pharmaciens de la santé publique
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des pharmaciens biologistes majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 875.0
+    '2013-01-01':
+      value: 2046.0
+    '2015-01-01':
+      value: 2686.0
+    '2025-01-01':
+      value: 2986.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des pharmaciens biologistes majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 875.0
+    '2013-01-01':
+      value: 2046.0
+    '2015-01-01':
+      value: 2686.0
+    '2025-01-01':
+      value: 2986.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des pharmaciens biologistes majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 875.0
+    '2013-01-01':
+      value: 2046.0
+    '2015-01-01':
+      value: 2686.0
+    '2025-01-01':
+      value: 2986.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des pharmaciens biologistes majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 875.0
+    '2013-01-01':
+      value: 2046.0
+    '2015-01-01':
+      value: 2686.0
+    '2025-01-01':
+      value: 2986.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des pharmaciens biologistes majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 875.0
+    '2013-01-01':
+      value: 2046.0
+    '2015-01-01':
+      value: 2686.0
+    '2025-01-01':
+      value: 2986.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des pharmaciens biologistes majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 875.0
+    '2013-01-01':
+      value: 2046.0
+    '2015-01-01':
+      value: 2686.0
+    '2025-01-01':
+      value: 2986.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des pharmaciens biologistes majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 875.0
+    '2013-01-01':
+      value: 2046.0
+    '2015-01-01':
+      value: 2686.0
+    '2025-01-01':
+      value: 2986.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des pharmaciens biologistes majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 875.0
+    '2013-01-01':
+      value: 2046.0
+    '2015-01-01':
+      value: 2686.0
+    '2025-01-01':
+      value: 2986.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des pharmaciens biologistes majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 875.0
+    '2013-01-01':
+      value: 2046.0
+    '2015-01-01':
+      value: 2686.0
+    '2025-01-01':
+      value: 2986.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des pharmaciens biologistes majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 875.0
+    '2013-01-01':
+      value: 2046.0
+    '2015-01-01':
+      value: 2686.0
+    '2025-01-01':
+      value: 2986.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des pharmaciens biologistes majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 875.0
+    '2013-01-01':
+      value: 2046.0
+    '2015-01-01':
+      value: 2686.0
+    '2025-01-01':
+      value: 2986.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des pharmaciens biologistes majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 875.0
+    '2013-01-01':
+      value: 2046.0
+    '2015-01-01':
+      value: 2686.0
+    '2025-01-01':
+      value: 2986.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des pharmaciens biologistes majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 875.0
+    '2013-01-01':
+      value: 2046.0
+    '2015-01-01':
+      value: 2686.0
+    '2025-01-01':
+      value: 2986.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des pharmaciens biologistes majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 875.0
+    '2013-01-01':
+      value: 2046.0
+    '2015-01-01':
+      value: 2686.0
+    '2025-01-01':
+      value: 2986.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des pharmaciens biologistes majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 875.0
+    '2013-01-01':
+      value: 2046.0
+    '2015-01-01':
+      value: 2686.0
+    '2025-01-01':
+      value: 2986.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des pharmaciens biologistes majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 875.0
+    '2013-01-01':
+      value: 2046.0
+    '2015-01-01':
+      value: 2686.0
+    '2025-01-01':
+      value: 2986.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des pharmaciens biologistes majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 875.0
+    '2013-01-01':
+      value: 2046.0
+    '2015-01-01':
+      value: 2686.0
+    '2025-01-01':
+      value: 2986.0
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des pharmaciens biologistes majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 875.0
+    '2013-01-01':
+      value: 2046.0
+    '2015-01-01':
+      value: 2686.0
+    '2025-01-01':
+      value: 2986.0
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des pharmaciens biologistes majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 875.0
+    '2013-01-01':
+      value: 2046.0
+    '2015-01-01':
+      value: 2686.0
+    '2025-01-01':
+      value: 2986.0
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)

--- a/openfisca_tunisia/parameters/fonction_publique/pharmaciens_de_la_sante_publique/pharmacien_biologiste_principal_de_la_sante_publique/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/pharmaciens_de_la_sante_publique/pharmacien_biologiste_principal_de_la_sante_publique/indemnite_specifique_mensuelle.yaml
@@ -1,184 +1,509 @@
 description: Indemnité spécifique mensuelle des pharmaciens biologistes principaux de la santes publiques du corps des pharmaciens de la santé publique
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des pharmaciens biologistes principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2158.0
+    '2025-01-01':
+      value: 2458.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des pharmaciens biologistes principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2158.0
+    '2025-01-01':
+      value: 2458.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des pharmaciens biologistes principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2158.0
+    '2025-01-01':
+      value: 2458.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des pharmaciens biologistes principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2158.0
+    '2025-01-01':
+      value: 2458.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des pharmaciens biologistes principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2158.0
+    '2025-01-01':
+      value: 2458.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des pharmaciens biologistes principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2158.0
+    '2025-01-01':
+      value: 2458.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des pharmaciens biologistes principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2158.0
+    '2025-01-01':
+      value: 2458.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des pharmaciens biologistes principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2158.0
+    '2025-01-01':
+      value: 2458.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des pharmaciens biologistes principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2158.0
+    '2025-01-01':
+      value: 2458.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des pharmaciens biologistes principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2158.0
+    '2025-01-01':
+      value: 2458.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des pharmaciens biologistes principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2158.0
+    '2025-01-01':
+      value: 2458.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des pharmaciens biologistes principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2158.0
+    '2025-01-01':
+      value: 2458.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des pharmaciens biologistes principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2158.0
+    '2025-01-01':
+      value: 2458.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des pharmaciens biologistes principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2158.0
+    '2025-01-01':
+      value: 2458.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des pharmaciens biologistes principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2158.0
+    '2025-01-01':
+      value: 2458.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des pharmaciens biologistes principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2158.0
+    '2025-01-01':
+      value: 2458.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des pharmaciens biologistes principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2158.0
+    '2025-01-01':
+      value: 2458.0
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des pharmaciens biologistes principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2158.0
+    '2025-01-01':
+      value: 2458.0
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des pharmaciens biologistes principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2158.0
+    '2025-01-01':
+      value: 2458.0
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des pharmaciens biologistes principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2158.0
+    '2025-01-01':
+      value: 2458.0
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des pharmaciens biologistes principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2158.0
+    '2025-01-01':
+      value: 2458.0
   metadata:
     short_label: Échelon 21
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des pharmaciens biologistes principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2158.0
+    '2025-01-01':
+      value: 2458.0
   metadata:
     short_label: Échelon 22
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)

--- a/openfisca_tunisia/parameters/fonction_publique/pharmaciens_de_la_sante_publique/pharmacien_de_la_sante_publique/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/pharmaciens_de_la_sante_publique/pharmacien_de_la_sante_publique/indemnite_specifique_mensuelle.yaml
@@ -1,208 +1,578 @@
 description: Indemnité spécifique mensuelle des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 21
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 22
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_23:
   description: Indemnité spécifique mensuelle de l'échelon 23 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 23
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_24:
   description: Indemnité spécifique mensuelle de l'échelon 24 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 24
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_25:
   description: Indemnité spécifique mensuelle de l'échelon 25 des pharmaciens de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 385.0
+    '2013-01-01':
+      value: 1097.0
+    '2015-01-01':
+      value: 1467.0
+    '2025-01-01':
+      value: 1767.0
   metadata:
     short_label: Échelon 25
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)

--- a/openfisca_tunisia/parameters/fonction_publique/pharmaciens_de_la_sante_publique/pharmacien_major_de_la_sante_publique/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/pharmaciens_de_la_sante_publique/pharmacien_major_de_la_sante_publique/indemnite_specifique_mensuelle.yaml
@@ -1,168 +1,463 @@
 description: Indemnité spécifique mensuelle des pharmaciens majors de la santes publiques du corps des pharmaciens de la santé publique
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des pharmaciens majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2208.0
+    '2025-01-01':
+      value: 2508.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des pharmaciens majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2208.0
+    '2025-01-01':
+      value: 2508.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des pharmaciens majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2208.0
+    '2025-01-01':
+      value: 2508.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des pharmaciens majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2208.0
+    '2025-01-01':
+      value: 2508.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des pharmaciens majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2208.0
+    '2025-01-01':
+      value: 2508.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des pharmaciens majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2208.0
+    '2025-01-01':
+      value: 2508.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des pharmaciens majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2208.0
+    '2025-01-01':
+      value: 2508.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des pharmaciens majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2208.0
+    '2025-01-01':
+      value: 2508.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des pharmaciens majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2208.0
+    '2025-01-01':
+      value: 2508.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des pharmaciens majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2208.0
+    '2025-01-01':
+      value: 2508.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des pharmaciens majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2208.0
+    '2025-01-01':
+      value: 2508.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des pharmaciens majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2208.0
+    '2025-01-01':
+      value: 2508.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des pharmaciens majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2208.0
+    '2025-01-01':
+      value: 2508.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des pharmaciens majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2208.0
+    '2025-01-01':
+      value: 2508.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des pharmaciens majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2208.0
+    '2025-01-01':
+      value: 2508.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des pharmaciens majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2208.0
+    '2025-01-01':
+      value: 2508.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des pharmaciens majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2208.0
+    '2025-01-01':
+      value: 2508.0
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des pharmaciens majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2208.0
+    '2025-01-01':
+      value: 2508.0
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des pharmaciens majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2208.0
+    '2025-01-01':
+      value: 2508.0
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des pharmaciens majors de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 676.0
+    '2013-01-01':
+      value: 1658.0
+    '2015-01-01':
+      value: 2208.0
+    '2025-01-01':
+      value: 2508.0
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)

--- a/openfisca_tunisia/parameters/fonction_publique/pharmaciens_de_la_sante_publique/pharmacien_principal_de_la_sante_publique/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/pharmaciens_de_la_sante_publique/pharmacien_principal_de_la_sante_publique/indemnite_specifique_mensuelle.yaml
@@ -1,184 +1,509 @@
 description: Indemnité spécifique mensuelle des pharmaciens principaux de la santes publiques du corps des pharmaciens de la santé publique
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des pharmaciens principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 515.0
+    '2013-01-01':
+      value: 1335.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des pharmaciens principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 515.0
+    '2013-01-01':
+      value: 1335.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des pharmaciens principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 515.0
+    '2013-01-01':
+      value: 1335.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des pharmaciens principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 515.0
+    '2013-01-01':
+      value: 1335.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des pharmaciens principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 515.0
+    '2013-01-01':
+      value: 1335.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des pharmaciens principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 515.0
+    '2013-01-01':
+      value: 1335.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des pharmaciens principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 515.0
+    '2013-01-01':
+      value: 1335.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des pharmaciens principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 515.0
+    '2013-01-01':
+      value: 1335.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des pharmaciens principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 515.0
+    '2013-01-01':
+      value: 1335.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des pharmaciens principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 515.0
+    '2013-01-01':
+      value: 1335.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des pharmaciens principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 515.0
+    '2013-01-01':
+      value: 1335.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des pharmaciens principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 515.0
+    '2013-01-01':
+      value: 1335.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des pharmaciens principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 515.0
+    '2013-01-01':
+      value: 1335.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des pharmaciens principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 515.0
+    '2013-01-01':
+      value: 1335.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des pharmaciens principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 515.0
+    '2013-01-01':
+      value: 1335.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des pharmaciens principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 515.0
+    '2013-01-01':
+      value: 1335.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des pharmaciens principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 515.0
+    '2013-01-01':
+      value: 1335.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des pharmaciens principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 515.0
+    '2013-01-01':
+      value: 1335.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des pharmaciens principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 515.0
+    '2013-01-01':
+      value: 1335.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des pharmaciens principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 515.0
+    '2013-01-01':
+      value: 1335.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des pharmaciens principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 515.0
+    '2013-01-01':
+      value: 1335.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 21
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des pharmaciens principaux de la santes publiques du corps des pharmaciens de la santé publique
   values:
     '1999-10-22':
-      value: 0.0
+      value: 515.0
+    '2013-01-01':
+      value: 1335.0
+    '2015-01-01':
+      value: 1775.0
+    '2025-01-01':
+      value: 2075.0
   metadata:
     short_label: Échelon 22
     unit: currency
+    reference:
+      '1999-10-22':
+        title: Décret 91-241 (colonne terminale 1/5/1992)
+      '2013-01-01':
+        title: Décret 91-241 + Σ globaux 1996-2012 (96-1925, 99-2138, 2002-2956, 2005-3200, 2008-4078, 2012-2995 ; cumul à terme — exc. 2009-902 NON ajoutée, déjà fondue dans le global 2008-2010 ; cf. ancre dentiste 2014-45)
+      '2015-01-01':
+        title: Décret 2014-1800 (+ 2014-4560, global 2014-2015 à terme)
+      '2025-01-01':
+        title: Décret 2022-797 (A1 +100x3 = +300, à terme)

--- a/openfisca_tunisia/parameters/fonction_publique/redacteurs_actes_conservation_fonciere/redacteur_actes_cpf/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/redacteurs_actes_conservation_fonciere/redacteur_actes_cpf/indemnite_specifique_mensuelle.yaml
@@ -1,208 +1,778 @@
 description: Indemnité spécifique mensuelle des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 21
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 22
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_23:
   description: Indemnité spécifique mensuelle de l'échelon 23 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 23
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_24:
   description: Indemnité spécifique mensuelle de l'échelon 24 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 24
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_25:
   description: Indemnité spécifique mensuelle de l'échelon 25 des redacteurs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 325.0
+    '2001-01-01':
+      value: 420.0
+    '2004-01-01':
+      value: 512.0
+    '2007-01-01':
+      value: 604.0
+    '2010-12-31':
+      value: 743.0
+    '2013-01-01':
+      value: 813.0
   metadata:
     short_label: Échelon 25
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983

--- a/openfisca_tunisia/parameters/fonction_publique/redacteurs_actes_conservation_fonciere/redacteur_adjoint_actes_cpf/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/redacteurs_actes_conservation_fonciere/redacteur_adjoint_actes_cpf/indemnite_specifique_mensuelle.yaml
@@ -1,208 +1,778 @@
 description: Indemnité spécifique mensuelle des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 21
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 22
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_23:
   description: Indemnité spécifique mensuelle de l'échelon 23 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 23
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_24:
   description: Indemnité spécifique mensuelle de l'échelon 24 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 24
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_25:
   description: Indemnité spécifique mensuelle de l'échelon 25 des redacteurs adjoints actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 276.0
+    '2001-01-01':
+      value: 361.0
+    '2004-01-01':
+      value: 443.5
+    '2007-01-01':
+      value: 526.0
+    '2010-12-31':
+      value: 650.0
+    '2013-01-01':
+      value: 720.0
   metadata:
     short_label: Échelon 25
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983

--- a/openfisca_tunisia/parameters/fonction_publique/redacteurs_actes_conservation_fonciere/redacteur_en_chef_actes_cpf/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/redacteurs_actes_conservation_fonciere/redacteur_en_chef_actes_cpf/indemnite_specifique_mensuelle.yaml
@@ -1,144 +1,530 @@
 description: Indemnité spécifique mensuelle des redacteurs en chefs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des redacteurs en chefs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 365.0
+    '2001-01-01':
+      value: 460.0
+    '2004-01-01':
+      value: 552.0
+    '2007-01-01':
+      value: 644.0
+    '2010-12-31':
+      value: 783.0
+    '2013-01-01':
+      value: 853.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des redacteurs en chefs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 365.0
+    '2001-01-01':
+      value: 460.0
+    '2004-01-01':
+      value: 552.0
+    '2007-01-01':
+      value: 644.0
+    '2010-12-31':
+      value: 783.0
+    '2013-01-01':
+      value: 853.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des redacteurs en chefs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 365.0
+    '2001-01-01':
+      value: 460.0
+    '2004-01-01':
+      value: 552.0
+    '2007-01-01':
+      value: 644.0
+    '2010-12-31':
+      value: 783.0
+    '2013-01-01':
+      value: 853.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des redacteurs en chefs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 365.0
+    '2001-01-01':
+      value: 460.0
+    '2004-01-01':
+      value: 552.0
+    '2007-01-01':
+      value: 644.0
+    '2010-12-31':
+      value: 783.0
+    '2013-01-01':
+      value: 853.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des redacteurs en chefs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 365.0
+    '2001-01-01':
+      value: 460.0
+    '2004-01-01':
+      value: 552.0
+    '2007-01-01':
+      value: 644.0
+    '2010-12-31':
+      value: 783.0
+    '2013-01-01':
+      value: 853.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des redacteurs en chefs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 365.0
+    '2001-01-01':
+      value: 460.0
+    '2004-01-01':
+      value: 552.0
+    '2007-01-01':
+      value: 644.0
+    '2010-12-31':
+      value: 783.0
+    '2013-01-01':
+      value: 853.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des redacteurs en chefs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 365.0
+    '2001-01-01':
+      value: 460.0
+    '2004-01-01':
+      value: 552.0
+    '2007-01-01':
+      value: 644.0
+    '2010-12-31':
+      value: 783.0
+    '2013-01-01':
+      value: 853.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des redacteurs en chefs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 365.0
+    '2001-01-01':
+      value: 460.0
+    '2004-01-01':
+      value: 552.0
+    '2007-01-01':
+      value: 644.0
+    '2010-12-31':
+      value: 783.0
+    '2013-01-01':
+      value: 853.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des redacteurs en chefs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 365.0
+    '2001-01-01':
+      value: 460.0
+    '2004-01-01':
+      value: 552.0
+    '2007-01-01':
+      value: 644.0
+    '2010-12-31':
+      value: 783.0
+    '2013-01-01':
+      value: 853.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des redacteurs en chefs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 365.0
+    '2001-01-01':
+      value: 460.0
+    '2004-01-01':
+      value: 552.0
+    '2007-01-01':
+      value: 644.0
+    '2010-12-31':
+      value: 783.0
+    '2013-01-01':
+      value: 853.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des redacteurs en chefs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 365.0
+    '2001-01-01':
+      value: 460.0
+    '2004-01-01':
+      value: 552.0
+    '2007-01-01':
+      value: 644.0
+    '2010-12-31':
+      value: 783.0
+    '2013-01-01':
+      value: 853.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des redacteurs en chefs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 365.0
+    '2001-01-01':
+      value: 460.0
+    '2004-01-01':
+      value: 552.0
+    '2007-01-01':
+      value: 644.0
+    '2010-12-31':
+      value: 783.0
+    '2013-01-01':
+      value: 853.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des redacteurs en chefs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 365.0
+    '2001-01-01':
+      value: 460.0
+    '2004-01-01':
+      value: 552.0
+    '2007-01-01':
+      value: 644.0
+    '2010-12-31':
+      value: 783.0
+    '2013-01-01':
+      value: 853.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des redacteurs en chefs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 365.0
+    '2001-01-01':
+      value: 460.0
+    '2004-01-01':
+      value: 552.0
+    '2007-01-01':
+      value: 644.0
+    '2010-12-31':
+      value: 783.0
+    '2013-01-01':
+      value: 853.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des redacteurs en chefs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 365.0
+    '2001-01-01':
+      value: 460.0
+    '2004-01-01':
+      value: 552.0
+    '2007-01-01':
+      value: 644.0
+    '2010-12-31':
+      value: 783.0
+    '2013-01-01':
+      value: 853.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des redacteurs en chefs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 365.0
+    '2001-01-01':
+      value: 460.0
+    '2004-01-01':
+      value: 552.0
+    '2007-01-01':
+      value: 644.0
+    '2010-12-31':
+      value: 783.0
+    '2013-01-01':
+      value: 853.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des redacteurs en chefs actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 365.0
+    '2001-01-01':
+      value: 460.0
+    '2004-01-01':
+      value: 552.0
+    '2007-01-01':
+      value: 644.0
+    '2010-12-31':
+      value: 783.0
+    '2013-01-01':
+      value: 853.0
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983

--- a/openfisca_tunisia/parameters/fonction_publique/redacteurs_actes_conservation_fonciere/redacteur_general_actes_cpf/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/redacteurs_actes_conservation_fonciere/redacteur_general_actes_cpf/indemnite_specifique_mensuelle.yaml
@@ -1,136 +1,499 @@
 description: Indemnité spécifique mensuelle des redacteurs généraux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des redacteurs généraux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 385.0
+    '2001-01-01':
+      value: 480.0
+    '2004-01-01':
+      value: 572.0
+    '2007-01-01':
+      value: 664.0
+    '2010-12-31':
+      value: 803.0
+    '2013-01-01':
+      value: 873.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des redacteurs généraux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 385.0
+    '2001-01-01':
+      value: 480.0
+    '2004-01-01':
+      value: 572.0
+    '2007-01-01':
+      value: 664.0
+    '2010-12-31':
+      value: 803.0
+    '2013-01-01':
+      value: 873.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des redacteurs généraux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 385.0
+    '2001-01-01':
+      value: 480.0
+    '2004-01-01':
+      value: 572.0
+    '2007-01-01':
+      value: 664.0
+    '2010-12-31':
+      value: 803.0
+    '2013-01-01':
+      value: 873.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des redacteurs généraux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 385.0
+    '2001-01-01':
+      value: 480.0
+    '2004-01-01':
+      value: 572.0
+    '2007-01-01':
+      value: 664.0
+    '2010-12-31':
+      value: 803.0
+    '2013-01-01':
+      value: 873.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des redacteurs généraux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 385.0
+    '2001-01-01':
+      value: 480.0
+    '2004-01-01':
+      value: 572.0
+    '2007-01-01':
+      value: 664.0
+    '2010-12-31':
+      value: 803.0
+    '2013-01-01':
+      value: 873.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des redacteurs généraux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 385.0
+    '2001-01-01':
+      value: 480.0
+    '2004-01-01':
+      value: 572.0
+    '2007-01-01':
+      value: 664.0
+    '2010-12-31':
+      value: 803.0
+    '2013-01-01':
+      value: 873.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des redacteurs généraux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 385.0
+    '2001-01-01':
+      value: 480.0
+    '2004-01-01':
+      value: 572.0
+    '2007-01-01':
+      value: 664.0
+    '2010-12-31':
+      value: 803.0
+    '2013-01-01':
+      value: 873.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des redacteurs généraux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 385.0
+    '2001-01-01':
+      value: 480.0
+    '2004-01-01':
+      value: 572.0
+    '2007-01-01':
+      value: 664.0
+    '2010-12-31':
+      value: 803.0
+    '2013-01-01':
+      value: 873.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des redacteurs généraux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 385.0
+    '2001-01-01':
+      value: 480.0
+    '2004-01-01':
+      value: 572.0
+    '2007-01-01':
+      value: 664.0
+    '2010-12-31':
+      value: 803.0
+    '2013-01-01':
+      value: 873.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des redacteurs généraux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 385.0
+    '2001-01-01':
+      value: 480.0
+    '2004-01-01':
+      value: 572.0
+    '2007-01-01':
+      value: 664.0
+    '2010-12-31':
+      value: 803.0
+    '2013-01-01':
+      value: 873.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des redacteurs généraux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 385.0
+    '2001-01-01':
+      value: 480.0
+    '2004-01-01':
+      value: 572.0
+    '2007-01-01':
+      value: 664.0
+    '2010-12-31':
+      value: 803.0
+    '2013-01-01':
+      value: 873.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des redacteurs généraux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 385.0
+    '2001-01-01':
+      value: 480.0
+    '2004-01-01':
+      value: 572.0
+    '2007-01-01':
+      value: 664.0
+    '2010-12-31':
+      value: 803.0
+    '2013-01-01':
+      value: 873.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des redacteurs généraux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 385.0
+    '2001-01-01':
+      value: 480.0
+    '2004-01-01':
+      value: 572.0
+    '2007-01-01':
+      value: 664.0
+    '2010-12-31':
+      value: 803.0
+    '2013-01-01':
+      value: 873.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des redacteurs généraux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 385.0
+    '2001-01-01':
+      value: 480.0
+    '2004-01-01':
+      value: 572.0
+    '2007-01-01':
+      value: 664.0
+    '2010-12-31':
+      value: 803.0
+    '2013-01-01':
+      value: 873.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des redacteurs généraux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 385.0
+    '2001-01-01':
+      value: 480.0
+    '2004-01-01':
+      value: 572.0
+    '2007-01-01':
+      value: 664.0
+    '2010-12-31':
+      value: 803.0
+    '2013-01-01':
+      value: 873.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des redacteurs généraux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 385.0
+    '2001-01-01':
+      value: 480.0
+    '2004-01-01':
+      value: 572.0
+    '2007-01-01':
+      value: 664.0
+    '2010-12-31':
+      value: 803.0
+    '2013-01-01':
+      value: 873.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983

--- a/openfisca_tunisia/parameters/fonction_publique/redacteurs_actes_conservation_fonciere/redacteur_principal_actes_cpf/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/redacteurs_actes_conservation_fonciere/redacteur_principal_actes_cpf/indemnite_specifique_mensuelle.yaml
@@ -1,168 +1,623 @@
 description: Indemnité spécifique mensuelle des redacteurs principaux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des redacteurs principaux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 345.0
+    '2001-01-01':
+      value: 440.0
+    '2004-01-01':
+      value: 532.0
+    '2007-01-01':
+      value: 624.0
+    '2010-12-31':
+      value: 763.0
+    '2013-01-01':
+      value: 833.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des redacteurs principaux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 345.0
+    '2001-01-01':
+      value: 440.0
+    '2004-01-01':
+      value: 532.0
+    '2007-01-01':
+      value: 624.0
+    '2010-12-31':
+      value: 763.0
+    '2013-01-01':
+      value: 833.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des redacteurs principaux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 345.0
+    '2001-01-01':
+      value: 440.0
+    '2004-01-01':
+      value: 532.0
+    '2007-01-01':
+      value: 624.0
+    '2010-12-31':
+      value: 763.0
+    '2013-01-01':
+      value: 833.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des redacteurs principaux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 345.0
+    '2001-01-01':
+      value: 440.0
+    '2004-01-01':
+      value: 532.0
+    '2007-01-01':
+      value: 624.0
+    '2010-12-31':
+      value: 763.0
+    '2013-01-01':
+      value: 833.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des redacteurs principaux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 345.0
+    '2001-01-01':
+      value: 440.0
+    '2004-01-01':
+      value: 532.0
+    '2007-01-01':
+      value: 624.0
+    '2010-12-31':
+      value: 763.0
+    '2013-01-01':
+      value: 833.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des redacteurs principaux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 345.0
+    '2001-01-01':
+      value: 440.0
+    '2004-01-01':
+      value: 532.0
+    '2007-01-01':
+      value: 624.0
+    '2010-12-31':
+      value: 763.0
+    '2013-01-01':
+      value: 833.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des redacteurs principaux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 345.0
+    '2001-01-01':
+      value: 440.0
+    '2004-01-01':
+      value: 532.0
+    '2007-01-01':
+      value: 624.0
+    '2010-12-31':
+      value: 763.0
+    '2013-01-01':
+      value: 833.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des redacteurs principaux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 345.0
+    '2001-01-01':
+      value: 440.0
+    '2004-01-01':
+      value: 532.0
+    '2007-01-01':
+      value: 624.0
+    '2010-12-31':
+      value: 763.0
+    '2013-01-01':
+      value: 833.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des redacteurs principaux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 345.0
+    '2001-01-01':
+      value: 440.0
+    '2004-01-01':
+      value: 532.0
+    '2007-01-01':
+      value: 624.0
+    '2010-12-31':
+      value: 763.0
+    '2013-01-01':
+      value: 833.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des redacteurs principaux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 345.0
+    '2001-01-01':
+      value: 440.0
+    '2004-01-01':
+      value: 532.0
+    '2007-01-01':
+      value: 624.0
+    '2010-12-31':
+      value: 763.0
+    '2013-01-01':
+      value: 833.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des redacteurs principaux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 345.0
+    '2001-01-01':
+      value: 440.0
+    '2004-01-01':
+      value: 532.0
+    '2007-01-01':
+      value: 624.0
+    '2010-12-31':
+      value: 763.0
+    '2013-01-01':
+      value: 833.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des redacteurs principaux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 345.0
+    '2001-01-01':
+      value: 440.0
+    '2004-01-01':
+      value: 532.0
+    '2007-01-01':
+      value: 624.0
+    '2010-12-31':
+      value: 763.0
+    '2013-01-01':
+      value: 833.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des redacteurs principaux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 345.0
+    '2001-01-01':
+      value: 440.0
+    '2004-01-01':
+      value: 532.0
+    '2007-01-01':
+      value: 624.0
+    '2010-12-31':
+      value: 763.0
+    '2013-01-01':
+      value: 833.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des redacteurs principaux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 345.0
+    '2001-01-01':
+      value: 440.0
+    '2004-01-01':
+      value: 532.0
+    '2007-01-01':
+      value: 624.0
+    '2010-12-31':
+      value: 763.0
+    '2013-01-01':
+      value: 833.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des redacteurs principaux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 345.0
+    '2001-01-01':
+      value: 440.0
+    '2004-01-01':
+      value: 532.0
+    '2007-01-01':
+      value: 624.0
+    '2010-12-31':
+      value: 763.0
+    '2013-01-01':
+      value: 833.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des redacteurs principaux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 345.0
+    '2001-01-01':
+      value: 440.0
+    '2004-01-01':
+      value: 532.0
+    '2007-01-01':
+      value: 624.0
+    '2010-12-31':
+      value: 763.0
+    '2013-01-01':
+      value: 833.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des redacteurs principaux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 345.0
+    '2001-01-01':
+      value: 440.0
+    '2004-01-01':
+      value: 532.0
+    '2007-01-01':
+      value: 624.0
+    '2010-12-31':
+      value: 763.0
+    '2013-01-01':
+      value: 833.0
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des redacteurs principaux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 345.0
+    '2001-01-01':
+      value: 440.0
+    '2004-01-01':
+      value: 532.0
+    '2007-01-01':
+      value: 624.0
+    '2010-12-31':
+      value: 763.0
+    '2013-01-01':
+      value: 833.0
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des redacteurs principaux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 345.0
+    '2001-01-01':
+      value: 440.0
+    '2004-01-01':
+      value: 532.0
+    '2007-01-01':
+      value: 624.0
+    '2010-12-31':
+      value: 763.0
+    '2013-01-01':
+      value: 833.0
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des redacteurs principaux actes cpfs du corps des rédacteurs d'actes de la conservation de la propriété foncière
   values:
     '2000-01-18':
-      value: 0.0
+      value: 345.0
+    '2001-01-01':
+      value: 440.0
+    '2004-01-01':
+      value: 532.0
+    '2007-01-01':
+      value: 624.0
+    '2010-12-31':
+      value: 763.0
+    '2013-01-01':
+      value: 833.0
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '2000-01-18':
+        title: Décret 97-228
+      '2001-01-01':
+        title: Décret 99-2194
+      '2004-01-01':
+        title: Décret 2002-2951
+      '2007-01-01':
+        title: Décret 2005-3187
+      '2010-12-31':
+        title: Décret 2008-4089
+      '2013-01-01':
+        title: Décret 2012-2983

--- a/openfisca_tunisia/parameters/fonction_publique/surveillance_etablissements_socio_educatifs/surveillant/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillance_etablissements_socio_educatifs/surveillant/indemnite_specifique_mensuelle.yaml
@@ -1,208 +1,728 @@
 description: Indemnité spécifique mensuelle des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 21
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 22
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_23:
   description: Indemnité spécifique mensuelle de l'échelon 23 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 23
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_24:
   description: Indemnité spécifique mensuelle de l'échelon 24 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 24
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_25:
   description: Indemnité spécifique mensuelle de l'échelon 25 des surveillants du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 459.5
+    '2019-04-01':
+      value: 534.5
+    '2020-01-01':
+      value: 614.5
+    '2020-08-01':
+      value: 684.5
+    '2025-01-01':
+      value: 894.5
   metadata:
     short_label: Échelon 25
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/surveillance_etablissements_socio_educatifs/surveillant_general_de_1ere_categorie/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillance_etablissements_socio_educatifs/surveillant_general_de_1ere_categorie/indemnite_specifique_mensuelle.yaml
@@ -1,11 +1,6 @@
 description: Indemnité spécifique mensuelle des surveillants généraux de 1ère categories du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des surveillants généraux de 1ère categories du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:

--- a/openfisca_tunisia/parameters/fonction_publique/surveillance_etablissements_socio_educatifs/surveillant_general_de_2eme_categorie/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillance_etablissements_socio_educatifs/surveillant_general_de_2eme_categorie/indemnite_specifique_mensuelle.yaml
@@ -1,11 +1,6 @@
 description: Indemnité spécifique mensuelle des surveillants généraux de 2ème categories du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des surveillants généraux de 2ème categories du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:

--- a/openfisca_tunisia/parameters/fonction_publique/surveillance_etablissements_socio_educatifs/surveillant_principal/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillance_etablissements_socio_educatifs/surveillant_principal/indemnite_specifique_mensuelle.yaml
@@ -1,208 +1,728 @@
 description: Indemnité spécifique mensuelle des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
 metadata:
   short_label: Indemnité spécifique mensuelle
-documentation: Aucune indemnité spécifique mensuelle n'est définie dans le régime
-  indiciaire de ce corps. Les valeurs 0 sont nominales — il ne s'agit pas de données
-  manquantes. Les indemnités éventuelles pour ce corps relèvent de décrets séparés
-  (indemnités spéciales/de risque/de charges administratives) traités hors pipeline
-  salaire_base/.
 echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 1
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 2
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 3
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 4
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 5
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 6
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 7
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 8
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 9
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 10
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 11
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 12
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 13
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 14
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 15
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 16
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 17
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 18
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 19
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 20
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 21
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 22
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_23:
   description: Indemnité spécifique mensuelle de l'échelon 23 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 23
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_24:
   description: Indemnité spécifique mensuelle de l'échelon 24 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 24
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_25:
   description: Indemnité spécifique mensuelle de l'échelon 25 des surveillants principaux du corps des personnels de surveillance des établissements et institutions socio-éducatives relevant du ministère de la jeunesse, de l'enfance et des sports
   values:
     '2000-05-26':
       value: 0.0
+    '2013-06-25':
+      value: 573.0
+    '2019-04-01':
+      value: 653.0
+    '2020-01-01':
+      value: 743.0
+    '2020-08-01':
+      value: 818.0
+    '2025-01-01':
+      value: 1038.0
   metadata:
     short_label: Échelon 25
     unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2013-2527
+      '2019-04-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_ecoles_preparatoires_lycees/surveillant/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_ecoles_preparatoires_lycees/surveillant/indemnite_specifique_mensuelle.yaml
@@ -5,274 +5,674 @@ echelon_1:
   description: Indemnité spécifique mensuelle de l'échelon 1 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 1
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 2
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 3
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 4
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 5
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 6
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 7
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 8
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 9
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 10
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 11
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 12
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 13
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 14
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 15
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 16
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 17
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 18
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 19
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 20
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 21
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 22
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_23:
   description: Indemnité spécifique mensuelle de l'échelon 23 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 23
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_24:
   description: Indemnité spécifique mensuelle de l'échelon 24 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 24
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_25:
   description: Indemnité spécifique mensuelle de l'échelon 25 des surveillants du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
-      value: 459.0
+      value: 459.5
+    '2019-03-01':
+      value: 539.5
+    '2020-01-01':
+      value: 629.5
+    '2020-08-01':
+      value: 704.5
+    '2025-01-01':
+      value: 924.5
   metadata:
     short_label: Échelon 25
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_ecoles_preparatoires_lycees/surveillant_conseiller/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_ecoles_preparatoires_lycees/surveillant_conseiller/indemnite_specifique_mensuelle.yaml
@@ -6,240 +6,592 @@ echelon_1:
   values:
     '2013-06-25':
       value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
   metadata:
     short_label: Échelon 1
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des surveillants conseillers du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
   metadata:
     short_label: Échelon 2
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des surveillants conseillers du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
   metadata:
     short_label: Échelon 3
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des surveillants conseillers du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
   metadata:
     short_label: Échelon 4
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des surveillants conseillers du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
   metadata:
     short_label: Échelon 5
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des surveillants conseillers du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
   metadata:
     short_label: Échelon 6
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des surveillants conseillers du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
   metadata:
     short_label: Échelon 7
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des surveillants conseillers du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
   metadata:
     short_label: Échelon 8
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des surveillants conseillers du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
   metadata:
     short_label: Échelon 9
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des surveillants conseillers du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
   metadata:
     short_label: Échelon 10
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des surveillants conseillers du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
   metadata:
     short_label: Échelon 11
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des surveillants conseillers du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
   metadata:
     short_label: Échelon 12
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des surveillants conseillers du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
   metadata:
     short_label: Échelon 13
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des surveillants conseillers du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
   metadata:
     short_label: Échelon 14
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des surveillants conseillers du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
   metadata:
     short_label: Échelon 15
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des surveillants conseillers du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
   metadata:
     short_label: Échelon 16
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des surveillants conseillers du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
   metadata:
     short_label: Échelon 17
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des surveillants conseillers du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
   metadata:
     short_label: Échelon 18
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des surveillants conseillers du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
   metadata:
     short_label: Échelon 19
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des surveillants conseillers du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
   metadata:
     short_label: Échelon 20
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des surveillants conseillers du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
   metadata:
     short_label: Échelon 21
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des surveillants conseillers du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
   metadata:
     short_label: Échelon 22
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_ecoles_preparatoires_lycees/surveillant_conseiller_principal/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_ecoles_preparatoires_lycees/surveillant_conseiller_principal/indemnite_specifique_mensuelle.yaml
@@ -6,273 +6,673 @@ echelon_1:
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 1
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 2
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 3
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 4
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 5
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 6
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 7
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 8
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 9
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 10
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 11
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 12
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 13
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 14
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 15
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 16
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 17
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 18
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 19
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 20
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 21
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 22
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_23:
   description: Indemnité spécifique mensuelle de l'échelon 23 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 23
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_24:
   description: Indemnité spécifique mensuelle de l'échelon 24 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 24
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_25:
   description: Indemnité spécifique mensuelle de l'échelon 25 des surveillants conseillers principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
   metadata:
     short_label: Échelon 25
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_ecoles_preparatoires_lycees/surveillant_principal/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_ecoles_preparatoires_lycees/surveillant_principal/indemnite_specifique_mensuelle.yaml
@@ -6,273 +6,673 @@ echelon_1:
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 1
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 2
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 3
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 4
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 5
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 6
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 7
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 8
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 9
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 10
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 11
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 12
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 13
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 14
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 15
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 16
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 17
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 18
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 19
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 20
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_21:
   description: Indemnité spécifique mensuelle de l'échelon 21 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 21
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_22:
   description: Indemnité spécifique mensuelle de l'échelon 22 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 22
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_23:
   description: Indemnité spécifique mensuelle de l'échelon 23 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 23
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_24:
   description: Indemnité spécifique mensuelle de l'échelon 24 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 24
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_25:
   description: Indemnité spécifique mensuelle de l'échelon 25 des surveillants principaux du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 573.0
+    '2019-03-01':
+      value: 663.0
+    '2020-01-01':
+      value: 753.0
+    '2020-08-01':
+      value: 843.0
+    '2025-01-01':
+      value: 1113.0
   metadata:
     short_label: Échelon 25
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_ecoles_preparatoires_lycees/surveillant_principal_hors_classe/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_ecoles_preparatoires_lycees/surveillant_principal_hors_classe/indemnite_specifique_mensuelle.yaml
@@ -6,218 +6,538 @@ echelon_1:
   values:
     '2013-06-25':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 1
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_2:
   description: Indemnité spécifique mensuelle de l'échelon 2 des surveillants principaux hors classes du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 2
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_3:
   description: Indemnité spécifique mensuelle de l'échelon 3 des surveillants principaux hors classes du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 3
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_4:
   description: Indemnité spécifique mensuelle de l'échelon 4 des surveillants principaux hors classes du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 4
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_5:
   description: Indemnité spécifique mensuelle de l'échelon 5 des surveillants principaux hors classes du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 5
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_6:
   description: Indemnité spécifique mensuelle de l'échelon 6 des surveillants principaux hors classes du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 6
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_7:
   description: Indemnité spécifique mensuelle de l'échelon 7 des surveillants principaux hors classes du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 7
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_8:
   description: Indemnité spécifique mensuelle de l'échelon 8 des surveillants principaux hors classes du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 8
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_9:
   description: Indemnité spécifique mensuelle de l'échelon 9 des surveillants principaux hors classes du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 9
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_10:
   description: Indemnité spécifique mensuelle de l'échelon 10 des surveillants principaux hors classes du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 10
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_11:
   description: Indemnité spécifique mensuelle de l'échelon 11 des surveillants principaux hors classes du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 11
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_12:
   description: Indemnité spécifique mensuelle de l'échelon 12 des surveillants principaux hors classes du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 12
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_13:
   description: Indemnité spécifique mensuelle de l'échelon 13 des surveillants principaux hors classes du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 13
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_14:
   description: Indemnité spécifique mensuelle de l'échelon 14 des surveillants principaux hors classes du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 14
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_15:
   description: Indemnité spécifique mensuelle de l'échelon 15 des surveillants principaux hors classes du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 15
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_16:
   description: Indemnité spécifique mensuelle de l'échelon 16 des surveillants principaux hors classes du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 16
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_17:
   description: Indemnité spécifique mensuelle de l'échelon 17 des surveillants principaux hors classes du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 17
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_18:
   description: Indemnité spécifique mensuelle de l'échelon 18 des surveillants principaux hors classes du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 18
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_19:
   description: Indemnité spécifique mensuelle de l'échelon 19 des surveillants principaux hors classes du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 19
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
 echelon_20:
   description: Indemnité spécifique mensuelle de l'échelon 20 des surveillants principaux hors classes du corps des surveillants exerçant dans les écoles préparatoires et les lycées
   values:
     '2013-06-25':
       value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
   metadata:
     short_label: Échelon 20
     unit: currency
     reference:
       '2013-06-25':
         title: Décret 2013-2527
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/index.yaml
@@ -1,0 +1,3 @@
+description: Corps des surveillants généraux relevant du ministère de l'éducation
+metadata:
+  short_label: Corps des surveillants généraux relevant du ministère de l'éducation

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,678 @@
+description: Indemnité spécifique mensuelle du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 623.0
+    '2019-03-01':
+      value: 713.0
+    '2020-01-01':
+      value: 803.0
+    '2020-08-01':
+      value: 893.0
+    '2025-01-01':
+      value: 1163.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Surveillant général
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A2

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general/traitement_de_base.yaml
@@ -1,0 +1,278 @@
+description: Traitement de base mensuel du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 521.25
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 530.25
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 539.25
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 548.25
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 557.25
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 566.25
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 575.25
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 584.25
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 593.25
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 602.25
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 611.25
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 620.25
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 629.25
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 638.25
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 647.25
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 656.25
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 665.25
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 674.25
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 683.25
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 692.25
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 701.25
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 710.25
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 719.25
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 728.25
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 du grade « surveillant général » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 737.25
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,718 @@
+description: Indemnité spécifique mensuelle du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 642.0
+    '2019-03-01':
+      value: 732.0
+    '2020-01-01':
+      value: 822.0
+    '2020-08-01':
+      value: 912.0
+    '2025-01-01':
+      value: 1212.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Surveillant général en chef
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A1

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef/traitement_de_base.yaml
@@ -1,0 +1,318 @@
+description: Traitement de base mensuel du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 668.5
+    '2014-05-06':
+      value: 611.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 680.0
+    '2014-05-06':
+      value: 622.5
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 691.5
+    '2014-05-06':
+      value: 634.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 703.0
+    '2014-05-06':
+      value: 645.5
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 714.5
+    '2014-05-06':
+      value: 657.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 726.0
+    '2014-05-06':
+      value: 668.5
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 737.5
+    '2014-05-06':
+      value: 680.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 749.0
+    '2014-05-06':
+      value: 691.5
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 760.5
+    '2014-05-06':
+      value: 703.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 772.0
+    '2014-05-06':
+      value: 714.5
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 783.5
+    '2014-05-06':
+      value: 726.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 795.0
+    '2014-05-06':
+      value: 737.5
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 806.5
+    '2014-05-06':
+      value: 749.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 818.0
+    '2014-05-06':
+      value: 760.5
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 829.5
+    '2014-05-06':
+      value: 772.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 841.0
+    '2014-05-06':
+      value: 783.5
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 852.5
+    '2014-05-06':
+      value: 795.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 864.0
+    '2014-05-06':
+      value: 806.5
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 875.5
+    '2014-05-06':
+      value: 818.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 887.0
+    '2014-05-06':
+      value: 829.5
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 841.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 852.5
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 864.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 875.5
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 du grade « surveillant général en chef » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 887.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef_emerite/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef_emerite/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,303 @@
+description: Indemnité spécifique mensuelle du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1487.0
+    '2025-01-01':
+      value: 1787.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1487.0
+    '2025-01-01':
+      value: 1787.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1487.0
+    '2025-01-01':
+      value: 1787.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1487.0
+    '2025-01-01':
+      value: 1787.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1487.0
+    '2025-01-01':
+      value: 1787.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1487.0
+    '2025-01-01':
+      value: 1787.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1487.0
+    '2025-01-01':
+      value: 1787.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1487.0
+    '2025-01-01':
+      value: 1787.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1487.0
+    '2025-01-01':
+      value: 1787.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1487.0
+    '2025-01-01':
+      value: 1787.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1487.0
+    '2025-01-01':
+      value: 1787.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1487.0
+    '2025-01-01':
+      value: 1787.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1487.0
+    '2025-01-01':
+      value: 1787.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1487.0
+    '2025-01-01':
+      value: 1787.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1487.0
+    '2025-01-01':
+      value: 1787.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1487.0
+    '2025-01-01':
+      value: 1787.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1487.0
+    '2025-01-01':
+      value: 1787.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1487.0
+    '2025-01-01':
+      value: 1787.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1487.0
+    '2025-01-01':
+      value: 1787.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1487.0
+    '2025-01-01':
+      value: 1787.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef_emerite/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef_emerite/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Surveillant général en chef émérite
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A1

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef_emerite/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef_emerite/traitement_de_base.yaml
@@ -1,0 +1,223 @@
+description: Traitement de base mensuel du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 668.5
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 680.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 691.5
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 703.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 714.5
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 726.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 737.5
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 749.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 760.5
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 772.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 783.5
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 795.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 806.5
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 818.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 829.5
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 841.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 852.5
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 864.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 875.5
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « surveillant général en chef émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 887.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef_hors_classe/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef_hors_classe/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,718 @@
+description: Indemnité spécifique mensuelle du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 0.0
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 717.0
+    '2019-03-01':
+      value: 807.0
+    '2020-01-01':
+      value: 897.0
+    '2020-08-01':
+      value: 987.0
+    '2025-01-01':
+      value: 1287.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef_hors_classe/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef_hors_classe/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Surveillant général en chef hors classe
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A1

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef_hors_classe/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef_hors_classe/traitement_de_base.yaml
@@ -1,0 +1,318 @@
+description: Traitement de base mensuel du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 668.5
+    '2014-05-06':
+      value: 611.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 680.0
+    '2014-05-06':
+      value: 622.5
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 691.5
+    '2014-05-06':
+      value: 634.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 703.0
+    '2014-05-06':
+      value: 645.5
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 714.5
+    '2014-05-06':
+      value: 657.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 726.0
+    '2014-05-06':
+      value: 668.5
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 737.5
+    '2014-05-06':
+      value: 680.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 749.0
+    '2014-05-06':
+      value: 691.5
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 760.5
+    '2014-05-06':
+      value: 703.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 772.0
+    '2014-05-06':
+      value: 714.5
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 783.5
+    '2014-05-06':
+      value: 726.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 795.0
+    '2014-05-06':
+      value: 737.5
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 806.5
+    '2014-05-06':
+      value: 749.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 818.0
+    '2014-05-06':
+      value: 760.5
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 829.5
+    '2014-05-06':
+      value: 772.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 841.0
+    '2014-05-06':
+      value: 783.5
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 852.5
+    '2014-05-06':
+      value: 795.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 864.0
+    '2014-05-06':
+      value: 806.5
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 875.5
+    '2014-05-06':
+      value: 818.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2013-06-25':
+      value: 887.0
+    '2014-05-06':
+      value: 829.5
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2013-06-25':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 841.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 852.5
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 864.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 875.5
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 du grade « surveillant général en chef hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 887.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef_principal/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef_principal/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,543 @@
+description: Indemnité spécifique mensuelle du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 807.0
+    '2019-03-01':
+      value: 897.0
+    '2020-01-01':
+      value: 987.0
+    '2020-08-01':
+      value: 1077.0
+    '2025-01-01':
+      value: 1377.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef_principal/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef_principal/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Surveillant général en chef principal
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A1

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef_principal/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_en_chef_principal/traitement_de_base.yaml
@@ -1,0 +1,223 @@
+description: Traitement de base mensuel du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 668.5
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 680.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 691.5
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 703.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 714.5
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 726.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 737.5
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 749.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 760.5
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 772.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 783.5
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 795.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 806.5
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 818.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 829.5
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 841.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 852.5
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 864.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 875.5
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « surveillant général en chef principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 887.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_principal/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_principal/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,678 @@
+description: Indemnité spécifique mensuelle du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 673.0
+    '2019-03-01':
+      value: 763.0
+    '2020-01-01':
+      value: 853.0
+    '2020-08-01':
+      value: 943.0
+    '2025-01-01':
+      value: 1213.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_principal/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_principal/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Surveillant général principal
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A2

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_principal/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_principal/traitement_de_base.yaml
@@ -1,0 +1,278 @@
+description: Traitement de base mensuel du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 521.25
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 530.25
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 539.25
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 548.25
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 557.25
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 566.25
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 575.25
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 584.25
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 593.25
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 602.25
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 611.25
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 620.25
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 629.25
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 638.25
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 647.25
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 656.25
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 665.25
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 674.25
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 683.25
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 692.25
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 701.25
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 710.25
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 719.25
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 728.25
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 du grade « surveillant général principal » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 737.25
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_principal_emerite/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_principal_emerite/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,378 @@
+description: Indemnité spécifique mensuelle du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 1273.0
+    '2025-01-01':
+      value: 1543.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2021-492
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_principal_emerite/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_principal_emerite/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Surveillant général principal émérite
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A2

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_principal_emerite/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_principal_emerite/traitement_de_base.yaml
@@ -1,0 +1,278 @@
+description: Traitement de base mensuel du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 521.25
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 530.25
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 539.25
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 548.25
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 557.25
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 566.25
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 575.25
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 584.25
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 593.25
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 602.25
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 611.25
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 620.25
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 629.25
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 638.25
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 647.25
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 656.25
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 665.25
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 674.25
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 683.25
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 692.25
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 701.25
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 710.25
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 719.25
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 728.25
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 du grade « surveillant général principal émérite » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2021-07-06':
+      value: 737.25
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2021-07-06':
+        title: Décret 2007-268

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_principal_hors_classe/indemnite_specifique_mensuelle.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_principal_hors_classe/indemnite_specifique_mensuelle.yaml
@@ -1,0 +1,678 @@
+description: Indemnité spécifique mensuelle du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Indemnité spécifique mensuelle
+echelon_1:
+  description: Indemnité spécifique mensuelle de l'échelon 1 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_2:
+  description: Indemnité spécifique mensuelle de l'échelon 2 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_3:
+  description: Indemnité spécifique mensuelle de l'échelon 3 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_4:
+  description: Indemnité spécifique mensuelle de l'échelon 4 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_5:
+  description: Indemnité spécifique mensuelle de l'échelon 5 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_6:
+  description: Indemnité spécifique mensuelle de l'échelon 6 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_7:
+  description: Indemnité spécifique mensuelle de l'échelon 7 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_8:
+  description: Indemnité spécifique mensuelle de l'échelon 8 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_9:
+  description: Indemnité spécifique mensuelle de l'échelon 9 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_10:
+  description: Indemnité spécifique mensuelle de l'échelon 10 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_11:
+  description: Indemnité spécifique mensuelle de l'échelon 11 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_12:
+  description: Indemnité spécifique mensuelle de l'échelon 12 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_13:
+  description: Indemnité spécifique mensuelle de l'échelon 13 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_14:
+  description: Indemnité spécifique mensuelle de l'échelon 14 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_15:
+  description: Indemnité spécifique mensuelle de l'échelon 15 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_16:
+  description: Indemnité spécifique mensuelle de l'échelon 16 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_17:
+  description: Indemnité spécifique mensuelle de l'échelon 17 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_18:
+  description: Indemnité spécifique mensuelle de l'échelon 18 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_19:
+  description: Indemnité spécifique mensuelle de l'échelon 19 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_20:
+  description: Indemnité spécifique mensuelle de l'échelon 20 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_21:
+  description: Indemnité spécifique mensuelle de l'échelon 21 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_22:
+  description: Indemnité spécifique mensuelle de l'échelon 22 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_23:
+  description: Indemnité spécifique mensuelle de l'échelon 23 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_24:
+  description: Indemnité spécifique mensuelle de l'échelon 24 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797
+echelon_25:
+  description: Indemnité spécifique mensuelle de l'échelon 25 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 693.0
+    '2019-03-01':
+      value: 783.0
+    '2020-01-01':
+      value: 873.0
+    '2020-08-01':
+      value: 963.0
+    '2025-01-01':
+      value: 1233.0
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2014-1463
+      '2019-03-01':
+        title: Décret 2019-209
+      '2020-01-01':
+        title: Décret 2019-1133
+      '2020-08-01':
+        title: Décret 2020-767
+      '2025-01-01':
+        title: Décret 2022-797

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_principal_hors_classe/index.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_principal_hors_classe/index.yaml
@@ -1,0 +1,7 @@
+description: Grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Surveillant général principal hors classe
+  order:
+    - indemnite_specifique_mensuelle
+    - traitement_de_base
+documentation: Grille de catégorie A2

--- a/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_principal_hors_classe/traitement_de_base.yaml
+++ b/openfisca_tunisia/parameters/fonction_publique/surveillants_generaux_education/surveillant_general_principal_hors_classe/traitement_de_base.yaml
@@ -1,0 +1,278 @@
+description: Traitement de base mensuel du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+metadata:
+  short_label: Traitement de base mensuel
+echelon_1:
+  description: Traitement de base mensuel de l'échelon 1 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 521.25
+  metadata:
+    short_label: Échelon 1
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_2:
+  description: Traitement de base mensuel de l'échelon 2 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 530.25
+  metadata:
+    short_label: Échelon 2
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_3:
+  description: Traitement de base mensuel de l'échelon 3 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 539.25
+  metadata:
+    short_label: Échelon 3
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_4:
+  description: Traitement de base mensuel de l'échelon 4 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 548.25
+  metadata:
+    short_label: Échelon 4
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_5:
+  description: Traitement de base mensuel de l'échelon 5 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 557.25
+  metadata:
+    short_label: Échelon 5
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_6:
+  description: Traitement de base mensuel de l'échelon 6 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 566.25
+  metadata:
+    short_label: Échelon 6
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_7:
+  description: Traitement de base mensuel de l'échelon 7 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 575.25
+  metadata:
+    short_label: Échelon 7
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_8:
+  description: Traitement de base mensuel de l'échelon 8 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 584.25
+  metadata:
+    short_label: Échelon 8
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_9:
+  description: Traitement de base mensuel de l'échelon 9 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 593.25
+  metadata:
+    short_label: Échelon 9
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_10:
+  description: Traitement de base mensuel de l'échelon 10 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 602.25
+  metadata:
+    short_label: Échelon 10
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_11:
+  description: Traitement de base mensuel de l'échelon 11 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 611.25
+  metadata:
+    short_label: Échelon 11
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_12:
+  description: Traitement de base mensuel de l'échelon 12 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 620.25
+  metadata:
+    short_label: Échelon 12
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_13:
+  description: Traitement de base mensuel de l'échelon 13 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 629.25
+  metadata:
+    short_label: Échelon 13
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_14:
+  description: Traitement de base mensuel de l'échelon 14 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 638.25
+  metadata:
+    short_label: Échelon 14
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_15:
+  description: Traitement de base mensuel de l'échelon 15 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 647.25
+  metadata:
+    short_label: Échelon 15
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_16:
+  description: Traitement de base mensuel de l'échelon 16 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 656.25
+  metadata:
+    short_label: Échelon 16
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_17:
+  description: Traitement de base mensuel de l'échelon 17 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 665.25
+  metadata:
+    short_label: Échelon 17
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_18:
+  description: Traitement de base mensuel de l'échelon 18 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 674.25
+  metadata:
+    short_label: Échelon 18
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_19:
+  description: Traitement de base mensuel de l'échelon 19 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 683.25
+  metadata:
+    short_label: Échelon 19
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_20:
+  description: Traitement de base mensuel de l'échelon 20 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 692.25
+  metadata:
+    short_label: Échelon 20
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_21:
+  description: Traitement de base mensuel de l'échelon 21 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 701.25
+  metadata:
+    short_label: Échelon 21
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_22:
+  description: Traitement de base mensuel de l'échelon 22 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 710.25
+  metadata:
+    short_label: Échelon 22
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_23:
+  description: Traitement de base mensuel de l'échelon 23 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 719.25
+  metadata:
+    short_label: Échelon 23
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_24:
+  description: Traitement de base mensuel de l'échelon 24 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 728.25
+  metadata:
+    short_label: Échelon 24
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268
+echelon_25:
+  description: Traitement de base mensuel de l'échelon 25 du grade « surveillant général principal hors classe » du corps « Corps des surveillants généraux relevant du ministère de l'éducation »
+  values:
+    '2014-05-06':
+      value: 737.25
+  metadata:
+    short_label: Échelon 25
+    unit: currency
+    reference:
+      '2014-05-06':
+        title: Décret 2007-268

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-Tunisia"
-version = "0.66"
+version = "0.67"
 description = "OpenFisca Rules as Code model for Tunisia."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "tunisia"]


### PR DESCRIPTION
## Résumé

Injection des nouveautés de la campagne 2026-06 du dépôt `tunisia-legislative-references` dans `parameters/fonction_publique/`, via un **patch chirurgical format-preserving** (ruamel round-trip) : seuls les `values`/`reference` des nœuds changés et les corps/grades nouveaux sont écrits. Les champs curés à la main dans `master` (`description`, `short_label`, `order`, `documentation`) sont **préservés**. **Aucun dossier supprimé.**

## Contenu

- **10 corps** passent indemnité spécifique **0 → chiffrée** (régimes reconstruits en source primaire JORT). La note « valeurs 0 nominales » est retirée des 7 corps concernés :
  `agents_affaires_culturelles`, `agents_bibliotheques_documentation`, `agents_de_conciliation`, `corps_administratif_commun`, `pharmaciens_de_la_sante_publique`, `redacteurs_actes_conservation_fonciere`, `surveillance_etablissements_socio_educatifs` (+ `conseillers_educatifs`, `enseignants_lycees`, `surveillants_ecoles_preparatoires_lycees`).
- **`enseignants_lycees`** : 4 grades ré-encodés 16/20 → 25 échelons (concordance identité 2015-1165) → `traitement_de_base` mis à jour, échelons 17-25 ajoutés ; 2 grades classe exceptionnelle créés (2015-1163).
- **5 corps nouveaux** générés au format master (libellés repris des `intitule_fr` curés) :
  `cadres_techniques_administration`, `enseignement_secondaire_technique_professionnel`, `maitres_principaux_eps`, `personnel_institutions_formation_sante`, `surveillants_generaux_education`.

## Validation

`CountryTaxBenefitSystem()` charge l'arbre complet :
- `agents_affaires_culturelles` ISM éch.1 @2025 = **1705** / @2021 = **0**
- `enseignants_lycees` ré-encodés : sommet éch.25 TB = **887** préservé
- `surveillants_generaux_education` (nouveau) ISM éch.1 @2025 = **1163**

## Note

Aucune variable OpenFisca ne lit encore `indemnite_specifique_mensuelle` : les paramètres sont corrects mais inertes tant qu'aucune formule ne les agrège dans le salaire brut FP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)