### PR TITLE
feat(params): complète les pensions étrangères et date le minimum d'impôt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.73 - [#PRNUM](https://github.com/openfisca/openfisca-tunisia/pull/PRNUM)
+## 0.73 - [#386](https://github.com/openfisca/openfisca-tunisia/pull/386)
 
 * Correction d'un bug.
 * Périodes concernées : toutes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.73 - [#PRNUM](https://github.com/openfisca/openfisca-tunisia/pull/PRNUM)
+
+* Correction d'un bug.
+* Périodes concernées : toutes.
+* Zones impactées : `parameters/impot_revenu/tspr`, `parameters/impot_revenu/minimum_impot`.
+* Détails :
+  - Complète l'abattement sur les pensions de source étrangère, qui ne connaissait que le régime de faveur de 80 %. Trois régimes successifs sont désormais encodés et sourcés : aucun abattement de 1990 à 1996, 25 % par renvoi à l'article 26 à partir des revenus 1997 (article 61 de la loi de finances 1998), 80 % à partir des pensions perçues en 2006. La borne 2001 sans support est supprimée.
+  - Établit la date du minimum d'impôt au titre des avantages fiscaux : le taux de 60 % s'applique **à partir du 1er janvier 1999** en vertu de l'article 62 de la loi de finances pour 1998, et non de 2014 comme encodé jusqu'ici sans support.
+
+<!-- -->
+
 ## 0.72 - [#385](https://github.com/openfisca/openfisca-tunisia/pull/385)
 
 * Ajout de paramètres.

--- a/openfisca_tunisia/parameters/impot_revenu/minimum_impot/taux.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/minimum_impot/taux.yaml
@@ -2,31 +2,32 @@ description: Minimum d'impôt au titre des avantages fiscaux (article 12 bis de 
 values:
   1990-01-01:
     value: 0
-  2014-01-01:
+  1999-01-01:
     value: 0.60
   2017-04-01:
     value: 0.45
 metadata:
   unit: /1
   reference:
+    1999-01-01:
+      title: Article 62 de la loi n° 97-88 du 29 décembre 1997 portant loi de finances pour l'année 1998, JORT n° 104 des 30-31 décembre 1997, p. 2441
     2017-04-01:
-      title: Article 2 § 6 de la loi n° 2017-8 du 14 février 2017 portant refonte du dispositif des avantages fiscaux, JORT n° 15 du 21 février 2017, p. 777 ; l'article 23 fixe l'application « à partir du 1er avril 2017 »
+      title: Article 2 § 6 de la loi n° 2017-8 du 14 février 2017 portant refonte du dispositif des avantages fiscaux, JORT n° 15 du 21 février 2017, p. 778 ; l'article 23 fixe l'application « à partir du 1er avril 2017 »
 documentation: |
-  Ce paramètre est le minimum d'impôt de l'ARTICLE 12 BIS DE LA LOI N° 89-114 du 30 décembre 1989
-  portant promulgation du code — et non d'un article du code lui-même, ce qui explique qu'il soit
-  introuvable dans les millésimes consolidés. Il plafonne indirectement les avantages fiscaux :
-  quel que soit le volume de déductions mobilisées, l'impôt ne peut descendre en dessous de cette
+  Minimum d'impôt de l'ARTICLE 12 BIS DE LA LOI N° 89-114 du 30 décembre 1989 portant
+  promulgation du code — et non d'un article du code, ce qui explique qu'il soit introuvable
+  dans les millésimes consolidés. Il plafonne indirectement les avantages fiscaux : quel que
+  soit le volume de déductions mobilisées, l'impôt ne peut descendre en dessous de cette
   fraction de ce qu'il aurait été sans elles.
 
-  NE PAS CONFONDRE avec deux homonymes : l'article 44 § II du code (minimum d'impôt assis sur le
-  chiffre d'affaires) et l'article 12 bis DU CODE (amortissements).
+  NE PAS CONFONDRE avec deux homonymes : l'article 44 § II du code (minimum d'impôt assis sur
+  le chiffre d'affaires) et l'article 12 bis DU CODE (amortissements, ajouté par l'article 41
+  de la loi de finances 2008).
 
-  Date corrigée : le passage à 45 % est daté du 1er AVRIL 2017 et non de 2020. C'est la seule date
-  d'effet calendaire, en cours d'exercice, de tout ce sous-arbre ; l'exercice de rattachement n'est
-  pas établi et la valeur est donc datée au 1er avril, telle que l'énonce l'article 23.
+  DATE DU 60 % ÉTABLIE. Elle était jusqu'ici inconnue et encodée à 2014 sans support. L'article
+  62 de la loi de finances pour 1998 dispose : « Le taux de l'impôt minimum prévu par les
+  articles 12 et 12 bis de la loi n° 89-114 […] est relevé à partir du 1er janvier 1999
+  respectivement à 20% et 60%. » La date est CALENDAIRE, comme celle de 2017.
 
-  RÉSERVE : la borne 2014-01-01 pour le taux de 60 % N'A AUCUN SUPPORT ÉTABLI. Le taux de 60 %
-  existait au moins depuis 2007, et le véhicule qui l'a institué n'est pas identifié — le
-  dépouillement des lois de finances 2000-2006 est bloqué par des PDF dont la police à encodage
-  décalé supprime les chiffres à l'extraction. La valeur est conservée faute de mieux ; sa date
-  est à retenir comme non fiable.
+  Le mot « relevé » implique une valeur antérieure, inférieure à 60 %, qui reste inconnue : la
+  valeur nulle portée à 1990 est un défaut d'encodage, pas un fait établi.

--- a/openfisca_tunisia/parameters/impot_revenu/tspr/abat_pen_etr.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/tspr/abat_pen_etr.yaml
@@ -1,22 +1,38 @@
 description: Abattement sur les pensions et rentes viagères de source étrangère
 values:
-  2001-01-01:
+  1990-01-01:
     value: 0
+  1997-01-01:
+    value: 0.25
   2006-01-01:
     value: 0.8
 metadata:
   unit: /1
   reference:
+    1990-01-01:
+      title: Article 37 du code de l'IRPP et de l'IS annexé à la loi n° 89-114 du 30 décembre 1989, JORT n° 1 des 2-5 janvier 1990
+      href: https://www.pist.tn/jort/1990/1990F/Jo00190.pdf
+    1997-01-01:
+      title: Article 61 de la loi n° 97-88 du 29 décembre 1997 portant loi de finances pour l'année 1998, JORT n° 104 des 30-31 décembre 1997, p. 2441
     2006-01-01:
-      title: Article 35 de la loi n° 2006-85 du 25 décembre 2006 portant loi de finances pour l'année 2007, intitulé « Instauration d'un régime fiscal de faveur pour les pensions et les rentes viagères provenant de l'étranger » ; note commune n° 18/2007 rattachant la mesure aux « pensions et rentes perçues en 2006 et déclarées en 2007 »
+      title: Article 35 de la loi n° 2006-85 du 25 décembre 2006 portant loi de finances pour l'année 2007, intitulé « Instauration d'un régime fiscal de faveur pour les pensions et les rentes viagères provenant de l'étranger » ; note commune n° 18/2007 rattachant la mesure aux pensions perçues en 2006
 documentation: |
-  Abattement applicable aux pensions et rentes viagères de source étrangère, sous condition de
-  transfert des sommes en Tunisie (article 37 dernier alinéa du code).
+  Abattement applicable aux pensions et rentes viagères de source étrangère.
 
-  Date corrigée de 2007 à 2006 : la note commune n° 18/2007 rattache expressément la mesure aux
-  pensions perçues EN 2006.
+  Trois régimes successifs, désormais tous sourcés.
 
-  RÉSERVE : la borne 2001-01-01 n'a aucun support établi. Avant le régime de faveur, ces pensions
-  relevaient par renvoi de l'abattement de droit commun de l'article 26 (25 %), introduit par
-  l'article 61 de la loi de finances pour 1998 — valeur et date non vérifiées, la valeur nulle
-  encodée ici est donc probablement fausse pour la période antérieure à 2006.
+  1990 : aucune règle propre. L'article 37 du code, dans sa version d'origine, impose les
+  « sommes effectivement perçues de l'étranger », sans abattement.
+
+  1997 : l'article 61 de la loi de finances pour 1998 ajoute à l'article 37 un renvoi à
+  l'article 26 — « Le revenu net des traitements, salaires, pensions et rentes viagères est
+  déterminé conformément aux dispositions de l'article 26 du présent code » — ce qui étend aux
+  pensions de source étrangère l'abattement de droit commun de 25 %. L'article n'énonce pas de
+  date d'effet propre ; le rattachement aux revenus de 1997 est DÉRIVÉ de la règle générale de
+  conversion. À noter que l'article 62 de la même loi, lui, porte une clause explicite : deux
+  mesures d'une même loi de finances ne prennent pas nécessairement effet la même année.
+
+  2006 : régime de faveur de 80 %, sous condition de transfert des sommes vers un compte
+  bancaire ou postal en Tunisie et de production des justificatifs.
+
+  La borne 2001-01-01 précédemment encodée, sans valeur ni support, est supprimée.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-Tunisia"
-version = "0.72"
+version = "0.73"
 description = "OpenFisca Rules as Code model for Tunisia."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "tunisia"]

--- a/tests/test_pensions_etrangeres.py
+++ b/tests/test_pensions_etrangeres.py
@@ -1,0 +1,46 @@
+"""Pensions de source étrangère et minimum d'impôt : contrôle sur le texte publié au JORT.
+
+Les trois régimes successifs des pensions étrangères et la date du minimum d'impôt de
+l'article 12 bis de la loi n° 89-114 sont établis sur fac-similé (JORT n° 1 des 2-5 janvier
+1990 et JORT n° 104 des 30-31 décembre 1997, page 2441).
+"""
+
+from openfisca_tunisia import TunisiaTaxBenefitSystem
+
+tax_benefit_system = TunisiaTaxBenefitSystem()
+
+
+def impot_revenu(date):
+    return tax_benefit_system.get_parameters_at_instant(date).impot_revenu
+
+
+def test_pensions_etrangeres_trois_regimes():
+    # Article 37 d'origine : les « sommes effectivement perçues de l'étranger », sans abattement.
+    assert impot_revenu("1990-01-01").tspr.abat_pen_etr == 0
+    assert impot_revenu("1996-01-01").tspr.abat_pen_etr == 0
+
+    # Article 61 de la loi de finances 1998 : renvoi à l'article 26, soit 25 %.
+    assert impot_revenu("1997-01-01").tspr.abat_pen_etr == 0.25
+    assert impot_revenu("2005-01-01").tspr.abat_pen_etr == 0.25
+
+    # Article 35 de la loi de finances 2007 : régime de faveur de 80 %.
+    assert impot_revenu("2006-01-01").tspr.abat_pen_etr == 0.8
+    assert impot_revenu("2026-01-01").tspr.abat_pen_etr == 0.8
+
+
+def test_abattement_etranger_aligne_sur_le_droit_commun_entre_1997_et_2005():
+    """Le renvoi de l'article 61 aligne les pensions étrangères sur l'article 26."""
+    for annee in range(1997, 2006):
+        etranger = impot_revenu(f"{annee}-01-01").tspr.abat_pen_etr
+        droit_commun = impot_revenu(f"{annee}-01-01").tspr.abat_pen
+        assert etranger == droit_commun, annee
+
+
+def test_minimum_impot_avantages_fiscaux():
+    """« … est relevé à partir du 1er janvier 1999 respectivement à 20% et 60% » (art. 62 LF 1998)."""
+    assert impot_revenu("1998-12-31").minimum_impot.taux == 0
+    assert impot_revenu("1999-01-01").minimum_impot.taux == 0.60
+    assert impot_revenu("2017-03-31").minimum_impot.taux == 0.60
+    # Article 2 § 6 de la loi n° 2017-8, applicable « à partir du 1er avril 2017 ».
+    assert impot_revenu("2017-04-01").minimum_impot.taux == 0.45
+    assert impot_revenu("2026-01-01").minimum_impot.taux == 0.45

--- a/uv.lock
+++ b/uv.lock
@@ -1524,7 +1524,7 @@ web-api = [
 
 [[package]]
 name = "openfisca-tunisia"
-version = "0.72"
+version = "0.73"
 source = { editable = "." }
 dependencies = [
     { name = "openfisca-core", extra = ["web-api"] },


### PR DESCRIPTION
Empilée sur #385. Deux corrections tirées du **même fascicule** — le JORT n° 104 des 30-31 décembre 1997, page 2441, lu à l'image.

## Pensions de source étrangère : trois régimes au lieu d'un

Le paramètre ne connaissait que le régime de faveur de 80 %, précédé d'une borne à zéro datée de 2001 **sans aucun support**.

| Années de revenus | Abattement | Texte |
|---|---:|---|
| 1990 → 1996 | aucun | Article 37 du code : les « sommes effectivement perçues de l'étranger » |
| 1997 → 2005 | **25 %** | Article 61 de la loi n° 97-88 (LF 1998) : renvoi à l'article 26 |
| 2006 → | 80 % | Article 35 de la loi n° 2006-85 (LF 2007) ; note commune n° 18/2007 |

L'article 61 ajoute à l'article 37 : « *Le revenu net des traitements, salaires, pensions et rentes viagères est déterminé conformément aux dispositions de l'article 26 du présent code* ». Il **aligne donc ces pensions sur le droit commun** — un test le vérifie sur toute la période intermédiaire, en comparant le paramètre à `abat_pen` année par année.

L'article n'énonce pas de date d'effet propre ; le rattachement aux revenus de 1997 est **dérivé** de la règle générale de conversion et documenté comme tel. Détail éclairant : l'article **62** de la même loi, lui, porte une clause explicite — deux mesures d'une même loi de finances ne prennent pas nécessairement effet la même année.

## Minimum d'impôt : une date qu'on croyait hors d'atteinte

La date du taux de **60 %** de l'article 12 *bis* de la loi n° 89-114 était inconnue et encodée à **2014 sans support**. Le dépouillement des lois de finances 2000-2006 avait été déclaré *structurellement inopérant*, les PDF de cette période employant une police à encodage décalé qui **supprime les chiffres** à l'extraction.

Le texte se trouvait en amont de la fenêtre où on le cherchait — article 62 de la loi de finances pour 1998 :

> « Le taux de l'impôt minimum prévu par les articles 12 et 12 bis de la loi n° 89-114 du 30 décembre 1989 […] est relevé **à partir du 1er janvier 1999** respectivement à **20 % et 60 %**. »

La date est **calendaire**, comme celle du passage à 45 % au 1er avril 2017. Le paramètre porte désormais 1999 et non 2014.

Le mot « **relevé** » implique une valeur antérieure inférieure à 60 %, qui reste inconnue. La documentation dit explicitement que la valeur nulle portée à 1990 est un **défaut d'encodage et non un fait établi** — pour qu'on ne la lise pas comme une absence de minimum d'impôt avant 1999.

## Tests

`uv run openfisca test --country-package openfisca_tunisia tests` : **133 passed**.

Trois tests : les trois régimes successifs, l'alignement sur le droit commun de 1997 à 2005, et les bornes calendaires du minimum d'impôt de part et d'autre du 1er avril 2017 et du 1er janvier 1999.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2qMrmbL6BUDiEo3NmpU5m

---

## Amendements de formule appelés par ces corrections

Un paramètre ne suffit pas toujours à rendre le modèle conforme au texte. Les points ci-dessous relèvent du code et font l'objet de tickets distincts, pour ne pas mêler correction de données et changement de comportement :

- **#387** — les formules de `contribution_sociale_solidarite` lisent `impot_revenu.exoneration.seuil`, paramètre abrogé à compter des revenus 2017. Le résultat est correct par coïncidence, les deux valeurs valant 5 000 D. C'est ce couplage qui empêche de clôturer le paramètre.
- **#388** — `deduction_assurance_vie` applique la majoration à tous les enfants, alors que le texte de 1990 la réserve aux **quatre premiers**. Écart sur les revenus 1990 à 1996.
- **#389** — `interets_emprunts_obligataires` porte en réalité le **plafond global** de l'article 39 § II, et non un plafond propre aux obligations. La structure du code est juste, seuls les noms trompent ; le renommage est cassant et traité à part.
- **#390** — la formule de `revenu_assimile_salaire_apres_abattements` applicable avant 2011 n'a pas la branche `smig_ext` que porte celle de 2011. L'écart peut être intentionnel ; il faut identifier le texte instituant ce seuil pour trancher.
