### PR TITLE
fix(params): corrige l'assiette de l'IRPP sur texte officiel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.71 - [#PRNUM](https://github.com/openfisca/openfisca-tunisia/pull/PRNUM)
+
+* Correction d'un bug.
+* Périodes concernées : jusqu'au 31/12/2010.
+* Zones impactées : `variables/prelevements_obligatoires/impot_revenu/revenus_categoriels/tspr`.
+* Détails :
+  - Corrige `revenu_assimile_salaire_apres_abattements` : la formule applicable avant 2011 encadrait le résultat par `min_(..., 0)` au lieu de `max_(..., 0)`. Le revenu après abattements était donc systématiquement nul, et **l'IRPP de tous les salariés était nul pour les revenus antérieurs à 2011**. Un salaire imposable de 20 000 D en 2010 donne désormais 3 525 D d'impôt au lieu de 0.
+
+<!-- -->
+
 ## 0.70 - [#382](https://github.com/openfisca/openfisca-tunisia/pull/382)
 
 * Correction d'un bug.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.71 - [#PRNUM](https://github.com/openfisca/openfisca-tunisia/pull/PRNUM)
+## 0.71 - [#383](https://github.com/openfisca/openfisca-tunisia/pull/383)
 
 * Correction d'un bug.
 * Périodes concernées : jusqu'au 31/12/2010.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.70 - [#PRNUM](https://github.com/openfisca/openfisca-tunisia/pull/PRNUM)
+
+* Correction d'un bug.
+* Périodes concernées : toutes.
+* Zones impactées : `parameters/impot_revenu/tspr`, `parameters/impot_revenu/deductions/famille`, `parameters/impot_revenu/foncier`, `parameters/impot_revenu/bnc`, `parameters/impot_revenu/minimum_impot`.
+* Détails :
+  - Corrige le plafond de la déduction pour frais professionnels sur les salaires : il était encodé à 2 000 D dès 1990, alors que l'article 14 § 2 de la loi de finances 2017 le **crée**. De 1990 à 2016 inclus, la déduction de 10 % est sans limite. L'assiette salariale était surestimée pour tous les revenus supérieurs à 20 000 D sur 27 exercices.
+  - Corrige l'abattement pour salaire minimum, qui restait appliqué alors qu'il est abrogé à compter des revenus 2014 par l'article 73 § 2 de la loi de finances 2014.
+  - Corrige la déduction forfaitaire des revenus fonciers bâtis : 30 % dès 1990 et non 2007, bascule à 20 % aux revenus 2015 et non 2016, et ajout du relèvement à 25 % aux revenus 2024, absent.
+  - Corrige les dates des déductions pour charges de famille (enfant infirme, enfant étudiant, parent à charge) et supprime une valeur d'enfant infirme de 2004 sans support. Corrige le numéro d'article cité pour le chef de famille et les enfants (article 54 et non 55 de la loi de finances 2018).
+  - Corrige la date du minimum d'impôt au titre des avantages fiscaux : 45 % à partir du 1er avril 2017 et non de 2020.
+  - Corrige la part forfaitaire des bénéfices non commerciaux (70 % dès 1990) et l'abattement sur pensions étrangères (80 % aux revenus 2006 et non 2007).
+  - Ajoute à chaque paramètre corrigé ses références JORT et une documentation distinguant les dates attestées par note commune des dates dérivées de la règle de conversion en années de revenus.
+
+<!-- -->
+
 ## 0.69 - [#381](https://github.com/openfisca/openfisca-tunisia/pull/381)
 
 * Ajout de paramètres.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.70 - [#PRNUM](https://github.com/openfisca/openfisca-tunisia/pull/PRNUM)
+## 0.70 - [#382](https://github.com/openfisca/openfisca-tunisia/pull/382)
 
 * Correction d'un bug.
 * Périodes concernées : toutes.

--- a/openfisca_tunisia/parameters/impot_revenu/bnc/forf/part_forf.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/bnc/forf/part_forf.yaml
@@ -1,8 +1,22 @@
-description: Part des recettes brutes TTC imposées
+description: Part des recettes brutes retenue comme bénéfice forfaitaire
 values:
-  2007-01-01:
-    value: 0.7
-  2014-01-01:
-    value: 0.8
+  1990-01-01:
+    value: 0.70
+  2013-01-01:
+    value: 0.80
 metadata:
   unit: /1
+  reference:
+    1990-01-01:
+      title: Article 22 § II du code de l'IRPP et de l'IS annexé à la loi n° 89-114 du 30 décembre 1989, JORT n° 1 des 2-5 janvier 1990, p. 6
+      href: https://www.pist.tn/jort/1990/1990F/Jo00190.pdf
+    2013-01-01:
+      title: Article 46 de la loi n° 2013-54 du 30 décembre 2013 portant loi de finances pour l'année 2014, intitulé « Rationalisation de l'assiette forfaitaire des bénéfices non commerciaux »
+documentation: |
+  Régime forfaitaire optionnel des bénéfices non commerciaux : le bénéfice imposable est égal à
+  cette part des recettes brutes.
+
+  Dates corrigées : le taux de 70 % remonte à 1990 et non à 2007. L'article 46 de la loi de
+  finances pour 2014 le remplace par 80 % ; il n'énonce pas de date d'effet propre et aucune note
+  commune n'a été identifiée, de sorte que le rattachement aux revenus de 2013 est DÉRIVÉ de la
+  règle de conversion et non attesté. À confirmer.

--- a/openfisca_tunisia/parameters/impot_revenu/deductions/famille/chef_de_famille.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/deductions/famille/chef_de_famille.yaml
@@ -11,7 +11,7 @@ metadata:
       title: Code de l'impôt sur le revenu des personnes physiques et de l'impôt sur les sociétés - Article 40 - Paragraphe I
       href: http://www.legislation.tn/fr/affich-code-article/code-de-l%2526%2523039%3Bimp%C3%B4t-sur-le-revenu-des-personnes-physiques-et-de-l%2526%2523039%3Bimp%C3%B4t-sur-les-soci%C3%A9t%C3%A9s-article-40-__6169
     2019-01-01:
-      title: Article 55 de la loi no 2017-66 du 18-12-2017 portant Loi de finances 2018. Note commune 7/2018 http://www.impots.finances.gov.tn/images/Note_commune_N07.pdf
+      title: Article 54 de la loi n° 2017-66 du 18 décembre 2017 portant loi de finances 2018 (l'article 55 vise le paragraphe III, enfant étudiant et enfant infirme). Effet aux revenus 2019 par la clause propre de l'article 67 § 4. Note commune 7/2018 http://www.impots.finances.gov.tn/images/Note_commune_N07.pdf
 documentation: |-
   Montant de la déduction sur le montant des revenus nets du "chef de famille".
   مبلغ الطرح من مبلغ المداخيل الصافية لرئيس العائلة

--- a/openfisca_tunisia/parameters/impot_revenu/deductions/famille/enf1.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/deductions/famille/enf1.yaml
@@ -8,4 +8,4 @@ metadata:
   unit: currency
   reference:
     2019-01-01:
-      title: Article 55 de la loi no 2017-66 du 18-12-2017 portant Loi de finances 2018. Note commune 7/2018 http://www.impots.finances.gov.tn/images/Note_commune_N07.pdf
+      title: Article 54 de la loi n° 2017-66 du 18 décembre 2017 portant loi de finances 2018 (l'article 55 vise le paragraphe III, enfant étudiant et enfant infirme). Effet aux revenus 2019 par la clause propre de l'article 67 § 4. Note commune 7/2018 http://www.impots.finances.gov.tn/images/Note_commune_N07.pdf

--- a/openfisca_tunisia/parameters/impot_revenu/deductions/famille/enf2.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/deductions/famille/enf2.yaml
@@ -8,4 +8,4 @@ metadata:
   unit: currency
   reference:
     2019-01-01:
-      title: Article 55 de la loi no 2017-66 du 18-12-2017 portant Loi de finances 2018. Note commune 7/2018 http://www.impots.finances.gov.tn/images/Note_commune_N07.pdf
+      title: Article 54 de la loi n° 2017-66 du 18 décembre 2017 portant loi de finances 2018 (l'article 55 vise le paragraphe III, enfant étudiant et enfant infirme). Effet aux revenus 2019 par la clause propre de l'article 67 § 4. Note commune 7/2018 http://www.impots.finances.gov.tn/images/Note_commune_N07.pdf

--- a/openfisca_tunisia/parameters/impot_revenu/deductions/famille/enf3.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/deductions/famille/enf3.yaml
@@ -8,4 +8,4 @@ metadata:
   unit: currency
   reference:
     2019-01-01:
-      title: Article 55 de la loi no 2017-66 du 18-12-2017 portant Loi de finances 2018. Note commune 7/2018 http://www.impots.finances.gov.tn/images/Note_commune_N07.pdf
+      title: Article 54 de la loi n° 2017-66 du 18 décembre 2017 portant loi de finances 2018 (l'article 55 vise le paragraphe III, enfant étudiant et enfant infirme). Effet aux revenus 2019 par la clause propre de l'article 67 § 4. Note commune 7/2018 http://www.impots.finances.gov.tn/images/Note_commune_N07.pdf

--- a/openfisca_tunisia/parameters/impot_revenu/deductions/famille/enf4.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/deductions/famille/enf4.yaml
@@ -8,4 +8,4 @@ metadata:
   unit: currency
   reference:
     2019-01-01:
-      title: Article 55 de la loi no 2017-66 du 18-12-2017 portant Loi de finances 2018. Note commune 7/2018 http://www.impots.finances.gov.tn/images/Note_commune_N07.pdf
+      title: Article 54 de la loi n° 2017-66 du 18 décembre 2017 portant loi de finances 2018 (l'article 55 vise le paragraphe III, enfant étudiant et enfant infirme). Effet aux revenus 2019 par la clause propre de l'article 67 § 4. Note commune 7/2018 http://www.impots.finances.gov.tn/images/Note_commune_N07.pdf

--- a/openfisca_tunisia/parameters/impot_revenu/deductions/famille/enf_sup.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/deductions/famille/enf_sup.yaml
@@ -2,14 +2,26 @@ description: Enfant non boursier du supérieur
 values:
   1990-01-01:
     value: 300
-  2010-01-01:
+  2009-01-01:
     value: 600
-  2014-01-01:
+  2013-01-01:
     value: 1000
 metadata:
   unit: currency
   reference:
-    2010-01-01:
-      title: Article 40 de la loi no 2009-71 du 21-12-2004 portant Loi de finances 2010
-    2014-01-01:
-      title: Loi de finances 2014
+    1990-01-01:
+      title: Article 40 § III du code de l'IRPP et de l'IS annexé à la loi n° 89-114 du 30 décembre 1989, JORT n° 1 des 2-5 janvier 1990, p. 8
+      href: https://www.pist.tn/jort/1990/1990F/Jo00190.pdf
+    2009-01-01:
+      title: Article 40 § 2 de la loi n° 2009-71 du 21 décembre 2009 (loi de finances 2010)
+    2013-01-01:
+      title: Article 94 § 2 de la loi n° 2013-54 du 30 décembre 2013 (loi de finances 2014)
+documentation: |
+  Déduction au titre d'un enfant poursuivant des études supérieures sans bénéfice de bourse et
+  âgé de moins de 25 ans (article 40 § III).
+
+  Les dates sont des ANNÉES DE REVENUS et ont été décalées d'un an : les articles instituteurs
+  n'énoncent pas de date d'effet propre, et l'article final de la loi de finances pour N est lu
+  par l'administration comme visant les revenus de N-1. Au sein de la loi de finances pour 2014,
+  l'article 73 porte au contraire une clause propre visant les revenus de 2014 : deux mesures
+  d'une même loi ne prennent pas nécessairement effet la même année de revenus.

--- a/openfisca_tunisia/parameters/impot_revenu/deductions/famille/infirme.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/deductions/famille/infirme.yaml
@@ -3,27 +3,33 @@ values:
   1990-01-01:
     value: 500
   2004-01-01:
-    value: 600
-  2005-01-01:
     value: 750
-  2010-01-01:
+  2009-01-01:
     value: 1000
-  2014-01-01:
+  2013-01-01:
     value: 1200
   2017-01-01:
     value: 2000
 metadata:
   unit: currency
   reference:
-    0001-01-01:
-      title: Article 40.III du Code l'impôt sur le revenu des personnes physiques et de l'impôt sur les sociétés
-    2005-01-01:
-      title: Article 50 de la loi no 2004-90 du 31-12-2004 portant Loi de finances 2005
-    2010-01-01:
-      title: Article 40 de la loi no 2009-71 du 21-12-2009 portant Loi de finances 2010
-    2014-01-01:
-      title: Article 94 de la loi no 2013-54 du 30-12-2017 portant Loi de finances 2014
+    1990-01-01:
+      title: Article 40 § III du code de l'IRPP et de l'IS annexé à la loi n° 89-114 du 30 décembre 1989, JORT n° 1 des 2-5 janvier 1990, p. 8
+      href: https://www.pist.tn/jort/1990/1990F/Jo00190.pdf
+    2004-01-01:
+      title: Article 50 de la loi n° 2004-90 du 31 décembre 2004 (loi de finances 2005) ; note commune n° 33/2005 rattachant la mesure aux revenus de l'année 2004
+    2009-01-01:
+      title: Article 40 § 2 de la loi n° 2009-71 du 21 décembre 2009 (loi de finances 2010)
+    2013-01-01:
+      title: Article 94 § 2 de la loi n° 2013-54 du 30 décembre 2013 (loi de finances 2014)
     2017-01-01:
-      - title: Article 55 de la loi no 2017-66 du 18-12-2017 portant Loi de finances 2018. .
-      - title: Note commune 7/2018
-        href: https://jibaya.tn/docs/note-commune-numero-7-commentaire-des-dispositions-des-articles-54-et-55-de-la-loi-n-2017-66-du-18-decembre-2017-portant-loi-de-finances-pour-lannee-2018-relatives-au-r/
+      title: Article 55 de la loi n° 2017-66 du 18 décembre 2017 (loi de finances 2018) ; note commune n° 7/2018 rattachant la mesure aux revenus réalisés à partir du 1er janvier 2017
+documentation: |
+  Déduction au titre d'un enfant infirme, sans condition d'âge ni de rang (article 40 § III).
+
+  Les dates sont des ANNÉES DE REVENUS. La valeur de 600 dinars précédemment encodée en 2004
+  est SUPPRIMÉE : elle n'a aucun support: la note commune n° 33/2005 atteste un passage direct
+  de 500 à 750 dinars.
+
+  Les millésimes 2004 et 2009 sont dérivés de la règle de conversion (loi de finances pour N
+  muette sur sa date d'effet -> revenus de N-1) ; 2004 et 2017 sont attestés par note commune.

--- a/openfisca_tunisia/parameters/impot_revenu/deductions/famille/parent_max.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/deductions/famille/parent_max.yaml
@@ -2,7 +2,20 @@ description: Parent à charge (montant maximum)
 values:
   1990-01-01:
     value: 150
-  2018-01-01:
+  2019-01-01:
     value: 450
 metadata:
   unit: currency
+  reference:
+    1990-01-01:
+      title: Article 40 § IV du code de l'IRPP et de l'IS annexé à la loi n° 89-114 du 30 décembre 1989, JORT n° 1 des 2-5 janvier 1990, p. 8
+      href: https://www.pist.tn/jort/1990/1990F/Jo00190.pdf
+    2019-01-01:
+      title: Article 41 de la loi n° 2019-78 du 23 décembre 2019 portant loi de finances pour l'année 2020, JORT n° 104 du 27 décembre 2019, p. 4435 ; note commune n° 3/2020 rattachant la mesure aux revenus réalisés à partir du 1er janvier 2019
+documentation: |
+  Plafond, par parent à charge, de la déduction de 5 % du revenu net (article 40 § IV).
+
+  Date corrigée de 2018 à 2019 : la note commune n° 3/2020 rattache la mesure aux revenus
+  réalisés à partir du 1er janvier 2019. La comparaison des millésimes du code consolidé le
+  confirme indirectement — l'édition 2019 porte encore la condition de ressources ancienne,
+  l'édition 2020 la nouvelle.

--- a/openfisca_tunisia/parameters/impot_revenu/deductions/famille/parent_plaf.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/deductions/famille/parent_plaf.yaml
@@ -1,8 +1,21 @@
-description: Parent à charge (plafond de revenu en SMIG)
+description: Parent à charge (plafond de revenu, en multiples du SMIG)
 values:
   1990-01-01:
     value: 1
-  2018-01-01:
+  2019-01-01:
     value: 2
 metadata:
   unit: /1
+  reference:
+    1990-01-01:
+      title: Article 40 § IV du code de l'IRPP et de l'IS annexé à la loi n° 89-114 du 30 décembre 1989, JORT n° 1 des 2-5 janvier 1990, p. 8
+      href: https://www.pist.tn/jort/1990/1990F/Jo00190.pdf
+    2019-01-01:
+      title: Article 41 de la loi n° 2019-78 du 23 décembre 2019 (loi de finances 2020) ; note commune n° 3/2020
+documentation: |
+  Condition de ressources du parent à charge : son revenu, augmenté du montant de la déduction,
+  ne doit pas excéder ce multiple du SMIG.
+
+  Date corrigée de 2018 à 2019. Le doublement est directement lisible dans le code consolidé :
+  l'édition 2019 dit « n'excède pas le salaire minimum interprofessionnel garanti », l'édition
+  2020 « n'excède pas le double du salaire minimum interprofessionnel garanti ».

--- a/openfisca_tunisia/parameters/impot_revenu/foncier/bati/deduction_frais.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/foncier/bati/deduction_frais.yaml
@@ -1,8 +1,34 @@
-description: Déduction pour frais, charges et amortissments
+description: Déduction forfaitaire pour frais, charges et amortissements des propriétés bâties
 values:
-  2007-01-01:
-    value: 0.3
-  2016-01-01:
-    value: 0.2
+  1990-01-01:
+    value: 0.30
+  2015-01-01:
+    value: 0.20
+  2024-01-01:
+    value: 0.25
 metadata:
   unit: /1
+  reference:
+    1990-01-01:
+      title: Article 28 § II du code de l'IRPP et de l'IS annexé à la loi n° 89-114 du 30 décembre 1989, JORT n° 1 des 2-5 janvier 1990, p. 7
+      href: https://www.pist.tn/jort/1990/1990F/Jo00190.pdf
+    2015-01-01:
+      title: Article 21 § 1 de la loi n° 2015-53 du 25 décembre 2015 portant loi de finances pour l'année 2016, JORT n° 104 du 29 décembre 2015, p. 3142-3143 ; note commune n° 16/2016 rattachant la mesure à l'exercice 2015
+    2024-01-01:
+      title: Article 39 § 1 de la loi n° 2024-48 du 9 décembre 2024 portant loi de finances pour l'année 2025, JORT n° 149 du 10 décembre 2024, p. 3431-3432 de l'édition française ; l'article 39 § 2 vise « les revenus des propriétés bâties réalisés à partir du 1er janvier 2024 »
+  official_journal_date:
+    2024-01-01: "2024-12-10"
+documentation: |
+  ATTENTION : LES TROIS TAUX NE SONT PAS COMPARABLES ENTRE EUX, leur assiette de charges
+  couvertes ayant changé.
+
+  De 1990 à 2023, le forfait couvre les frais de gestion, la rémunération du concierge, les
+  assurances et l'amortissement, les frais de réparation et d'entretien restant déductibles au
+  réel EN SUS. À partir des revenus de 2024, le forfait de 25 % ABSORBE les frais de réparation
+  et d'entretien. Un bailleur engageant des travaux peut donc être perdant malgré un taux nominal
+  plus élevé.
+
+  Dates corrigées : le taux de 30 % remonte à 1990 et non à 2007 ; la bascule à 20 % vaut pour les
+  revenus de 2015 et non de 2016 ; le relèvement à 25 % pour les revenus de 2024 était absent.
+  Ce dernier est confirmé par comparaison des millésimes du code consolidé, qui porte 20 % jusqu'à
+  l'édition 2023 et 25 % dans l'édition 2025.

--- a/openfisca_tunisia/parameters/impot_revenu/minimum_impot/taux.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/minimum_impot/taux.yaml
@@ -1,9 +1,32 @@
-description: Taux minimum d'imposition applicable suite aux déductions d'impôts et investissements
-unit: /1
+description: Minimum d'impôt au titre des avantages fiscaux (article 12 bis de la loi n° 89-114)
 values:
   1990-01-01:
     value: 0
   2014-01-01:
     value: 0.60
-  2020-01-01:
+  2017-04-01:
     value: 0.45
+metadata:
+  unit: /1
+  reference:
+    2017-04-01:
+      title: Article 2 § 6 de la loi n° 2017-8 du 14 février 2017 portant refonte du dispositif des avantages fiscaux, JORT n° 15 du 21 février 2017, p. 777 ; l'article 23 fixe l'application « à partir du 1er avril 2017 »
+documentation: |
+  Ce paramètre est le minimum d'impôt de l'ARTICLE 12 BIS DE LA LOI N° 89-114 du 30 décembre 1989
+  portant promulgation du code — et non d'un article du code lui-même, ce qui explique qu'il soit
+  introuvable dans les millésimes consolidés. Il plafonne indirectement les avantages fiscaux :
+  quel que soit le volume de déductions mobilisées, l'impôt ne peut descendre en dessous de cette
+  fraction de ce qu'il aurait été sans elles.
+
+  NE PAS CONFONDRE avec deux homonymes : l'article 44 § II du code (minimum d'impôt assis sur le
+  chiffre d'affaires) et l'article 12 bis DU CODE (amortissements).
+
+  Date corrigée : le passage à 45 % est daté du 1er AVRIL 2017 et non de 2020. C'est la seule date
+  d'effet calendaire, en cours d'exercice, de tout ce sous-arbre ; l'exercice de rattachement n'est
+  pas établi et la valeur est donc datée au 1er avril, telle que l'énonce l'article 23.
+
+  RÉSERVE : la borne 2014-01-01 pour le taux de 60 % N'A AUCUN SUPPORT ÉTABLI. Le taux de 60 %
+  existait au moins depuis 2007, et le véhicule qui l'a institué n'est pas identifié — le
+  dépouillement des lois de finances 2000-2006 est bloqué par des PDF dont la police à encodage
+  décalé supprime les chiffres à l'extraction. La valeur est conservée faute de mieux ; sa date
+  est à retenir comme non fiable.

--- a/openfisca_tunisia/parameters/impot_revenu/tspr/abat_pen_etr.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/tspr/abat_pen_etr.yaml
@@ -1,8 +1,22 @@
-description: Abattement sur les pensions étrangères
+description: Abattement sur les pensions et rentes viagères de source étrangère
 values:
   2001-01-01:
     value: 0
-  2007-01-01:
+  2006-01-01:
     value: 0.8
 metadata:
   unit: /1
+  reference:
+    2006-01-01:
+      title: Article 35 de la loi n° 2006-85 du 25 décembre 2006 portant loi de finances pour l'année 2007, intitulé « Instauration d'un régime fiscal de faveur pour les pensions et les rentes viagères provenant de l'étranger » ; note commune n° 18/2007 rattachant la mesure aux « pensions et rentes perçues en 2006 et déclarées en 2007 »
+documentation: |
+  Abattement applicable aux pensions et rentes viagères de source étrangère, sous condition de
+  transfert des sommes en Tunisie (article 37 dernier alinéa du code).
+
+  Date corrigée de 2007 à 2006 : la note commune n° 18/2007 rattache expressément la mesure aux
+  pensions perçues EN 2006.
+
+  RÉSERVE : la borne 2001-01-01 n'a aucun support établi. Avant le régime de faveur, ces pensions
+  relevaient par renvoi de l'abattement de droit commun de l'article 26 (25 %), introduit par
+  l'article 61 de la loi de finances pour 1998 — valeur et date non vérifiées, la valeur nulle
+  encodée ici est donc probablement fausse pour la période antérieure à 2006.

--- a/openfisca_tunisia/parameters/impot_revenu/tspr/abattement_pour_salaire_minimum.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/tspr/abattement_pour_salaire_minimum.yaml
@@ -1,8 +1,34 @@
-description: Abattement pour salaire minimum
+description: Déduction supplémentaire pour les salariés payés au salaire minimum
 values:
-  2005-01-01:
+  2004-01-01:
     value: 500
-  2010-01-01:
+  2009-01-01:
     value: 1000
+  2014-01-01:
+    value: 0
 metadata:
   unit: currency
+  reference:
+    2004-01-01:
+      title: Article 49 de la loi n° 2004-90 du 31 décembre 2004 portant loi de finances pour l'année 2005, JORT n° 105 du 31 décembre 2004, p. 3440
+    2009-01-01:
+      title: Article 39 § 2 de la loi n° 2009-71 du 21 décembre 2009 portant loi de finances pour l'année 2010, JORT n° 102 du 22 décembre 2009, p. 3919
+    2014-01-01:
+      title: Abrogation par l'article 73 § 2 de la loi n° 2013-54 du 30 décembre 2013 portant loi de finances pour l'année 2014, JORT n° 105 du 31 décembre 2013, p. 3691
+  official_journal_date:
+    2014-01-01: "2013-12-31"
+documentation: |
+  Déduction supplémentaire du revenu annuel net des salariés payés au SMIG, ancien paragraphe V
+  de l'article 40 du code.
+
+  DISPOSITIF ABROGÉ à compter des revenus de 2014 par l'article 73 § 2 de la loi de finances pour
+  2014, qui lui substitue dans le même article l'exonération des revenus nets n'excédant pas
+  5 000 dinars. Le paragraphe V est absent des six millésimes du code consolidé (2019 à 2025).
+  La valeur nulle à partir de 2014 traduit cette abrogation ; le paramètre n'est pas clôturé par
+  une valeur absente parce que les formules qui le consomment le lisent sans garde.
+
+  Les années 2004 et 2009 sont des ANNÉES DE REVENUS. Les articles instituteurs n'énoncent pas de
+  date d'effet propre : elles sont dérivées de la lecture administrative de l'article final de la
+  loi (une loi de finances pour N muette produit effet sur les revenus de N-1), établie par la note
+  commune n° 33/2005 pour la loi de finances 2005 et par la note commune n° 14/2010 pour celle de
+  2010. L'abrogation, elle, est attestée par la clause propre de l'article 73 § 3.

--- a/openfisca_tunisia/parameters/impot_revenu/tspr/max_abat_sal.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/tspr/max_abat_sal.yaml
@@ -1,6 +1,29 @@
-description: Abattement sur les salaires
+description: Plafond de la déduction pour frais professionnels
 values:
   1990-01-01:
+    value: .inf
+  2017-01-01:
     value: 2000
 metadata:
   unit: currency
+  reference:
+    1990-01-01:
+      title: Article 26 § I du code de l'IRPP et de l'IS annexé à la loi n° 89-114 du 30 décembre 1989, JORT n° 1 des 2-5 janvier 1990, p. 6
+      href: https://www.pist.tn/jort/1990/1990F/Jo00190.pdf
+    2017-01-01:
+      title: Article 14 § 2 de la loi n° 2016-78 du 17 décembre 2016 portant loi de finances pour l'année 2017, JORT n° 105 du 27 décembre 2016, p. 3831
+      href: https://www.pist.tn/jort/2016/2016F/Jo1052016.pdf
+  official_journal_date:
+    2017-01-01: "2016-12-27"
+documentation: |
+  Plafond de la déduction forfaitaire pour frais professionnels sur les traitements et salaires
+  (article 26 § I du code).
+
+  CE PLAFOND N'EXISTE PAS AVANT LES REVENUS DE 2017. L'article 14 § 2 de la loi de finances pour
+  2017 le CRÉE — sa rédaction est « Est ajouté au deuxième tiret … sans que la déduction dépasse
+  2.000 dinars par an » — et non le relève. De 1990 à 2016 inclus, la déduction de 10 % s'applique
+  sans limite de montant. D'où la valeur infinie sur cette période, qui n'est pas une commodité de
+  calcul mais l'état du droit.
+
+  L'article 14 énonce sa propre date d'effet (§ 4) : « revenus réalisés à partir du 1er janvier
+  2017 ».

--- a/openfisca_tunisia/variables/prelevements_obligatoires/impot_revenu/revenus_categoriels/tspr.py
+++ b/openfisca_tunisia/variables/prelevements_obligatoires/impot_revenu/revenus_categoriels/tspr.py
@@ -91,7 +91,7 @@ class revenu_assimile_salaire_apres_abattements(Variable):
         abattement_frais_professionnels = min_(
             revenu_assimile_salaire * tspr.abat_sal, tspr.max_abat_sal
         )
-        revenu_assimile_salaire_apres_abattements = min_(
+        revenu_assimile_salaire_apres_abattements = max_(
             revenu_assimile_salaire
             - abattement_frais_professionnels
             - smig * tspr.abattement_pour_salaire_minimum,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-Tunisia"
-version = "0.70"
+version = "0.71"
 description = "OpenFisca Rules as Code model for Tunisia."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "tunisia"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-Tunisia"
-version = "0.69"
+version = "0.70"
 description = "OpenFisca Rules as Code model for Tunisia."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "tunisia"]

--- a/tests/formulas/impot_revenu/irpp.yaml
+++ b/tests/formulas/impot_revenu/irpp.yaml
@@ -141,3 +141,46 @@
     salaire_imposable: 6000
   output:
     revenu_net_imposable: 6000 * 0.9
+
+- name: Salarié 2010 - le revenu après abattements n'est pas nul
+  # Non-régression : la formule applicable avant 2011 encadrait le revenu après abattements par
+  # min_(..., 0) au lieu de max_(..., 0). Le résultat était donc systématiquement nul et l'IRPP
+  # de tous les salariés était nul pour les revenus antérieurs à 2011.
+  period: 2010
+  absolute_error_margin: 0.5
+  input:
+    male: true
+    marie: false
+    salaire_imposable: 20000
+  output:
+    # 20 000 - 10 % de frais professionnels, sans plafond avant 2017
+    revenu_assimile_salaire_apres_abattements: 18000
+    # 3 500 x 15 % + 5 000 x 20 % + 8 000 x 25 %
+    irpp: 3525
+
+- name: Salarié 2011 - continuité avec 2010
+  # Le barème et les abattements sont identiques en 2010 et 2011 : à revenu égal, l'impôt doit
+  # l'être aussi. C'est cette continuité que la formule antérieure à 2011 rompait.
+  period: 2011
+  absolute_error_margin: 0.5
+  input:
+    male: true
+    marie: false
+    salaire_imposable: 20000
+  output:
+    revenu_assimile_salaire_apres_abattements: 18000
+    irpp: 3525
+
+- name: Salarié au SMIG 2010 - le revenu après abattements reste borné à zéro
+  # La correction remplace min_ par max_ : elle ne doit pas laisser passer de revenu négatif
+  # lorsque les abattements excèdent le salaire.
+  period: 2010
+  absolute_error_margin: 0.5
+  input:
+    male: true
+    marie: false
+    smig: true
+    salaire_imposable: 1000
+  output:
+    revenu_assimile_salaire_apres_abattements: 0
+    irpp: 0

--- a/tests/formulas/impot_revenu/irpp.yaml
+++ b/tests/formulas/impot_revenu/irpp.yaml
@@ -123,6 +123,21 @@
     marie: false
     salaire_imposable: 100000
   output:
-    revenu_net_imposable: 98000
-    # 3 500 x 15 % + 5 000 x 20 % + 10 000 x 25 % + 30 000 x 30 % + 48 000 x 35 %
-    irpp: 29825
+    # 100 000 - 10 % de frais professionnels SANS PLAFOND : le plafond de 2 000 D
+    # n'est créé qu'en 2017 par l'article 14 § 2 de la loi de finances 2017.
+    revenu_net_imposable: 90000
+    # 3 500 x 15 % + 5 000 x 20 % + 10 000 x 25 % + 30 000 x 30 % + 40 000 x 35 %
+    irpp: 27025
+
+- name: Salarié au SMIG 2016 - la déduction supplémentaire est abrogée
+  # Non-régression : l'abattement pour salaire minimum est abrogé à compter des revenus 2014
+  # par l'article 73 § 2 de la loi de finances 2014. Il était encore appliqué par le modèle.
+  period: 2016
+  absolute_error_margin: 0.5
+  input:
+    male: true
+    marie: false
+    smig: true
+    salaire_imposable: 6000
+  output:
+    revenu_net_imposable: 6000 * 0.9

--- a/tests/test_contribution_personnelle_etat.py
+++ b/tests/test_contribution_personnelle_etat.py
@@ -8,7 +8,6 @@ limite supérieure de la tranche », imprimée dans le texte de loi, se déduit 
 encodé. Une erreur de seuil ou de taux casse cette seconde vérification.
 """
 
-import datetime
 
 from openfisca_tunisia import TunisiaTaxBenefitSystem
 

--- a/uv.lock
+++ b/uv.lock
@@ -1524,7 +1524,7 @@ web-api = [
 
 [[package]]
 name = "openfisca-tunisia"
-version = "0.69"
+version = "0.70"
 source = { editable = "." }
 dependencies = [
     { name = "openfisca-core", extra = ["web-api"] },

--- a/uv.lock
+++ b/uv.lock
@@ -1524,7 +1524,7 @@ web-api = [
 
 [[package]]
 name = "openfisca-tunisia"
-version = "0.70"
+version = "0.71"
 source = { editable = "." }
 dependencies = [
     { name = "openfisca-core", extra = ["web-api"] },


### PR DESCRIPTION
Empilée sur #381, elle-même sur #380. Douze erreurs de paramètres établies par dépouillement du code consolidé (six millésimes, 2019 à 2025), des lois de finances et des notes communes de la DGI.

## La correction principale : le plafond des frais professionnels n'existe pas avant 2017

`tspr/max_abat_sal.yaml` encodait **2 000 D dès 1990**. Or l'article 14 § 2 de la loi de finances 2017 le **crée** — sa rédaction est sans ambiguïté : « Est **ajouté** au deuxième tiret … *sans que la déduction dépasse 2.000 dinars par an* ». De 1990 à 2016 inclus, la déduction forfaitaire de 10 % sur les traitements et salaires s'applique **sans limite de montant**.

**Conséquence : l'assiette salariale était surestimée pour tout revenu supérieur à 20 000 D, sur vingt-sept exercices.** Pour un salaire imposable de 100 000 D en 2016, le revenu net imposable passe de 98 000 à 90 000 D et l'IRPP de 29 825 à 27 025 D.

La période sans plafond est encodée par une valeur **infinie**. Ce n'est pas une commodité de calcul : c'est l'état du droit, et `min(10 % × S, ∞)` en est la traduction exacte. L'alternative — clôturer le paramètre — casserait les trois formules qui le lisent sans garde.

Fait éditorial qui mérite d'être noté : ce plafond est la contrepartie, en haut d'assiette, de l'allègement en bas de barème opéré par le même article 14, dont l'intitulé officiel ne parle que d'« allégement de la charge fiscale des personnes physiques à faible revenu ».

## Un dispositif abrogé encore appliqué

`tspr/abattement_pour_salaire_minimum.yaml` appliquait encore la déduction supplémentaire des salariés payés au SMIG, **abrogée à compter des revenus 2014** par l'article 73 § 2 de la loi de finances 2014, qui lui substitue l'exonération à 5 000 D. Le paragraphe V de l'article 40 est **absent des six millésimes** du code consolidé.

## Corrections de dates

| Paramètre | Avant | Après | Fondement |
|---|---|---|---|
| `foncier/bati/deduction_frais` | 2007 : 30 % → 2016 : 20 % | 1990 : 30 % → **2015** : 20 % → **2024 : 25 %** | Le 30 % est d'origine ; NC 16/2016 pour 2015 ; le relèvement à 25 % **manquait entièrement** (art. 39 LF 2025) |
| `deductions/famille/infirme` | 1990/2004/2005/2010/2014/2017 | 1990/**2004**/**2009**/**2013**/2017 | La valeur de 600 D en 2004 **n'a aucun support** et est supprimée : la NC 33/2005 atteste un passage direct de 500 à 750 D |
| `deductions/famille/enf_sup` | 2010, 2014 | **2009**, **2013** | Règle de conversion |
| `deductions/famille/parent_max` et `parent_plaf` | 2018 | **2019** | NC 3/2020 |
| `minimum_impot/taux` | 2020 : 45 % | **2017-04-01** : 45 % | Art. 2 § 6 de la loi n° 2017-8, dont l'art. 23 fixe l'application au 1er avril 2017 |
| `bnc/forf/part_forf` | 2007 : 70 % → 2014 : 80 % | 1990 : 70 % → **2013** : 80 % | Le 70 % est d'origine ; 2013 dérivé, signalé comme tel |
| `tspr/abat_pen_etr` | 2007 : 80 % | **2006** : 80 % | NC 18/2007 : « pensions perçues **en 2006** » |

**Référence d'article corrigée** : le relèvement de la déduction du chef de famille et des enfants vient de l'**article 54** de la loi de finances 2018, non de l'article 55 (qui vise le § III, enfant étudiant et enfant infirme). Le code consolidé l'annote « Modifié Art 54-1 LF 2017-66 ».

## La cause commune des décalages d'un an

Presque toutes ces dates étaient fausses d'un an, pour une seule raison. Quand un article de loi de finances énonce sa propre date d'effet, elle vaut ; **quand il est muet et que seul joue l'article final de la loi, la doctrine administrative rattache la mesure aux revenus de l'année précédente**. Huit notes communes l'attestent sur vingt ans et quatre catégories de revenus.

Chaque paramètre corrigé documente désormais si sa date est **attestée par une note commune** ou **dérivée de cette règle**. Deux dates restent explicitement signalées comme non fiables plutôt que corrigées faute de source : la borne 2014 du taux de 60 % du minimum d'impôt, et la borne 2001 de l'abattement sur pensions étrangères.

## Confirmations par comparaison des millésimes

Trois corrections sont confirmées indépendamment par la seule comparaison des éditions du code consolidé, sans passer par les notes communes : le forfait foncier bâti (20 % jusqu'à l'édition 2023, 25 % dans l'édition 2025), la condition de ressources du parent à charge (SMIG en 2019, double du SMIG en 2020), et l'absence du § V de l'article 40 dans toutes les éditions.

## Tests

`uv run openfisca test --country-package openfisca_tunisia tests` : **127 passed**.

Le test de non-régression du barème 1990-2016, ajouté en #380, **encodait le plafond fautif** et a échoué : c'est exactement ce qu'on lui demande. Il est corrigé, avec le détail du calcul. Un test est ajouté sur l'abrogation de l'abattement SMIG.

## Deux bugs signalés, hors périmètre

1. **`revenu_assimile_salaire_apres_abattements`, formule antérieure à 2011**, utilise `min_(…, 0)` là où toutes les formules postérieures utilisent `max_(…, 0)`. Le revenu après abattements est donc toujours nul avant 2011. C'est un bug de formule, pas de paramètre ; il mérite sa propre PR car il change les résultats sur vingt exercices.
2. **`exoneration/seuil`** reste juridiquement ouvert alors qu'il est abrogé aux revenus 2017, parce que les formules de `contribution_sociale_solidarite` le lisent encore après cette date (voir #380).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2qMrmbL6BUDiEo3NmpU5m