### PR TITLE
fix(irpp): rétablit l'imposition des salaires avant 2011

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.71 - [#PRNUM](https://github.com/openfisca/openfisca-tunisia/pull/PRNUM)
+
+* Correction d'un bug.
+* Périodes concernées : jusqu'au 31/12/2010.
+* Zones impactées : `variables/prelevements_obligatoires/impot_revenu/revenus_categoriels/tspr`.
+* Détails :
+  - Corrige `revenu_assimile_salaire_apres_abattements` : la formule applicable avant 2011 encadrait le résultat par `min_(..., 0)` au lieu de `max_(..., 0)`. Le revenu après abattements était donc systématiquement nul, et **l'IRPP de tous les salariés était nul pour les revenus antérieurs à 2011**. Un salaire imposable de 20 000 D en 2010 donne désormais 3 525 D d'impôt au lieu de 0.
+
+<!-- -->
+
 ## 0.70 - [#382](https://github.com/openfisca/openfisca-tunisia/pull/382)
 
 * Correction d'un bug.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.71 - [#PRNUM](https://github.com/openfisca/openfisca-tunisia/pull/PRNUM)
+## 0.71 - [#383](https://github.com/openfisca/openfisca-tunisia/pull/383)
 
 * Correction d'un bug.
 * Périodes concernées : jusqu'au 31/12/2010.

--- a/openfisca_tunisia/variables/prelevements_obligatoires/impot_revenu/revenus_categoriels/tspr.py
+++ b/openfisca_tunisia/variables/prelevements_obligatoires/impot_revenu/revenus_categoriels/tspr.py
@@ -91,7 +91,7 @@ class revenu_assimile_salaire_apres_abattements(Variable):
         abattement_frais_professionnels = min_(
             revenu_assimile_salaire * tspr.abat_sal, tspr.max_abat_sal
         )
-        revenu_assimile_salaire_apres_abattements = min_(
+        revenu_assimile_salaire_apres_abattements = max_(
             revenu_assimile_salaire
             - abattement_frais_professionnels
             - smig * tspr.abattement_pour_salaire_minimum,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-Tunisia"
-version = "0.70"
+version = "0.71"
 description = "OpenFisca Rules as Code model for Tunisia."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "tunisia"]

--- a/tests/formulas/impot_revenu/irpp.yaml
+++ b/tests/formulas/impot_revenu/irpp.yaml
@@ -141,3 +141,46 @@
     salaire_imposable: 6000
   output:
     revenu_net_imposable: 6000 * 0.9
+
+- name: Salarié 2010 - le revenu après abattements n'est pas nul
+  # Non-régression : la formule applicable avant 2011 encadrait le revenu après abattements par
+  # min_(..., 0) au lieu de max_(..., 0). Le résultat était donc systématiquement nul et l'IRPP
+  # de tous les salariés était nul pour les revenus antérieurs à 2011.
+  period: 2010
+  absolute_error_margin: 0.5
+  input:
+    male: true
+    marie: false
+    salaire_imposable: 20000
+  output:
+    # 20 000 - 10 % de frais professionnels, sans plafond avant 2017
+    revenu_assimile_salaire_apres_abattements: 18000
+    # 3 500 x 15 % + 5 000 x 20 % + 8 000 x 25 %
+    irpp: 3525
+
+- name: Salarié 2011 - continuité avec 2010
+  # Le barème et les abattements sont identiques en 2010 et 2011 : à revenu égal, l'impôt doit
+  # l'être aussi. C'est cette continuité que la formule antérieure à 2011 rompait.
+  period: 2011
+  absolute_error_margin: 0.5
+  input:
+    male: true
+    marie: false
+    salaire_imposable: 20000
+  output:
+    revenu_assimile_salaire_apres_abattements: 18000
+    irpp: 3525
+
+- name: Salarié au SMIG 2010 - le revenu après abattements reste borné à zéro
+  # La correction remplace min_ par max_ : elle ne doit pas laisser passer de revenu négatif
+  # lorsque les abattements excèdent le salaire.
+  period: 2010
+  absolute_error_margin: 0.5
+  input:
+    male: true
+    marie: false
+    smig: true
+    salaire_imposable: 1000
+  output:
+    revenu_assimile_salaire_apres_abattements: 0
+    irpp: 0

--- a/tests/test_contribution_personnelle_etat.py
+++ b/tests/test_contribution_personnelle_etat.py
@@ -8,7 +8,6 @@ limite supérieure de la tranche », imprimée dans le texte de loi, se déduit 
 encodé. Une erreur de seuil ou de taux casse cette seconde vérification.
 """
 
-import datetime
 
 from openfisca_tunisia import TunisiaTaxBenefitSystem
 

--- a/uv.lock
+++ b/uv.lock
@@ -1524,7 +1524,7 @@ web-api = [
 
 [[package]]
 name = "openfisca-tunisia"
-version = "0.70"
+version = "0.71"
 source = { editable = "." }
 dependencies = [
     { name = "openfisca-core", extra = ["web-api"] },


### PR DESCRIPTION
Empilée sur #382. Un seul caractère change ; l'effet porte sur vingt et un exercices.

## Le bug

La formule de `revenu_assimile_salaire_apres_abattements` applicable aux revenus **antérieurs à 2011** encadre son résultat par `min_(..., 0)` :

```python
revenu_assimile_salaire_apres_abattements = min_(
    revenu_assimile_salaire - abattement_frais_professionnels - smig * tspr.abattement_pour_salaire_minimum,
    0,
)
```

La formule postérieure (`formula_2011`), et toutes les formules voisines, utilisent `max_(..., 0)`. Avec `min_`, le résultat est **toujours négatif ou nul** — donc nul dès que le salaire dépasse les abattements, c'est-à-dire dans tous les cas usuels.

**Conséquence : l'IRPP de tous les salariés est nul pour les revenus antérieurs à 2011**, soit vingt et un exercices, de 1990 à 2010.

## Mesure, avant et après

| Salaire imposable 20 000 D | Revenu après abattements | IRPP |
|---|---|---|
| 2005, avant | 0 | **0** |
| 2010, avant | 0 | **0** |
| 2011, avant | 18 000 | 3 525 |
| 2005, 2010 et 2011, après | 18 000 | 3 525 |

La correction rétablit la **continuité de part et d'autre de 2011**, que rien ne justifiait : le barème et les abattements sont identiques ces deux années, l'impôt doit l'être aussi. C'est le contrôle le plus parlant, et il ne dépend d'aucune source externe.

Vérification du montant à la main, sur le barème de l'article 44 § I : 3 500 × 15 % + 5 000 × 20 % + 8 000 × 25 % = 3 525 D.

## Ce que la correction ne change pas

L'encadrement à zéro reste nécessaire : lorsque les abattements excèdent le salaire, le revenu imposable doit être nul et non négatif. C'est la seule chose que faisait correctement la version d'origine, et un test la couvre explicitement — un salarié au SMIG à 1 000 D en 2010, dont les abattements dépassent le salaire, reste à zéro.

## Périmètre

Cette PR ne touche qu'à ce `min_`. La formule antérieure à 2011 diffère par ailleurs de `formula_2011` sur le traitement de l'abattement pour salaire minimum, qui ne comporte pas la branche `smig_ext`. Cet écart peut être intentionnel — la règle a pu changer en 2011 — et n'est pas tranché ici.

## Tests

`uv run openfisca test --country-package openfisca_tunisia tests` : **130 passed**.

Trois tests ajoutés : le cas de 2010 avec le détail du calcul, la continuité 2010/2011, et le maintien de la borne à zéro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2qMrmbL6BUDiEo3NmpU5m