### PR TITLE
fix(irpp): rétablit la tranche supérieure du barème 1990-2016

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.69 - [#PRNUM](https://github.com/openfisca/openfisca-tunisia/pull/PRNUM)
+## 0.69 - [#381](https://github.com/openfisca/openfisca-tunisia/pull/381)
 
 * Ajout de paramètres.
 * Périodes concernées : jusqu'au 31/12/1989.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.68 - [#PRNUM](https://github.com/openfisca/openfisca-tunisia/pull/PRNUM)
+
+* Correction d'un bug.
+* Périodes concernées : jusqu'au 31/12/2016.
+* Zones impactées : `parameters/impot_revenu/bareme`, `parameters/impot_revenu/exoneration`.
+* Détails :
+  - Corrige le barème de l'IRPP applicable aux revenus de 1990 à 2016 : la tranche supérieure était absente. Le barème encodé s'arrêtait à « au-delà de 20 000 D : 30 % », alors que l'article 44 § I du code de l'IRPP et de l'IS institue une tranche de 20 000,001 à 50 000 D à 30 % puis une tranche à 35 % au-delà de 50 000 D. Les revenus nets imposables supérieurs à 50 000 D étaient sous-imposés.
+  - Ajoute les références JORT (avec URL pist.tn) des trois millésimes du barème : code annexé à la loi n° 89-114 (JORT n° 1 du 2-5 janvier 1990, p. 9), article 14-1 de la loi n° 2016-78 (JORT n° 105 du 27 décembre 2016, p. 3831) et article 36 de la loi n° 2024-48 (JORT n° 149 du 10 décembre 2024, p. 6429).
+  - Documente le seuil d'exonération de 2014 : il s'agit d'une exonération catégorielle des salariés et pensionnés, abrogée à compter des revenus de 2017, et non de l'ancêtre de la tranche à 0 % du barème.
+
+<!-- -->
+
 ## 0.67 - [#369](https://github.com/openfisca/openfisca-tunisia/pull/369)
 
 * Ajout de paramètres.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.68 - [#PRNUM](https://github.com/openfisca/openfisca-tunisia/pull/PRNUM)
+## 0.68 - [#380](https://github.com/openfisca/openfisca-tunisia/pull/380)
 
 * Correction d'un bug.
 * Périodes concernées : jusqu'au 31/12/2016.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.69 - [#PRNUM](https://github.com/openfisca/openfisca-tunisia/pull/PRNUM)
+
+* Ajout de paramètres.
+* Périodes concernées : jusqu'au 31/12/1989.
+* Zones impactées : `parameters/impot_revenu/contribution_personnelle_etat`.
+* Détails :
+  - Ajoute le tarif de la contribution personnelle d'État, impôt progressif sur le revenu global institué par le décret du 31 mars 1932 et supprimé pour les revenus réalisés à compter du 1er janvier 1990. Trois rédactions successives de l'article 8 : revenus 1980 (11 tranches, 80 % au-delà de 8 500 D), revenus 1983 (20 tranches, 80 % au-delà de 100 000 D) et revenus 1986 (18 tranches, 68 % au-delà de 80 000 D), avec leurs références JORT.
+  - Ajoute le plafond de cotisation effective (55 % du revenu global imposable pour les revenus 1980, 60 % à partir des revenus 1983), qui n'a pas d'équivalent dans l'IRPP.
+  - Aucune variable ne consomme ces paramètres : le modèle ne calcule pas l'avant-1990. Ils servent de référence datée et sourcée. Des tests vérifient que la colonne des taux d'imposition à la limite supérieure, imprimée dans les textes de loi, se déduit du tarif encodé.
+
+<!-- -->
+
 ## 0.68 - [#380](https://github.com/openfisca/openfisca-tunisia/pull/380)
 
 * Correction d'un bug.

--- a/openfisca_tunisia/parameters/impot_revenu/bareme.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/bareme.yaml
@@ -61,9 +61,17 @@ brackets:
     2025-01-01:
       value: 0.33
 - threshold:
+    1990-01-01:
+      value: 50000
+    2017-01-01:
+      value: null
     2025-01-01:
       value: 40000
   rate:
+    1990-01-01:
+      value: 0.35
+    2017-01-01:
+      value: null
     2025-01-01:
       value: 0.36
 - threshold:
@@ -81,11 +89,18 @@ brackets:
 metadata:
   label_en: Tax scale
   reference:
+    1990-01-01:
+      title: Article 44 § I du code de l'IRPP et de l'IS, annexé à la loi n° 89-114 du 30 décembre 1989, JORT n° 1 du 2-5 janvier 1990, p. 3-21 (article 44 p. 9)
+      href: https://www.pist.tn/jort/1990/1990F/Jo00190.pdf
     2017-01-01:
-      href: http://doc-fiscale.finances.gov.tn/cimf-internet/page/document/fr/preview?path=/Loi%20de%20Finances/2017/Loi%20de%20finances%202017.pdf#page=4
+      title: Article 14-1 de la loi n° 2016-78 du 17 décembre 2016 portant loi de finances pour l'année 2017, JORT n° 105 du 27 décembre 2016, p. 3831
+      href: https://www.pist.tn/jort/2016/2016F/Jo10516.pdf
     2025-01-01:
-      title: Article 36 de la loi n° 2024-48 du 9 décembre 2024 portant loi de finances pour l'année 2025, JORT n° 149/2024, p. 6429
+      title: Article 36 de la loi n° 2024-48 du 9 décembre 2024 portant loi de finances pour l'année 2025, JORT n° 149 du 10 décembre 2024, p. 6429
+      href: https://www.pist.tn/jort/2024/2024A/Ja1492024.pdf
   official_journal_date:
+    1990-01-01: "1990-01-02"
+    2017-01-01: "2016-12-27"
     2025-01-01: "2024-12-10"
   rate_unit: /1
   threshold_unit: currency

--- a/openfisca_tunisia/parameters/impot_revenu/contribution_personnelle_etat/bareme.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/contribution_personnelle_etat/bareme.yaml
@@ -1,0 +1,283 @@
+description: Tarif de la contribution personnelle d'État
+brackets:
+- threshold:
+    1980-01-01:
+      value: 0
+    1983-01-01:
+      value: 0
+    1986-01-01:
+      value: 0
+  rate:
+    1980-01-01:
+      value: 0.0
+    1983-01-01:
+      value: 0.0
+    1986-01-01:
+      value: 0.0
+- threshold:
+    1980-01-01:
+      value: 500
+    1983-01-01:
+      value: 900
+    1986-01-01:
+      value: 900
+  rate:
+    1980-01-01:
+      value: 0.08
+    1983-01-01:
+      value: 0.05
+    1986-01-01:
+      value: 0.05
+- threshold:
+    1980-01-01:
+      value: 1000
+    1983-01-01:
+      value: 1300
+    1986-01-01:
+      value: 1300
+  rate:
+    1980-01-01:
+      value: 0.15
+    1983-01-01:
+      value: 0.1
+    1986-01-01:
+      value: 0.1
+- threshold:
+    1980-01-01:
+      value: 1500
+    1983-01-01:
+      value: 1500
+    1986-01-01:
+      value: 1500
+  rate:
+    1980-01-01:
+      value: 0.2
+    1983-01-01:
+      value: 0.15
+    1986-01-01:
+      value: 0.15
+- threshold:
+    1980-01-01:
+      value: 2000
+    1983-01-01:
+      value: 2000
+    1986-01-01:
+      value: 2000
+  rate:
+    1980-01-01:
+      value: 0.25
+    1983-01-01:
+      value: 0.2
+    1986-01-01:
+      value: 0.2
+- threshold:
+    1980-01-01:
+      value: 2500
+    1983-01-01:
+      value: 2500
+    1986-01-01:
+      value: 2500
+  rate:
+    1980-01-01:
+      value: 0.3
+    1983-01-01:
+      value: 0.25
+    1986-01-01:
+      value: 0.25
+- threshold:
+    1980-01-01:
+      value: 3000
+    1983-01-01:
+      value: 3000
+    1986-01-01:
+      value: 3000
+  rate:
+    1980-01-01:
+      value: 0.4
+    1983-01-01:
+      value: 0.3
+    1986-01-01:
+      value: 0.3
+- threshold:
+    1980-01-01:
+      value: 4000
+    1983-01-01:
+      value: 3500
+    1986-01-01:
+      value: 3500
+  rate:
+    1980-01-01:
+      value: 0.5
+    1983-01-01:
+      value: 0.36
+    1986-01-01:
+      value: 0.36
+- threshold:
+    1980-01-01:
+      value: 5500
+    1983-01-01:
+      value: 4000
+    1986-01-01:
+      value: 4000
+  rate:
+    1980-01-01:
+      value: 0.6
+    1983-01-01:
+      value: 0.42
+    1986-01-01:
+      value: 0.42
+- threshold:
+    1980-01-01:
+      value: 7000
+    1983-01-01:
+      value: 5000
+    1986-01-01:
+      value: 5000
+  rate:
+    1980-01-01:
+      value: 0.7
+    1983-01-01:
+      value: 0.48
+    1986-01-01:
+      value: 0.48
+- threshold:
+    1980-01-01:
+      value: 8500
+    1983-01-01:
+      value: 6000
+    1986-01-01:
+      value: 6000
+  rate:
+    1980-01-01:
+      value: 0.8
+    1983-01-01:
+      value: 0.54
+    1986-01-01:
+      value: 0.54
+- threshold:
+    1983-01-01:
+      value: 8000
+    1986-01-01:
+      value: 8000
+  rate:
+    1983-01-01:
+      value: 0.56
+    1986-01-01:
+      value: 0.56
+- threshold:
+    1983-01-01:
+      value: 10000
+    1986-01-01:
+      value: 10000
+  rate:
+    1983-01-01:
+      value: 0.58
+    1986-01-01:
+      value: 0.58
+- threshold:
+    1983-01-01:
+      value: 14000
+    1986-01-01:
+      value: 14000
+  rate:
+    1983-01-01:
+      value: 0.6
+    1986-01-01:
+      value: 0.6
+- threshold:
+    1983-01-01:
+      value: 25000
+    1986-01-01:
+      value: 25000
+  rate:
+    1983-01-01:
+      value: 0.62
+    1986-01-01:
+      value: 0.62
+- threshold:
+    1983-01-01:
+      value: 50000
+    1986-01-01:
+      value: 40000
+  rate:
+    1983-01-01:
+      value: 0.64
+    1986-01-01:
+      value: 0.64
+- threshold:
+    1983-01-01:
+      value: 65000
+    1986-01-01:
+      value: 60000
+  rate:
+    1983-01-01:
+      value: 0.66
+    1986-01-01:
+      value: 0.66
+- threshold:
+    1983-01-01:
+      value: 80000
+    1986-01-01:
+      value: 80000
+  rate:
+    1983-01-01:
+      value: 0.7
+    1986-01-01:
+      value: 0.68
+- threshold:
+    1983-01-01:
+      value: 90000
+    1986-01-01:
+      value: null
+  rate:
+    1983-01-01:
+      value: 0.76
+    1986-01-01:
+      value: null
+- threshold:
+    1983-01-01:
+      value: 100000
+    1986-01-01:
+      value: null
+  rate:
+    1983-01-01:
+      value: 0.8
+    1986-01-01:
+      value: null
+metadata:
+  label_en: Personal state contribution tax scale
+  rate_unit: /1
+  threshold_unit: currency
+  reference:
+    1980-01-01:
+      title: Article 8 de la loi n° 79-66 du 31 décembre 1979 portant loi de finances pour la gestion 1980, JORT n° 76 des 28-31 décembre 1979, p. 3540
+      href: https://www.pist.tn/jort/1979/1979F/Jo07679.pdf
+    1983-01-01:
+      title: Article 9 de la loi n° 82-91 du 31 décembre 1982 portant loi de finances pour la gestion 1983, JORT n° 84 du 31 décembre 1982, p. 2877
+      href: https://www.pist.tn/jort/1982/1982F/Jo08482.pdf
+    1986-01-01:
+      title: Article 8 de la loi n° 85-109 du 31 décembre 1985 portant loi de finances pour la gestion 1986, JORT n° 91 du 31 décembre 1985, p. 1731
+      href: https://www.pist.tn/jort/1985/1985F/Jo09185.pdf
+  official_journal_date:
+    1980-01-01: "1979-12-31"
+    1983-01-01: "1982-12-31"
+    1986-01-01: "1985-12-31"
+documentation: |
+  Tarif de l'article 8 du décret du 31 mars 1932 instituant la contribution personnelle
+  d'État, dans ses rédactions successives. Chaque loi de finances citée en référence
+  abroge et remplace cet article 8.
+
+  Les dates sont des ANNÉES DE REVENUS : les lois de finances disposent que leurs
+  dispositions s'appliquent aux revenus réalisés à compter du 1er janvier de l'année
+  suivant leur publication.
+
+  La contribution personnelle d'État est SUPPRIMÉE pour les revenus réalisés à compter
+  du 1er janvier 1990 par l'article 2 de la loi n° 89-114 du 30 décembre 1989, qui lui
+  substitue l'impôt sur le revenu des personnes physiques. Ce tarif n'est donc pas
+  clôturé au-delà de 1989 par une valeur nulle mais ne doit jamais être lu après 1989 :
+  ce n'est pas un état antérieur du barème de l'IRPP, c'est un autre impôt, avec une
+  autre assiette et un plafonnement de cotisation propre.
+
+  Aucune variable du modèle ne consomme ces paramètres : openfisca-tunisia ne calcule
+  pas l'avant-1990. Ils servent de référence datée et sourcée, notamment aux tableaux
+  du précis socio-fiscal.

--- a/openfisca_tunisia/parameters/impot_revenu/contribution_personnelle_etat/index.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/contribution_personnelle_etat/index.yaml
@@ -1,0 +1,5 @@
+description: Contribution personnelle d'État (impôt progressif sur le revenu global, supprimé pour les revenus réalisés à compter du 1er janvier 1990)
+metadata:
+  order:
+  - bareme
+  - plafond_cotisation

--- a/openfisca_tunisia/parameters/impot_revenu/contribution_personnelle_etat/plafond_cotisation.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/contribution_personnelle_etat/plafond_cotisation.yaml
@@ -1,0 +1,24 @@
+description: Plafond de la cotisation effective, en part du revenu global imposable
+values:
+  1980-01-01:
+    value: 0.55
+  1983-01-01:
+    value: 0.60
+metadata:
+  unit: /1
+  reference:
+    1980-01-01:
+      title: Article 8 (nouveau) § II, loi n° 79-66 du 31 décembre 1979, JORT n° 76 des 28-31 décembre 1979, p. 3540
+      href: https://www.pist.tn/jort/1979/1979F/Jo07679.pdf
+    1983-01-01:
+      title: Article 8 (nouveau) § II, loi n° 82-91 du 31 décembre 1982, JORT n° 84 du 31 décembre 1982, p. 2877
+      href: https://www.pist.tn/jort/1982/1982F/Jo08482.pdf
+documentation: |
+  « La cotisation effective de la contribution personnelle d'État calculée conformément aux
+  dispositions du paragraphe III ci-après ne peut excéder X % du revenu global imposable. »
+
+  Ce plafonnement n'a pas d'équivalent dans le barème de l'IRPP institué en 1990. Il explique
+  que la dernière ligne du barème publié au JORT de 1979 porte, dans la colonne des taux
+  d'imposition à la limite supérieure, la valeur du plafond (55 %) et non un taux calculé.
+
+  Le plafond est maintenu à 60 % par l'article 8 de la loi n° 85-109 (loi de finances 1986).

--- a/openfisca_tunisia/parameters/impot_revenu/exoneration/seuil.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/exoneration/seuil.yaml
@@ -1,6 +1,26 @@
-description: Seuil de revenu imposable net pour être exonéré
+description: Seuil de revenu net imposable pour l'exonération catégorielle des salariés et pensionnés
 values:
   2014-01-01:
     value: 5000
 metadata:
   unit: currency
+  reference:
+    2014-01-01:
+      title: Article 73-1 de la loi n° 2013-54 du 30 décembre 2013 portant loi de finances pour l'année 2014, JORT n° 105 du 31 décembre 2013, p. 3691
+  official_journal_date:
+    2014-01-01: "2013-12-31"
+documentation: |
+  Exonération catégorielle des salariés et pensionnés dont le revenu net imposable
+  n'excède pas 5 000 dinars, instituée par l'article 73-1 de la loi de finances pour 2014.
+
+  ATTENTION — ce paramètre est juridiquement ABROGÉ à compter des revenus de 2017 par
+  l'article 14-5 de la loi n° 2016-78 (loi de finances pour 2017), qui lui substitue la
+  tranche à 0 % du barème jusqu'à 5 000 dinars. La variable `exoneration` respecte cette
+  borne (`end = "2016-12-31"`).
+
+  Il n'est pas clôturé ici (pas de `value: null` en 2017) parce que les formules de la
+  contribution sociale de solidarité (`contribution_sociale_solidarite`, formules 2018 et
+  2020) le lisent encore pour des années postérieures à l'abrogation. Elles devraient
+  vraisemblablement s'appuyer sur le seuil de la première tranche imposée du barème plutôt
+  que sur ce paramètre. Clôturer ce paramètre sans corriger d'abord ces formules provoque
+  une ParameterNotFoundError. Voir la discussion dans la PR qui a introduit cette note.

--- a/openfisca_tunisia/parameters/impot_revenu/index.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/index.yaml
@@ -2,6 +2,7 @@ description: Impôt sur le revenu
 metadata:
   order:
   - bareme
+  - contribution_personnelle_etat
   - contribution_budget_etat
   - deductions
   - exoneration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-Tunisia"
-version = "0.67"
+version = "0.68"
 description = "OpenFisca Rules as Code model for Tunisia."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "tunisia"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-Tunisia"
-version = "0.68"
+version = "0.69"
 description = "OpenFisca Rules as Code model for Tunisia."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "tunisia"]

--- a/tests/formulas/impot_revenu/irpp.yaml
+++ b/tests/formulas/impot_revenu/irpp.yaml
@@ -110,3 +110,19 @@
     revenu_assimile_salaire: 0
     revenu_assimile_salaire_apres_abattements: 0 * (1 - 0.1)
     irpp: 0
+
+- name: Haut revenu 2016 - tranche supérieure du barème 1990-2016 (35 % au-delà de 50 000 D)
+  # Non-régression : le barème encodé s'arrêtait à « au-delà de 20 000 D : 30 % » et omettait
+  # la coupure à 50 000 D et la tranche à 35 %. Barème officiel : article 44 § I du code de
+  # l'IRPP et de l'IS annexé à la loi n° 89-114, JORT n° 1 du 2-5 janvier 1990, p. 9 —
+  # inchangé jusqu'aux revenus de 2016 inclus.
+  period: 2016
+  absolute_error_margin: 0.5
+  input:
+    male: true
+    marie: false
+    salaire_imposable: 100000
+  output:
+    revenu_net_imposable: 98000
+    # 3 500 x 15 % + 5 000 x 20 % + 10 000 x 25 % + 30 000 x 30 % + 48 000 x 35 %
+    irpp: 29825

--- a/tests/test_contribution_personnelle_etat.py
+++ b/tests/test_contribution_personnelle_etat.py
@@ -1,0 +1,94 @@
+"""Contribution personnelle d'État : contrôle du tarif sur le texte publié au JORT.
+
+Aucune variable du modèle ne consomme ces paramètres — openfisca-tunisia ne calcule pas
+l'avant-1990. Ils servent de référence datée, notamment aux tableaux du précis socio-fiscal.
+Ces tests sont donc leur seul garde-fou : ils vérifient d'une part la structure des trois
+tarifs successifs, d'autre part que la colonne « taux d'imposition du revenu global à la
+limite supérieure de la tranche », imprimée dans le texte de loi, se déduit bien du tarif
+encodé. Une erreur de seuil ou de taux casse cette seconde vérification.
+"""
+
+import datetime
+
+from openfisca_tunisia import TunisiaTaxBenefitSystem
+
+tax_benefit_system = TunisiaTaxBenefitSystem()
+
+
+def bareme(annee):
+    parametres = tax_benefit_system.get_parameters_at_instant(f"{annee}-01-01")
+    return parametres.impot_revenu.contribution_personnelle_etat.bareme
+
+
+def taux_effectifs(bareme):
+    """Taux d'imposition du revenu global à la limite supérieure de chaque tranche.
+
+    Deux décimales TRONQUÉES et non arrondies : c'est la convention du JORT, qui imprime
+    « 1,53 % » pour 1,538 % et « 20,12 % » pour 20,125 %.
+    """
+    seuils, taux = list(bareme.thresholds), list(bareme.rates)
+    resultats, cumul = [], 0.0
+    for indice in range(len(seuils) - 1):
+        cumul += (seuils[indice + 1] - seuils[indice]) * taux[indice]
+        resultats.append(int(cumul / seuils[indice + 1] * 100 * 100 + 1e-9) / 100)
+    return resultats
+
+
+def test_structure_des_trois_tarifs():
+    # Revenus 1980 : art. 8 de la loi n° 79-66, JORT n° 76 des 28-31 décembre 1979, p. 3540.
+    assert len(bareme(1980).thresholds) == 11
+    assert bareme(1980).thresholds[-1] == 8500
+    assert bareme(1980).rates[-1] == 0.80
+
+    # Revenus 1983 : art. 9 de la loi n° 82-91, JORT n° 84 du 31 décembre 1982, p. 2877.
+    assert len(bareme(1983).thresholds) == 20
+    assert bareme(1983).thresholds[-1] == 100000
+    assert bareme(1983).rates[-1] == 0.80
+
+    # Revenus 1986 : art. 8 de la loi n° 85-109, JORT n° 91 du 31 décembre 1985, p. 1731.
+    assert len(bareme(1986).thresholds) == 18
+    assert bareme(1986).thresholds[-1] == 80000
+    assert bareme(1986).rates[-1] == 0.68
+
+
+def test_tarif_1986_reste_en_vigueur_jusqu_aux_revenus_de_1989():
+    """La CPE est supprimée pour les revenus réalisés à compter du 1er janvier 1990."""
+    assert list(bareme(1989).thresholds) == list(bareme(1986).thresholds)
+    assert list(bareme(1989).rates) == list(bareme(1986).rates)
+
+
+def test_taux_effectifs_conformes_au_jort_1986():
+    """Colonne imprimée à l'article 8 de la loi n° 85-109 (JORT n° 91/1985, p. 1731)."""
+    assert taux_effectifs(bareme(1986)) == [
+        0.0, 1.53, 2.66, 5.75, 8.6, 11.33, 14.0, 16.75, 21.8, 26.16,
+        33.12, 37.7, 43.5, 50.76, 54.97, 57.98, 59.98,
+    ]
+
+
+def test_taux_effectifs_conformes_au_jort_1983():
+    """Colonne imprimée à l'article 9 de la loi n° 82-91 (JORT n° 84/1982, p. 2877).
+
+    La valeur de la tranche 50 000-65 000 est illisible sur le fac-similé ; elle est
+    déduite des deux valeurs voisines, lisibles, et des seuils du tarif.
+    """
+    assert taux_effectifs(bareme(1983)) == [
+        0.0, 1.53, 2.66, 5.75, 8.6, 11.33, 14.0, 16.75, 21.8, 26.16,
+        33.12, 37.7, 43.5, 50.76, 56.38, 58.13, 59.61, 60.76, 62.29,
+    ]
+
+
+def test_taux_effectifs_conformes_au_jort_1980():
+    """Colonne imprimée à l'article 8 de la loi n° 79-66 (JORT n° 76/1979, p. 3540)."""
+    assert taux_effectifs(bareme(1980)) == [
+        0.0, 4.0, 7.66, 10.75, 13.6, 16.33, 22.25, 29.81, 36.28, 42.23,
+    ]
+
+
+def test_plafond_de_cotisation():
+    def plafond(annee):
+        parametres = tax_benefit_system.get_parameters_at_instant(f"{annee}-01-01")
+        return parametres.impot_revenu.contribution_personnelle_etat.plafond_cotisation
+
+    assert plafond(1980) == 0.55
+    assert plafond(1983) == 0.60
+    assert plafond(1989) == 0.60

--- a/tests/test_contribution_personnelle_etat.py
+++ b/tests/test_contribution_personnelle_etat.py
@@ -8,7 +8,6 @@ limite supérieure de la tranche », imprimée dans le texte de loi, se déduit 
 encodé. Une erreur de seuil ou de taux casse cette seconde vérification.
 """
 
-import datetime
 
 from openfisca_tunisia import TunisiaTaxBenefitSystem
 

--- a/uv.lock
+++ b/uv.lock
@@ -1524,7 +1524,7 @@ web-api = [
 
 [[package]]
 name = "openfisca-tunisia"
-version = "0.65"
+version = "0.68"
 source = { editable = "." }
 dependencies = [
     { name = "openfisca-core", extra = ["web-api"] },

--- a/uv.lock
+++ b/uv.lock
@@ -1524,7 +1524,7 @@ web-api = [
 
 [[package]]
 name = "openfisca-tunisia"
-version = "0.68"
+version = "0.69"
 source = { editable = "." }
 dependencies = [
     { name = "openfisca-core", extra = ["web-api"] },


### PR DESCRIPTION
## Problème

Le barème de l'IRPP encodé pour les revenus de 1990 à 2016 s'arrêtait à « au-delà de 20 000 D : 30 % » et **omettait la tranche supérieure**. La date d'effet `1990-01-01` ne portait par ailleurs aucune référence.

```
avant :  0 % | 1 500 : 15 % | 5 000 : 20 % | 10 000 : 25 % | 20 000 : 30 %
après :  0 % | 1 500 : 15 % | 5 000 : 20 % | 10 000 : 25 % | 20 000 : 30 % | 50 000 : 35 %
```

**Conséquence : les revenus nets imposables supérieurs à 50 000 D étaient sous-imposés sur toute la période 1990-2016.** Pour un salaire imposable de 100 000 D en 2016, l'IRPP passe de 27 425 D à 29 825 D.

## Source

Article 44 § I du code de l'IRPP et de l'IS, annexé à la loi n° 89-114 du 30 décembre 1989. Le code annexé n'a pas été publié dans le JORT n° 88 du 31 décembre 1989 (qui ne porte que la loi de promulgation) mais dans le **[JORT n° 1 du 2-5 janvier 1990](https://www.pist.tn/jort/1990/1990F/Jo00190.pdf), p. 3-21, article 44 en page 9**.

Le tableau officiel comporte une troisième colonne (taux d'imposition du revenu global à la limite supérieure), qui permet de contrôler la lecture :

| Tranches (dinars) | Taux | Taux effectif à la limite supérieure |
|---|---|---|
| 0 à 1 500 | 0 % | 0 % |
| 1 500,001 à 5 000 | 15 % | 10,50 % |
| 5 000,001 à 10 000 | 20 % | 15,25 % |
| 10 000,001 à 20 000 | 25 % | 20,12 % |
| 20 000,001 à 50 000 | 30 % | 26,05 % |
| au-delà de 50 000 | 35 % | — |

Ce barème est resté **inchangé jusqu'aux revenus de 2016 inclus** : l'article 44 § I n'a été modifié qu'une fois, par l'article 14-1 de la loi n° 2016-78. Vérifié par dépouillement des lois de finances de la période, par la chaîne d'annotation du code consolidé (dont le § II porte des mentions remontant à 1997, alors que le § I n'en porte qu'une), et par la note commune n° 3/2017 de la DGI qui reproduit l'ancien barème.

## Modifications

- `parameters/impot_revenu/bareme.yaml` : ajout de la tranche manquante, fermée en 2017 par `value: null` puisque le barème de 2017 n'en compte que cinq. Ajout des références JORT et des `official_journal_date` des trois millésimes (1990, 2017, 2025). La page du JORT de 2025 est corrigée en métadonnée de titre (n° 149 du 10 décembre 2024, p. 6429).
- `parameters/impot_revenu/exoneration/seuil.yaml` : documentation. Ce paramètre est une **exonération catégorielle des salariés et pensionnés** (article 73-1 de la LF 2014), juridiquement **abrogée à compter des revenus de 2017** par l'article 14-5 de la LF 2017, qui lui substitue la tranche à 0 % du barème. Ce ne sont pas le même dispositif.
- `tests/formulas/impot_revenu/irpp.yaml` : test de non-régression sur un haut revenu en 2016, avec le détail du calcul attendu.

## Point à trancher séparément

Je **n'ai pas** clôturé `exoneration/seuil` en 2017 (`value: null`), bien que ce soit la réalité juridique, parce que les formules de `contribution_sociale_solidarite` (formules 2018 et 2020) lisent encore ce paramètre pour des années postérieures à l'abrogation. Le clôturer provoque une `ParameterNotFoundError` sur `tests/test_basics.py`.

Ces formules devraient vraisemblablement s'appuyer sur le seuil de la première tranche imposée du barème plutôt que sur un paramètre d'exonération abrogé — les deux valent 5 000 D depuis 2017, donc le résultat est aujourd'hui correct par coïncidence, mais le couplage est fragile. Cela relève d'une PR distincte sur les variables ; une note de documentation est ajoutée dans le paramètre en attendant.

## Tests

`uv run openfisca test --country-package openfisca_tunisia tests` : **118 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2qMrmbL6BUDiEo3NmpU5m