### PR TITLE
feat(params): ajoute le tarif de la contribution personnelle d'État

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.69 - [#PRNUM](https://github.com/openfisca/openfisca-tunisia/pull/PRNUM)
+## 0.69 - [#381](https://github.com/openfisca/openfisca-tunisia/pull/381)
 
 * Ajout de paramètres.
 * Périodes concernées : jusqu'au 31/12/1989.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.69 - [#PRNUM](https://github.com/openfisca/openfisca-tunisia/pull/PRNUM)
+
+* Ajout de paramètres.
+* Périodes concernées : jusqu'au 31/12/1989.
+* Zones impactées : `parameters/impot_revenu/contribution_personnelle_etat`.
+* Détails :
+  - Ajoute le tarif de la contribution personnelle d'État, impôt progressif sur le revenu global institué par le décret du 31 mars 1932 et supprimé pour les revenus réalisés à compter du 1er janvier 1990. Trois rédactions successives de l'article 8 : revenus 1980 (11 tranches, 80 % au-delà de 8 500 D), revenus 1983 (20 tranches, 80 % au-delà de 100 000 D) et revenus 1986 (18 tranches, 68 % au-delà de 80 000 D), avec leurs références JORT.
+  - Ajoute le plafond de cotisation effective (55 % du revenu global imposable pour les revenus 1980, 60 % à partir des revenus 1983), qui n'a pas d'équivalent dans l'IRPP.
+  - Aucune variable ne consomme ces paramètres : le modèle ne calcule pas l'avant-1990. Ils servent de référence datée et sourcée. Des tests vérifient que la colonne des taux d'imposition à la limite supérieure, imprimée dans les textes de loi, se déduit du tarif encodé.
+
+<!-- -->
+
 ## 0.68 - [#380](https://github.com/openfisca/openfisca-tunisia/pull/380)
 
 * Correction d'un bug.

--- a/openfisca_tunisia/parameters/impot_revenu/contribution_personnelle_etat/bareme.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/contribution_personnelle_etat/bareme.yaml
@@ -1,0 +1,283 @@
+description: Tarif de la contribution personnelle d'État
+brackets:
+- threshold:
+    1980-01-01:
+      value: 0
+    1983-01-01:
+      value: 0
+    1986-01-01:
+      value: 0
+  rate:
+    1980-01-01:
+      value: 0.0
+    1983-01-01:
+      value: 0.0
+    1986-01-01:
+      value: 0.0
+- threshold:
+    1980-01-01:
+      value: 500
+    1983-01-01:
+      value: 900
+    1986-01-01:
+      value: 900
+  rate:
+    1980-01-01:
+      value: 0.08
+    1983-01-01:
+      value: 0.05
+    1986-01-01:
+      value: 0.05
+- threshold:
+    1980-01-01:
+      value: 1000
+    1983-01-01:
+      value: 1300
+    1986-01-01:
+      value: 1300
+  rate:
+    1980-01-01:
+      value: 0.15
+    1983-01-01:
+      value: 0.1
+    1986-01-01:
+      value: 0.1
+- threshold:
+    1980-01-01:
+      value: 1500
+    1983-01-01:
+      value: 1500
+    1986-01-01:
+      value: 1500
+  rate:
+    1980-01-01:
+      value: 0.2
+    1983-01-01:
+      value: 0.15
+    1986-01-01:
+      value: 0.15
+- threshold:
+    1980-01-01:
+      value: 2000
+    1983-01-01:
+      value: 2000
+    1986-01-01:
+      value: 2000
+  rate:
+    1980-01-01:
+      value: 0.25
+    1983-01-01:
+      value: 0.2
+    1986-01-01:
+      value: 0.2
+- threshold:
+    1980-01-01:
+      value: 2500
+    1983-01-01:
+      value: 2500
+    1986-01-01:
+      value: 2500
+  rate:
+    1980-01-01:
+      value: 0.3
+    1983-01-01:
+      value: 0.25
+    1986-01-01:
+      value: 0.25
+- threshold:
+    1980-01-01:
+      value: 3000
+    1983-01-01:
+      value: 3000
+    1986-01-01:
+      value: 3000
+  rate:
+    1980-01-01:
+      value: 0.4
+    1983-01-01:
+      value: 0.3
+    1986-01-01:
+      value: 0.3
+- threshold:
+    1980-01-01:
+      value: 4000
+    1983-01-01:
+      value: 3500
+    1986-01-01:
+      value: 3500
+  rate:
+    1980-01-01:
+      value: 0.5
+    1983-01-01:
+      value: 0.36
+    1986-01-01:
+      value: 0.36
+- threshold:
+    1980-01-01:
+      value: 5500
+    1983-01-01:
+      value: 4000
+    1986-01-01:
+      value: 4000
+  rate:
+    1980-01-01:
+      value: 0.6
+    1983-01-01:
+      value: 0.42
+    1986-01-01:
+      value: 0.42
+- threshold:
+    1980-01-01:
+      value: 7000
+    1983-01-01:
+      value: 5000
+    1986-01-01:
+      value: 5000
+  rate:
+    1980-01-01:
+      value: 0.7
+    1983-01-01:
+      value: 0.48
+    1986-01-01:
+      value: 0.48
+- threshold:
+    1980-01-01:
+      value: 8500
+    1983-01-01:
+      value: 6000
+    1986-01-01:
+      value: 6000
+  rate:
+    1980-01-01:
+      value: 0.8
+    1983-01-01:
+      value: 0.54
+    1986-01-01:
+      value: 0.54
+- threshold:
+    1983-01-01:
+      value: 8000
+    1986-01-01:
+      value: 8000
+  rate:
+    1983-01-01:
+      value: 0.56
+    1986-01-01:
+      value: 0.56
+- threshold:
+    1983-01-01:
+      value: 10000
+    1986-01-01:
+      value: 10000
+  rate:
+    1983-01-01:
+      value: 0.58
+    1986-01-01:
+      value: 0.58
+- threshold:
+    1983-01-01:
+      value: 14000
+    1986-01-01:
+      value: 14000
+  rate:
+    1983-01-01:
+      value: 0.6
+    1986-01-01:
+      value: 0.6
+- threshold:
+    1983-01-01:
+      value: 25000
+    1986-01-01:
+      value: 25000
+  rate:
+    1983-01-01:
+      value: 0.62
+    1986-01-01:
+      value: 0.62
+- threshold:
+    1983-01-01:
+      value: 50000
+    1986-01-01:
+      value: 40000
+  rate:
+    1983-01-01:
+      value: 0.64
+    1986-01-01:
+      value: 0.64
+- threshold:
+    1983-01-01:
+      value: 65000
+    1986-01-01:
+      value: 60000
+  rate:
+    1983-01-01:
+      value: 0.66
+    1986-01-01:
+      value: 0.66
+- threshold:
+    1983-01-01:
+      value: 80000
+    1986-01-01:
+      value: 80000
+  rate:
+    1983-01-01:
+      value: 0.7
+    1986-01-01:
+      value: 0.68
+- threshold:
+    1983-01-01:
+      value: 90000
+    1986-01-01:
+      value: null
+  rate:
+    1983-01-01:
+      value: 0.76
+    1986-01-01:
+      value: null
+- threshold:
+    1983-01-01:
+      value: 100000
+    1986-01-01:
+      value: null
+  rate:
+    1983-01-01:
+      value: 0.8
+    1986-01-01:
+      value: null
+metadata:
+  label_en: Personal state contribution tax scale
+  rate_unit: /1
+  threshold_unit: currency
+  reference:
+    1980-01-01:
+      title: Article 8 de la loi n° 79-66 du 31 décembre 1979 portant loi de finances pour la gestion 1980, JORT n° 76 des 28-31 décembre 1979, p. 3540
+      href: https://www.pist.tn/jort/1979/1979F/Jo07679.pdf
+    1983-01-01:
+      title: Article 9 de la loi n° 82-91 du 31 décembre 1982 portant loi de finances pour la gestion 1983, JORT n° 84 du 31 décembre 1982, p. 2877
+      href: https://www.pist.tn/jort/1982/1982F/Jo08482.pdf
+    1986-01-01:
+      title: Article 8 de la loi n° 85-109 du 31 décembre 1985 portant loi de finances pour la gestion 1986, JORT n° 91 du 31 décembre 1985, p. 1731
+      href: https://www.pist.tn/jort/1985/1985F/Jo09185.pdf
+  official_journal_date:
+    1980-01-01: "1979-12-31"
+    1983-01-01: "1982-12-31"
+    1986-01-01: "1985-12-31"
+documentation: |
+  Tarif de l'article 8 du décret du 31 mars 1932 instituant la contribution personnelle
+  d'État, dans ses rédactions successives. Chaque loi de finances citée en référence
+  abroge et remplace cet article 8.
+
+  Les dates sont des ANNÉES DE REVENUS : les lois de finances disposent que leurs
+  dispositions s'appliquent aux revenus réalisés à compter du 1er janvier de l'année
+  suivant leur publication.
+
+  La contribution personnelle d'État est SUPPRIMÉE pour les revenus réalisés à compter
+  du 1er janvier 1990 par l'article 2 de la loi n° 89-114 du 30 décembre 1989, qui lui
+  substitue l'impôt sur le revenu des personnes physiques. Ce tarif n'est donc pas
+  clôturé au-delà de 1989 par une valeur nulle mais ne doit jamais être lu après 1989 :
+  ce n'est pas un état antérieur du barème de l'IRPP, c'est un autre impôt, avec une
+  autre assiette et un plafonnement de cotisation propre.
+
+  Aucune variable du modèle ne consomme ces paramètres : openfisca-tunisia ne calcule
+  pas l'avant-1990. Ils servent de référence datée et sourcée, notamment aux tableaux
+  du précis socio-fiscal.

--- a/openfisca_tunisia/parameters/impot_revenu/contribution_personnelle_etat/index.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/contribution_personnelle_etat/index.yaml
@@ -1,0 +1,5 @@
+description: Contribution personnelle d'État (impôt progressif sur le revenu global, supprimé pour les revenus réalisés à compter du 1er janvier 1990)
+metadata:
+  order:
+  - bareme
+  - plafond_cotisation

--- a/openfisca_tunisia/parameters/impot_revenu/contribution_personnelle_etat/plafond_cotisation.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/contribution_personnelle_etat/plafond_cotisation.yaml
@@ -1,0 +1,24 @@
+description: Plafond de la cotisation effective, en part du revenu global imposable
+values:
+  1980-01-01:
+    value: 0.55
+  1983-01-01:
+    value: 0.60
+metadata:
+  unit: /1
+  reference:
+    1980-01-01:
+      title: Article 8 (nouveau) § II, loi n° 79-66 du 31 décembre 1979, JORT n° 76 des 28-31 décembre 1979, p. 3540
+      href: https://www.pist.tn/jort/1979/1979F/Jo07679.pdf
+    1983-01-01:
+      title: Article 8 (nouveau) § II, loi n° 82-91 du 31 décembre 1982, JORT n° 84 du 31 décembre 1982, p. 2877
+      href: https://www.pist.tn/jort/1982/1982F/Jo08482.pdf
+documentation: |
+  « La cotisation effective de la contribution personnelle d'État calculée conformément aux
+  dispositions du paragraphe III ci-après ne peut excéder X % du revenu global imposable. »
+
+  Ce plafonnement n'a pas d'équivalent dans le barème de l'IRPP institué en 1990. Il explique
+  que la dernière ligne du barème publié au JORT de 1979 porte, dans la colonne des taux
+  d'imposition à la limite supérieure, la valeur du plafond (55 %) et non un taux calculé.
+
+  Le plafond est maintenu à 60 % par l'article 8 de la loi n° 85-109 (loi de finances 1986).

--- a/openfisca_tunisia/parameters/impot_revenu/index.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/index.yaml
@@ -2,6 +2,7 @@ description: Impôt sur le revenu
 metadata:
   order:
   - bareme
+  - contribution_personnelle_etat
   - contribution_budget_etat
   - deductions
   - exoneration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-Tunisia"
-version = "0.68"
+version = "0.69"
 description = "OpenFisca Rules as Code model for Tunisia."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "tunisia"]

--- a/tests/test_contribution_personnelle_etat.py
+++ b/tests/test_contribution_personnelle_etat.py
@@ -1,0 +1,94 @@
+"""Contribution personnelle d'État : contrôle du tarif sur le texte publié au JORT.
+
+Aucune variable du modèle ne consomme ces paramètres — openfisca-tunisia ne calcule pas
+l'avant-1990. Ils servent de référence datée, notamment aux tableaux du précis socio-fiscal.
+Ces tests sont donc leur seul garde-fou : ils vérifient d'une part la structure des trois
+tarifs successifs, d'autre part que la colonne « taux d'imposition du revenu global à la
+limite supérieure de la tranche », imprimée dans le texte de loi, se déduit bien du tarif
+encodé. Une erreur de seuil ou de taux casse cette seconde vérification.
+"""
+
+import datetime
+
+from openfisca_tunisia import TunisiaTaxBenefitSystem
+
+tax_benefit_system = TunisiaTaxBenefitSystem()
+
+
+def bareme(annee):
+    parametres = tax_benefit_system.get_parameters_at_instant(f"{annee}-01-01")
+    return parametres.impot_revenu.contribution_personnelle_etat.bareme
+
+
+def taux_effectifs(bareme):
+    """Taux d'imposition du revenu global à la limite supérieure de chaque tranche.
+
+    Deux décimales TRONQUÉES et non arrondies : c'est la convention du JORT, qui imprime
+    « 1,53 % » pour 1,538 % et « 20,12 % » pour 20,125 %.
+    """
+    seuils, taux = list(bareme.thresholds), list(bareme.rates)
+    resultats, cumul = [], 0.0
+    for indice in range(len(seuils) - 1):
+        cumul += (seuils[indice + 1] - seuils[indice]) * taux[indice]
+        resultats.append(int(cumul / seuils[indice + 1] * 100 * 100 + 1e-9) / 100)
+    return resultats
+
+
+def test_structure_des_trois_tarifs():
+    # Revenus 1980 : art. 8 de la loi n° 79-66, JORT n° 76 des 28-31 décembre 1979, p. 3540.
+    assert len(bareme(1980).thresholds) == 11
+    assert bareme(1980).thresholds[-1] == 8500
+    assert bareme(1980).rates[-1] == 0.80
+
+    # Revenus 1983 : art. 9 de la loi n° 82-91, JORT n° 84 du 31 décembre 1982, p. 2877.
+    assert len(bareme(1983).thresholds) == 20
+    assert bareme(1983).thresholds[-1] == 100000
+    assert bareme(1983).rates[-1] == 0.80
+
+    # Revenus 1986 : art. 8 de la loi n° 85-109, JORT n° 91 du 31 décembre 1985, p. 1731.
+    assert len(bareme(1986).thresholds) == 18
+    assert bareme(1986).thresholds[-1] == 80000
+    assert bareme(1986).rates[-1] == 0.68
+
+
+def test_tarif_1986_reste_en_vigueur_jusqu_aux_revenus_de_1989():
+    """La CPE est supprimée pour les revenus réalisés à compter du 1er janvier 1990."""
+    assert list(bareme(1989).thresholds) == list(bareme(1986).thresholds)
+    assert list(bareme(1989).rates) == list(bareme(1986).rates)
+
+
+def test_taux_effectifs_conformes_au_jort_1986():
+    """Colonne imprimée à l'article 8 de la loi n° 85-109 (JORT n° 91/1985, p. 1731)."""
+    assert taux_effectifs(bareme(1986)) == [
+        0.0, 1.53, 2.66, 5.75, 8.6, 11.33, 14.0, 16.75, 21.8, 26.16,
+        33.12, 37.7, 43.5, 50.76, 54.97, 57.98, 59.98,
+    ]
+
+
+def test_taux_effectifs_conformes_au_jort_1983():
+    """Colonne imprimée à l'article 9 de la loi n° 82-91 (JORT n° 84/1982, p. 2877).
+
+    La valeur de la tranche 50 000-65 000 est illisible sur le fac-similé ; elle est
+    déduite des deux valeurs voisines, lisibles, et des seuils du tarif.
+    """
+    assert taux_effectifs(bareme(1983)) == [
+        0.0, 1.53, 2.66, 5.75, 8.6, 11.33, 14.0, 16.75, 21.8, 26.16,
+        33.12, 37.7, 43.5, 50.76, 56.38, 58.13, 59.61, 60.76, 62.29,
+    ]
+
+
+def test_taux_effectifs_conformes_au_jort_1980():
+    """Colonne imprimée à l'article 8 de la loi n° 79-66 (JORT n° 76/1979, p. 3540)."""
+    assert taux_effectifs(bareme(1980)) == [
+        0.0, 4.0, 7.66, 10.75, 13.6, 16.33, 22.25, 29.81, 36.28, 42.23,
+    ]
+
+
+def test_plafond_de_cotisation():
+    def plafond(annee):
+        parametres = tax_benefit_system.get_parameters_at_instant(f"{annee}-01-01")
+        return parametres.impot_revenu.contribution_personnelle_etat.plafond_cotisation
+
+    assert plafond(1980) == 0.55
+    assert plafond(1983) == 0.60
+    assert plafond(1989) == 0.60

--- a/uv.lock
+++ b/uv.lock
@@ -1524,7 +1524,7 @@ web-api = [
 
 [[package]]
 name = "openfisca-tunisia"
-version = "0.68"
+version = "0.69"
 source = { editable = "." }
 dependencies = [
     { name = "openfisca-core", extra = ["web-api"] },


### PR DESCRIPTION
Empilée sur #380. Objectif : rendre exploitables, dans le précis socio-fiscal, les barèmes de l'impôt progressif **antérieur** à l'IRPP.

## Ce qu'est la contribution personnelle d'État

L'impôt progressif sur le revenu global d'avant 1990. Institué par le **décret du 31 mars 1932**, il coexistait avec les impôts cédulaires et a été **supprimé pour les revenus réalisés à compter du 1er janvier 1990** par l'article 2 de la loi n° 89-114, qui lui substitue l'IRPP.

Précision qui a son importance : il n'a jamais existé en Tunisie, sous ce nom, d'« impôt général sur le revenu ». La nomenclature budgétaire de 1989 porte bien « Contribution Personnelle d'État ».

## Les trois tarifs

Chaque loi de finances citée abroge et remplace l'article 8 du décret de 1932. Relevés au JORT, pages lues à l'image.

| Revenus | Texte | Tranches | Taux marginal supérieur |
|---|---|---|---|
| 1980 | art. 8 de la loi n° 79-66, [JORT n° 76 des 28-31 déc. 1979](https://www.pist.tn/jort/1979/1979F/Jo07679.pdf), p. 3540 | 11 | 80 % au-delà de 8 500 D |
| 1983 | art. 9 de la loi n° 82-91, [JORT n° 84 du 31 déc. 1982](https://www.pist.tn/jort/1982/1982F/Jo08482.pdf), p. 2877 | 20 | 80 % au-delà de 100 000 D |
| 1986 | art. 8 de la loi n° 85-109, [JORT n° 91 du 31 déc. 1985](https://www.pist.tn/jort/1985/1985F/Jo09185.pdf), p. 1731 | 18 | 68 % au-delà de 80 000 D |

Le tarif de 1986 reste en vigueur jusqu'aux revenus de 1989 inclus. La rupture de 1989-1990 est donc brutale : **68 % → 35 %** et **18 tranches → 6**, en une seule fois.

S'y ajoute le **plafond de cotisation effective** — 55 % du revenu global imposable pour les revenus 1980, porté à 60 % à partir de 1983 — qui n'a aucun équivalent dans l'IRPP. Il explique que la dernière ligne du barème de 1979 porte « 55,00 % » dans la colonne des taux à la limite supérieure : c'est le plafond, pas un taux calculé.

## Placement dans l'arbre

`parameters/impot_revenu/contribution_personnelle_etat/`, c'est-à-dire sous `impot_revenu` mais dans un **sous-arbre distinct de `bareme`**.

La CPE n'est pas un état antérieur du barème de l'IRPP : c'est un autre impôt, avec une autre assiette, d'autres déductions et un plafonnement de cotisation. Prolonger `impot_revenu/bareme.yaml` vers l'amont aurait fait que `p(1985).impot_revenu.bareme` renvoie un tarif de CPE — exactement la confusion que ces données servent à écarter, et qui a produit des erreurs publiées ailleurs (« 16 tranches à 68 % » attribuées au code de 1989, « plafond de 80 000 D » présenté comme un ancien seuil de l'IRPP).

## Paramètres sans variable

**Aucune variable du modèle ne consomme ces paramètres** : openfisca-tunisia ne calcule pas l'avant-1990 et cette PR ne propose pas de le faire. Ils servent de référence datée et sourcée, et alimentent directement les tableaux du précis socio-fiscal, qui lit les paramètres du paquet.

C'est aussi pourquoi les tests comptent plus que d'habitude : ils sont le seul garde-fou.

## Vérification

Les trois textes publient, à côté du taux de chaque tranche, le **taux d'imposition du revenu global à la limite supérieure de la tranche**. Cette colonne n'est pas encodée : elle est recalculée depuis les seuils et les taux, et comparée aux valeurs imprimées. **39 valeurs publiées reproduites exactement**, ce qui contrôle chaque seuil et chaque taux du tarif.

Deux détails que cette vérification a mis au jour :

- le JORT **tronque** à deux décimales au lieu d'arrondir (« 1,53 % » pour 1,538 %) — le test applique la même convention ;
- la valeur de la tranche 50 000-65 000 du tarif de 1983 est **illisible sur le fac-similé**. Elle vaut 58,13 % d'après le calcul ; un tarif qui donnerait la lecture concurrente « 58,19 % » supposerait un seuil de 65 577 D, qui n'est pas un nombre rond. Le point est signalé dans le test.

`uv run openfisca test --country-package openfisca_tunisia tests` : **123 passed**.

## Suite possible

Le dépouillement des lois de finances de 1974 à 1988 n'a pas révélé d'autre rédaction du tarif — ces textes touchent la CPE sur les déductions et exonérations, pas sur l'article 8. Les rédactions antérieures à 1980 (lois de finances 1966 à 1971, loi n° 62-73) restent à relever si le besoin s'en fait sentir. Le même gisement contient le barème de l'**impôt sur les traitements et salaires** (décret du 29 mars 1945), autre cédulaire supprimé en 1990, qui pourrait rejoindre le même sous-arbre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2qMrmbL6BUDiEo3NmpU5m