### PR TITLE
fix(params): date les prestations familiales sur le texte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.74 - [#PRNUM](https://github.com/openfisca/openfisca-tunisia/pull/PRNUM)
+
+* Correction d'un bug.
+* Périodes concernées : toutes.
+* Zones impactées : `parameters/prestations/contributives/prestations_familiales`.
+* Détails :
+  - Corrige les treize valeurs des prestations familiales, toutes datées du 1er janvier 1960 alors qu'**aucune ne date de 1960**. Les taux de 18, 16 et 14 % viennent de la loi n° 75-82 (revenus 1976), le plafond de 122 dinars de la loi n° 86-75 (mai 1986) et non de la loi n° 88-38 qui était citée, la majoration pour salaire unique de la loi n° 80-36 (mai 1980), la contribution aux frais de crèche de la loi n° 94-88 et du décret n° 95-114 (octobre 1994).
+  - Ajoute l'état d'origine du barème, absent : l'article 61 de la loi n° 60-30 ne connaît qu'un taux **unique de 15 %** appliqué à une **bande d'assiette de 52 à 500 dinars**, et non un plafond simple.
+  - Crée trois paramètres sans lesquels la période 1960-1988 est inreprésentable : `af/plancher_trim` (borne basse de la bande, clôturée en 1976), `af/taux/enf4` (quatrième rang, clôturé en 1989) et `af/nb_enfants_max` (quatre enfants, ramené à trois par la loi n° 88-38).
+  - Ajoute à chaque paramètre sa référence JORT avec URL pist.tn, page et date d'effet énoncée par le texte.
+
+<!-- -->
+
 ## 0.73 - [#386](https://github.com/openfisca/openfisca-tunisia/pull/386)
 
 * Correction d'un bug.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.74 - [#PRNUM](https://github.com/openfisca/openfisca-tunisia/pull/PRNUM)
+## 0.74 - [#392](https://github.com/openfisca/openfisca-tunisia/pull/392)
 
 * Correction d'un bug.
 * Périodes concernées : toutes.

--- a/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/af/nb_enfants_max.yaml
+++ b/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/af/nb_enfants_max.yaml
@@ -1,0 +1,22 @@
+description: Nombre maximal d'enfants ouvrant droit aux allocations familiales
+values:
+  1960-01-01:
+    value: 4
+  1989-01-01:
+    value: 3
+metadata:
+  reference:
+    1960-01-01:
+      title: Article 52 de la loi n° 60-30 du 14 décembre 1960, JORT n° 57 de 1960, p. 1606
+      href: https://www.pist.tn/jort/1960/1960F/Jo05760.pdf
+    1989-01-01:
+      title: Article premier de la loi n° 88-38 du 6 mai 1988, JORT n° 33 des 13-17 mai 1988, p. 735 ; effet au 1er janvier 1989 (art. 5)
+      href: https://www.pist.tn/jort/1988/1988F/Jo03388.pdf
+documentation: |
+  PARAMÈTRE CRÉÉ. Le plafond de rang était en dur dans la formule `af_nbenf`, et à tort : elle
+  emploie `max_` là où `min_` était visé, ce qui impose un PLANCHER de trois enfants au lieu
+  d'un plafond.
+
+  Article 52 d'origine : « Le cinquième enfant et suivants, dans l'ordre de primogéniture ou
+  d'adoption, n'ouvrent, en aucun cas, droit aux allocations familiales. » L'article premier de
+  la loi n° 88-38 ramène ce nombre à trois à compter du 1er janvier 1989.

--- a/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/af/plaf_trim.yaml
+++ b/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/af/plaf_trim.yaml
@@ -1,14 +1,34 @@
-description: Plafond de revenus trimestriels
+description: Plafond de la rémunération globale trimestrielle servant d'assiette
 values:
   1960-01-01:
+    value: 500
+  1976-01-01:
+    value: 72
+  1986-05-01:
     value: 122
 metadata:
   unit: currency
-  notes:
+  reference:
     1960-01-01:
-    - title: loi n°88-38 du 6 mai 1988 complétant et modifiant la loi 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/loi_88_38_fr.pdf
-      note: "texte de base : la  loi 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale  (article 61)"
-    - title: القانون عدد 38 لسنة 1988 مؤرخ في 6 ماي 1988 يتعلق بتنقيح القاتون عدد 30 لسنة 1960 المؤرخ في 14 ديسمبر 1960 المتعلق بتنظيم انظمة الضمان الاجتماعي
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/loi_88_38_ar.pdf
-      note: "القاتون عدد 30 لسنة 1960 المؤرخ في 14 ديسمبر 1960 المتعلق بتنظيم انظمة الضمان الاجتماعي الفصل 61 :"
+      title: Article 61 de la loi n° 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale, JORT n° 57 de 1960, p. 1606
+      href: https://www.pist.tn/jort/1960/1960F/Jo05760.pdf
+    1976-01-01:
+      title: Article premier de la loi n° 75-82 du 30 décembre 1975, JORT n° 87 des 30-31 décembre 1975, p. 2852 ; effet au 1er janvier 1976 (art. 2)
+      href: https://www.pist.tn/jort/1975/1975F/Jo08775.pdf
+    1986-05-01:
+      title: Article premier de la loi n° 86-75 du 28 juillet 1986, JORT n° 43 des 1er-5 août 1986, p. 843 ; effet au 1er mai 1986 (art. 2)
+      href: https://www.pist.tn/jort/1986/1986F/Jo04386.pdf
+documentation: |
+  Plafond de la rémunération globale trimestrielle à laquelle s'appliquent les taux des
+  allocations familiales (article 61 de la loi n° 60-30).
+
+  DATE CORRIGÉE. La valeur de 122 dinars était encodée au 1er janvier 1960 en citant la loi
+  n° 88-38 de 1988 — une valeur juste rattachée à la mauvaise date, et au mauvais texte. C'est
+  la loi n° 86-75 qui porte le plafond à 122 dinars, avec effet au 1er mai 1986. Ce que la loi
+  n° 88-38 apporte, c'est la suppression du quatrième rang, non le plafond.
+
+  ATTENTION À LA PÉRIODE 1960-1975. L'article 61 d'origine ne fixe pas un plafond simple mais
+  une BANDE : les taux s'appliquent à la rémunération trimestrielle comprise entre 52 et
+  500 dinars. La borne basse est dans `plancher_trim`. La loi n° 75-82 supprime la bande au
+  profit d'un plafond unique de 72 dinars, à des taux plus élevés — la baisse apparente de
+  500 à 72 dinars n'est donc pas une coupe.

--- a/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/af/plancher_trim.yaml
+++ b/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/af/plancher_trim.yaml
@@ -1,0 +1,26 @@
+description: Plancher de la rémunération globale trimestrielle servant d'assiette
+values:
+  1960-01-01:
+    value: 52
+  1976-01-01:
+    value: null
+metadata:
+  unit: currency
+  reference:
+    1960-01-01:
+      title: Article 61 de la loi n° 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale, JORT n° 57 de 1960, p. 1606
+      href: https://www.pist.tn/jort/1960/1960F/Jo05760.pdf
+    1976-01-01:
+      title: Article premier de la loi n° 75-82 du 30 décembre 1975, JORT n° 87 des 30-31 décembre 1975, p. 2852 ; effet au 1er janvier 1976 (art. 2)
+      href: https://www.pist.tn/jort/1975/1975F/Jo08775.pdf
+documentation: |
+  Borne basse de la bande d'assiette de l'article 61 de la loi n° 60-30 dans sa rédaction
+  d'origine : les allocations familiales se calculaient sur la rémunération trimestrielle
+  comprise entre 52 et 500 dinars.
+
+  PARAMÈTRE CRÉÉ. Il manquait, et sans lui la période 1960-1975 est inreprésentable : le
+  modèle appliquait un plafond de 122 dinars, valeur de 1986, à des exercices où le régime
+  était tout autre.
+
+  La bande disparaît avec la loi n° 75-82 au profit d'un plafond unique : le paramètre est
+  clôturé au 1er janvier 1976.

--- a/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/af/taux/enf1.yaml
+++ b/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/af/taux/enf1.yaml
@@ -1,14 +1,21 @@
 description: Premier enfant à charge
 values:
   1960-01-01:
+    value: 0.15
+  1976-01-01:
     value: 0.18
 metadata:
   unit: /1
   reference:
     1960-01-01:
-    - title: loi n°88-38 du 6 mai 1988 complétant et modifiant la loi 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/loi_88_38_fr.pdf
-      note: "texte de base : la  loi 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale  (article 61)"
-    - title: القانون عدد 38 لسنة 1988 مؤرخ في 6 ماي 1988 يتعلق بتنقيح القاتون عدد 30 لسنة 1960 المؤرخ في 14 ديسمبر 1960 المتعلق بتنظيم انظمة الضمان الاجتماعي
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/loi_88_38_ar.pdf
-      note: "61قاتون عدد 30 لسنة 1960 المؤرخ في 14 ديسمبر 1960 المتعلق بتنظيم انظمة الضمان الاجتماعي : الفصل"
+      title: Article 61 de la loi n° 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale, JORT n° 57 de 1960, p. 1606
+      href: https://www.pist.tn/jort/1960/1960F/Jo05760.pdf
+    1976-01-01:
+      title: Article premier de la loi n° 75-82 du 30 décembre 1975, JORT n° 87 des 30-31 décembre 1975, p. 2852 ; effet au 1er janvier 1976 (art. 2)
+      href: https://www.pist.tn/jort/1975/1975F/Jo08775.pdf
+documentation: |
+  DATE CORRIGÉE. Le taux de 18% était encodé au 1er janvier 1960 en citant la loi n° 88-38
+  de 1988. Il date en réalité de la loi n° 75-82, avec effet au 1er janvier 1976.
+
+  L'article 61 d'origine ne connaît qu'un taux UNIQUE de 15 % par enfant, quel que soit son
+  rang. Le barème dégressif par rang — 18, 16, 14 puis 12 % — est l'apport de 1976.

--- a/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/af/taux/enf2.yaml
+++ b/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/af/taux/enf2.yaml
@@ -1,6 +1,21 @@
 description: Deuxième enfant à charge
 values:
   1960-01-01:
+    value: 0.15
+  1976-01-01:
     value: 0.16
 metadata:
   unit: /1
+  reference:
+    1960-01-01:
+      title: Article 61 de la loi n° 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale, JORT n° 57 de 1960, p. 1606
+      href: https://www.pist.tn/jort/1960/1960F/Jo05760.pdf
+    1976-01-01:
+      title: Article premier de la loi n° 75-82 du 30 décembre 1975, JORT n° 87 des 30-31 décembre 1975, p. 2852 ; effet au 1er janvier 1976 (art. 2)
+      href: https://www.pist.tn/jort/1975/1975F/Jo08775.pdf
+documentation: |
+  DATE CORRIGÉE. Le taux de 16% était encodé au 1er janvier 1960 en citant la loi n° 88-38
+  de 1988. Il date en réalité de la loi n° 75-82, avec effet au 1er janvier 1976.
+
+  L'article 61 d'origine ne connaît qu'un taux UNIQUE de 15 % par enfant, quel que soit son
+  rang. Le barème dégressif par rang — 18, 16, 14 puis 12 % — est l'apport de 1976.

--- a/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/af/taux/enf3.yaml
+++ b/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/af/taux/enf3.yaml
@@ -1,6 +1,21 @@
 description: Troisième enfant à charge
 values:
   1960-01-01:
+    value: 0.15
+  1976-01-01:
     value: 0.14
 metadata:
   unit: /1
+  reference:
+    1960-01-01:
+      title: Article 61 de la loi n° 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale, JORT n° 57 de 1960, p. 1606
+      href: https://www.pist.tn/jort/1960/1960F/Jo05760.pdf
+    1976-01-01:
+      title: Article premier de la loi n° 75-82 du 30 décembre 1975, JORT n° 87 des 30-31 décembre 1975, p. 2852 ; effet au 1er janvier 1976 (art. 2)
+      href: https://www.pist.tn/jort/1975/1975F/Jo08775.pdf
+documentation: |
+  DATE CORRIGÉE. Le taux de 14% était encodé au 1er janvier 1960 en citant la loi n° 88-38
+  de 1988. Il date en réalité de la loi n° 75-82, avec effet au 1er janvier 1976.
+
+  L'article 61 d'origine ne connaît qu'un taux UNIQUE de 15 % par enfant, quel que soit son
+  rang. Le barème dégressif par rang — 18, 16, 14 puis 12 % — est l'apport de 1976.

--- a/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/af/taux/enf4.yaml
+++ b/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/af/taux/enf4.yaml
@@ -1,0 +1,28 @@
+description: Quatrième enfant à charge
+values:
+  1960-01-01:
+    value: 0.15
+  1976-01-01:
+    value: 0.12
+  1989-01-01:
+    value: null
+metadata:
+  unit: /1
+  reference:
+    1960-01-01:
+      title: Article 61 de la loi n° 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale, JORT n° 57 de 1960, p. 1606
+      href: https://www.pist.tn/jort/1960/1960F/Jo05760.pdf
+    1976-01-01:
+      title: Article premier de la loi n° 75-82 du 30 décembre 1975, JORT n° 87 des 30-31 décembre 1975, p. 2852 ; effet au 1er janvier 1976 (art. 2)
+      href: https://www.pist.tn/jort/1975/1975F/Jo08775.pdf
+    1989-01-01:
+      title: Article premier de la loi n° 88-38 du 6 mai 1988, JORT n° 33 des 13-17 mai 1988, p. 735 ; effet au 1er janvier 1989 (art. 5)
+      href: https://www.pist.tn/jort/1988/1988F/Jo03388.pdf
+documentation: |
+  PARAMÈTRE CRÉÉ. Le quatrième rang manquait, et sans lui la période 1960-1988 est
+  inreprésentable : les allocations étaient dues pour les QUATRE premiers enfants.
+
+  L'article 52 d'origine ouvre le droit aux quatre premiers enfants, au taux unique de 15 %,
+  puis au taux de 12 % à partir des revenus de 1976. L'article premier de la loi n° 88-38
+  ramène le plafond de quatre à TROIS enfants à compter du 1er janvier 1989 : le paramètre est
+  clôturé à cette date.

--- a/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/creche/age_max.yaml
+++ b/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/creche/age_max.yaml
@@ -1,6 +1,17 @@
-description: Age (en mois) maximal
+description: Âge maximal de l'enfant, en mois
 values:
-  1960-01-01:
+  1994-10-01:
     value: 36
 metadata:
   unit: month
+  reference:
+    1994-10-01:
+      title: Loi n° 94-88 du 26 juillet 1994 et décret n° 95-114 du 16 janvier 1995 ; effet au 1er octobre 1994
+      href: https://www.pist.tn/jort/1994/1994F/Jo06094.pdf
+documentation: |
+  DATE ET BASE LÉGALE CORRIGÉES. La valeur était encodée au 1er janvier 1960 sans référence.
+  Le dispositif est institué par la loi n° 94-88 du 26 juillet 1994 et son décret d'application
+  n° 95-114 du 16 janvier 1995, avec effet au 1er octobre 1994 — soit trente-quatre ans après
+  la date encodée.
+
+  REVALORISATION NON ÉTABLIE : aucun texte modificatif repéré depuis.

--- a/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/creche/age_min.yaml
+++ b/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/creche/age_min.yaml
@@ -1,6 +1,17 @@
-description: Age (en mois) minimal
+description: Âge minimal de l'enfant, en mois
 values:
-  1960-01-01:
+  1994-10-01:
     value: 2
 metadata:
   unit: month
+  reference:
+    1994-10-01:
+      title: Loi n° 94-88 du 26 juillet 1994 et décret n° 95-114 du 16 janvier 1995 ; effet au 1er octobre 1994
+      href: https://www.pist.tn/jort/1994/1994F/Jo06094.pdf
+documentation: |
+  DATE ET BASE LÉGALE CORRIGÉES. La valeur était encodée au 1er janvier 1960 sans référence.
+  Le dispositif est institué par la loi n° 94-88 du 26 juillet 1994 et son décret d'application
+  n° 95-114 du 16 janvier 1995, avec effet au 1er octobre 1994 — soit trente-quatre ans après
+  la date encodée.
+
+  REVALORISATION NON ÉTABLIE : aucun texte modificatif repéré depuis.

--- a/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/creche/duree.yaml
+++ b/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/creche/duree.yaml
@@ -1,6 +1,17 @@
-description: Durée maximale (en mois)
+description: Durée maximale de service, en mois
 values:
-  1960-01-01:
+  1994-10-01:
     value: 11
 metadata:
   unit: month
+  reference:
+    1994-10-01:
+      title: Loi n° 94-88 du 26 juillet 1994 et décret n° 95-114 du 16 janvier 1995 ; effet au 1er octobre 1994
+      href: https://www.pist.tn/jort/1994/1994F/Jo06094.pdf
+documentation: |
+  DATE ET BASE LÉGALE CORRIGÉES. La valeur était encodée au 1er janvier 1960 sans référence.
+  Le dispositif est institué par la loi n° 94-88 du 26 juillet 1994 et son décret d'application
+  n° 95-114 du 16 janvier 1995, avec effet au 1er octobre 1994 — soit trente-quatre ans après
+  la date encodée.
+
+  REVALORISATION NON ÉTABLIE : aucun texte modificatif repéré depuis.

--- a/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/creche/montant.yaml
+++ b/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/creche/montant.yaml
@@ -1,6 +1,17 @@
-description: Montant
+description: Montant mensuel de la contribution
 values:
-  1960-01-01:
+  1994-10-01:
     value: 15
 metadata:
   unit: currency
+  reference:
+    1994-10-01:
+      title: Loi n° 94-88 du 26 juillet 1994 et décret n° 95-114 du 16 janvier 1995 ; effet au 1er octobre 1994
+      href: https://www.pist.tn/jort/1994/1994F/Jo06094.pdf
+documentation: |
+  DATE ET BASE LÉGALE CORRIGÉES. La valeur était encodée au 1er janvier 1960 sans référence.
+  Le dispositif est institué par la loi n° 94-88 du 26 juillet 1994 et son décret d'application
+  n° 95-114 du 16 janvier 1995, avec effet au 1er octobre 1994 — soit trente-quatre ans après
+  la date encodée.
+
+  REVALORISATION NON ÉTABLIE : aucun texte modificatif repéré depuis.

--- a/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/creche/plaf.yaml
+++ b/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/creche/plaf.yaml
@@ -1,6 +1,17 @@
-description: Plafond de ressources (en SMIG 48h)
+description: Plafond de revenu, en multiples du SMIG 48 heures
 values:
-  1960-01-01:
+  1994-10-01:
     value: 2.5
 metadata:
   unit: /1
+  reference:
+    1994-10-01:
+      title: Loi n° 94-88 du 26 juillet 1994 et décret n° 95-114 du 16 janvier 1995 ; effet au 1er octobre 1994
+      href: https://www.pist.tn/jort/1994/1994F/Jo06094.pdf
+documentation: |
+  DATE ET BASE LÉGALE CORRIGÉES. La valeur était encodée au 1er janvier 1960 sans référence.
+  Le dispositif est institué par la loi n° 94-88 du 26 juillet 1994 et son décret d'application
+  n° 95-114 du 16 janvier 1995, avec effet au 1er octobre 1994 — soit trente-quatre ans après
+  la date encodée.
+
+  REVALORISATION NON ÉTABLIE : aucun texte modificatif repéré depuis.

--- a/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/salaire_unique/enf1.yaml
+++ b/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/salaire_unique/enf1.yaml
@@ -1,6 +1,26 @@
-description: Premier enfant à charge
+description: Majoration trimestrielle pour un enfant à charge
 values:
-  1960-01-01:
+  1980-05-01:
     value: 9.375
 metadata:
   unit: currency
+  reference:
+    1980-05-01:
+      title: Article 65 bis de la loi n° 60-30, ajouté par l'article premier de la loi n° 80-36 du 28 mai 1980, JORT n° 32 des 27-30 mai 1980, p. 1478 ; effet au 1er mai 1980 (art. 2)
+      href: https://www.pist.tn/jort/1980/1980F/Jo03280.pdf
+documentation: |
+  DATE ET TEXTE CORRIGÉS. La valeur était encodée au 1er janvier 1960 sans aucune référence.
+  Le dispositif n'existe pas en 1960 : il est CRÉÉ par la loi n° 80-36 du 28 mai 1980, qui
+  ajoute au chapitre premier du titre II de la loi n° 60-30 une « SECTION I bis — Majoration
+  pour Salaire Unique » et un article 65 bis, avec effet au 1er mai 1980.
+
+  Le texte fondateur était réputé introuvable : son intitulé ne porte que « complétant la loi
+  n° 60-30 » et aucune recherche par titre ne pouvait l'atteindre. Le décret n° 74-463, seul
+  texte dont le titre porte l'expression « majoration pour salaire unique », ne la contient
+  pas dans son dispositif — il accorde aux militaires « les indemnités à caractère familial ».
+
+  Conditions cumulatives de l'article 65 bis : enfants à charge au sens de l'article 53, droit
+  ouvert aux allocations familiales, et conjoint sans activité professionnelle.
+
+  REVALORISATION NON ÉTABLIE : aucun texte modificatif n'a été repéré depuis 1980. Le montant
+  serait donc nominalement gelé, ce qui est plausible mais non vérifié.

--- a/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/salaire_unique/enf2.yaml
+++ b/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/salaire_unique/enf2.yaml
@@ -1,6 +1,26 @@
-description: Deuxième enfant à charge
+description: Majoration trimestrielle pour deux enfants à charge
 values:
-  1960-01-01:
+  1980-05-01:
     value: 18.75
 metadata:
   unit: currency
+  reference:
+    1980-05-01:
+      title: Article 65 bis de la loi n° 60-30, ajouté par l'article premier de la loi n° 80-36 du 28 mai 1980, JORT n° 32 des 27-30 mai 1980, p. 1478 ; effet au 1er mai 1980 (art. 2)
+      href: https://www.pist.tn/jort/1980/1980F/Jo03280.pdf
+documentation: |
+  DATE ET TEXTE CORRIGÉS. La valeur était encodée au 1er janvier 1960 sans aucune référence.
+  Le dispositif n'existe pas en 1960 : il est CRÉÉ par la loi n° 80-36 du 28 mai 1980, qui
+  ajoute au chapitre premier du titre II de la loi n° 60-30 une « SECTION I bis — Majoration
+  pour Salaire Unique » et un article 65 bis, avec effet au 1er mai 1980.
+
+  Le texte fondateur était réputé introuvable : son intitulé ne porte que « complétant la loi
+  n° 60-30 » et aucune recherche par titre ne pouvait l'atteindre. Le décret n° 74-463, seul
+  texte dont le titre porte l'expression « majoration pour salaire unique », ne la contient
+  pas dans son dispositif — il accorde aux militaires « les indemnités à caractère familial ».
+
+  Conditions cumulatives de l'article 65 bis : enfants à charge au sens de l'article 53, droit
+  ouvert aux allocations familiales, et conjoint sans activité professionnelle.
+
+  REVALORISATION NON ÉTABLIE : aucun texte modificatif n'a été repéré depuis 1980. Le montant
+  serait donc nominalement gelé, ce qui est plausible mais non vérifié.

--- a/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/salaire_unique/enf3.yaml
+++ b/openfisca_tunisia/parameters/prestations/contributives/prestations_familiales/salaire_unique/enf3.yaml
@@ -1,6 +1,26 @@
-description: Troisième enfant
+description: Majoration trimestrielle pour trois enfants à charge ou plus
 values:
-  1960-01-01:
+  1980-05-01:
     value: 23.475
 metadata:
   unit: currency
+  reference:
+    1980-05-01:
+      title: Article 65 bis de la loi n° 60-30, ajouté par l'article premier de la loi n° 80-36 du 28 mai 1980, JORT n° 32 des 27-30 mai 1980, p. 1478 ; effet au 1er mai 1980 (art. 2)
+      href: https://www.pist.tn/jort/1980/1980F/Jo03280.pdf
+documentation: |
+  DATE ET TEXTE CORRIGÉS. La valeur était encodée au 1er janvier 1960 sans aucune référence.
+  Le dispositif n'existe pas en 1960 : il est CRÉÉ par la loi n° 80-36 du 28 mai 1980, qui
+  ajoute au chapitre premier du titre II de la loi n° 60-30 une « SECTION I bis — Majoration
+  pour Salaire Unique » et un article 65 bis, avec effet au 1er mai 1980.
+
+  Le texte fondateur était réputé introuvable : son intitulé ne porte que « complétant la loi
+  n° 60-30 » et aucune recherche par titre ne pouvait l'atteindre. Le décret n° 74-463, seul
+  texte dont le titre porte l'expression « majoration pour salaire unique », ne la contient
+  pas dans son dispositif — il accorde aux militaires « les indemnités à caractère familial ».
+
+  Conditions cumulatives de l'article 65 bis : enfants à charge au sens de l'article 53, droit
+  ouvert aux allocations familiales, et conjoint sans activité professionnelle.
+
+  REVALORISATION NON ÉTABLIE : aucun texte modificatif n'a été repéré depuis 1980. Le montant
+  serait donc nominalement gelé, ce qui est plausible mais non vérifié.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-Tunisia"
-version = "0.73"
+version = "0.74"
 description = "OpenFisca Rules as Code model for Tunisia."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "tunisia"]

--- a/tests/test_prestations_familiales.py
+++ b/tests/test_prestations_familiales.py
@@ -1,0 +1,89 @@
+"""Prestations familiales : contrôle des séries sur le texte publié au JORT.
+
+Les quatre états successifs de l'article 61 de la loi n° 60-30 sont relevés sur fac-similé.
+Aucune valeur du dispositif ne date de 1960, contrairement à ce qui était encodé.
+"""
+
+from openfisca_tunisia import TunisiaTaxBenefitSystem
+
+tax_benefit_system = TunisiaTaxBenefitSystem()
+
+
+def pf(date):
+    parametres = tax_benefit_system.get_parameters_at_instant(date)
+    return parametres.prestations.contributives.prestations_familiales
+
+
+def test_les_quatre_ages_du_bareme():
+    """Article 61 : taux unique en 1960, barème dégressif en 1976, 4e rang supprimé en 1989."""
+    # 1960 : taux UNIQUE de 15 %, bande d'assiette 52-500 D, quatre rangs.
+    a = pf("1960-01-01").af
+    assert (a.taux.enf1, a.taux.enf2, a.taux.enf3, a.taux.enf4) == (0.15, 0.15, 0.15, 0.15)
+    assert a.plancher_trim == 52
+    assert a.plaf_trim == 500
+    assert a.nb_enfants_max == 4
+
+    # 1976 (loi n° 75-82) : barème dégressif, plafond unique de 72 D, plus de bande.
+    a = pf("1976-01-01").af
+    assert (a.taux.enf1, a.taux.enf2, a.taux.enf3, a.taux.enf4) == (0.18, 0.16, 0.14, 0.12)
+    assert a.plaf_trim == 72
+    assert a.nb_enfants_max == 4
+
+    # 1986 (loi n° 86-75) : plafond porté à 122 D, taux inchangés.
+    a = pf("1986-05-01").af
+    assert a.plaf_trim == 122
+    assert (a.taux.enf1, a.taux.enf2, a.taux.enf3, a.taux.enf4) == (0.18, 0.16, 0.14, 0.12)
+
+    # 1989 (loi n° 88-38) : le quatrième rang est supprimé, le plafond ne bouge pas.
+    a = pf("1989-01-01").af
+    assert a.plaf_trim == 122
+    assert a.nb_enfants_max == 3
+
+
+def test_le_plafond_de_122_dinars_ne_date_pas_de_1960():
+    """Non-régression : la valeur était encodée au 1er janvier 1960 en citant un texte de 1988."""
+    assert pf("1960-01-01").af.plaf_trim == 500
+    assert pf("1985-12-31").af.plaf_trim == 72
+    assert pf("1986-05-01").af.plaf_trim == 122
+
+
+def test_le_quatrieme_rang_et_le_plancher_sont_cloture_aux_bonnes_dates():
+    """Deux paramètres n'existent que sur une période bornée ; hors d'elle, ils sont absents."""
+    import pytest
+    from openfisca_core.errors import ParameterNotFoundError
+
+    # Le plancher d'assiette disparaît avec la bande, en 1976.
+    assert pf("1975-12-31").af.plancher_trim == 52
+    with pytest.raises(ParameterNotFoundError):
+        pf("1976-01-01").af.plancher_trim
+
+    # Le quatrième rang disparaît en 1989.
+    assert pf("1988-12-31").af.taux.enf4 == 0.12
+    with pytest.raises(ParameterNotFoundError):
+        pf("1989-01-01").af.taux.enf4
+
+
+def test_majoration_pour_salaire_unique_nexiste_pas_avant_1980():
+    """Le dispositif est créé par la loi n° 80-36, effet au 1er mai 1980."""
+    import pytest
+    from openfisca_core.errors import ParameterNotFoundError
+
+    with pytest.raises(ParameterNotFoundError):
+        pf("1980-04-30").salaire_unique.enf1
+
+    su = pf("1980-05-01").salaire_unique
+    assert (su.enf1, su.enf2, su.enf3) == (9.375, 18.750, 23.475)
+
+
+def test_contribution_creche_ne_date_pas_de_1960():
+    """Loi n° 94-88 et décret n° 95-114, effet au 1er octobre 1994."""
+    import pytest
+    from openfisca_core.errors import ParameterNotFoundError
+
+    with pytest.raises(ParameterNotFoundError):
+        pf("1994-09-30").creche.montant
+
+    c = pf("1994-10-01").creche
+    assert c.montant == 15
+    assert (c.age_min, c.age_max, c.duree) == (2, 36, 11)
+    assert c.plaf == 2.5

--- a/uv.lock
+++ b/uv.lock
@@ -1524,7 +1524,7 @@ web-api = [
 
 [[package]]
 name = "openfisca-tunisia"
-version = "0.73"
+version = "0.74"
 source = { editable = "." }
 dependencies = [
     { name = "openfisca-core", extra = ["web-api"] },


### PR DESCRIPTION
Les **treize valeurs** du sous-arbre `prestations/contributives/prestations_familiales/` étaient datées du **1er janvier 1960**. Aucune ne date de 1960.

Le dépouillement des **seize lois** modifiant la loi n° 60-30, ouvertes une par une et lues à l'image, établit **quatre états successifs** de son article 61 :

| Depuis | Texte | Taux par rang | Assiette trimestrielle |
|---|---|---|---|
| 1960 | loi n° 60-30, art. 61 | **15 %** uniforme | **bande 52 – 500 D** |
| **1er janvier 1976** | loi n° 75-82, art. 1er | **18 / 16 / 14 / 12 %** | plafond **72 D** |
| **1er mai 1986** | loi n° 86-75, art. 1er | inchangés | plafond **122 D** |
| **1er janvier 1989** | loi n° 88-38, art. 1er | **18 / 16 / 14 %** — 4ᵉ rang supprimé | 122 D, inchangé |

**Le plafond de 122 dinars vient de la loi n° 86-75, non de la loi n° 88-38** — qui était pourtant la seule référence citée par le paramètre. Ce que la loi n° 88-38 apporte, c'est la **suppression du quatrième rang**.

**La baisse apparente de 500 à 72 dinars n'est pas une coupe** : l'article d'origine applique un taux unique à une **bande d'assiette**, remplacée en 1976 par un plafond unique à des taux plus élevés.

## Trois paramètres créés

Sans eux, la période **1960-1988 est inreprésentable** — le modèle appliquait un plafond de 1986 et un barème de 1976 à des exercices où le régime était tout autre.

- **`af/plancher_trim`** — borne basse de la bande (52 D), clôturée en 1976 quand la bande disparaît ;
- **`af/taux/enf4`** — quatrième rang, à 15 % puis 12 %, clôturé en 1989 ;
- **`af/nb_enfants_max`** — quatre enfants, ramené à trois par la loi n° 88-38. Cette valeur était jusqu'ici une **constante en dur** dans `af_nbenf`, qui l'emploie de surcroît comme un **plancher** (`max_` au lieu de `min_`).

## Deux autres dispositifs, tout aussi mal datés

**La majoration pour salaire unique n'existe pas en 1960** : elle est créée par la **loi n° 80-36 du 28 mai 1980**, qui ajoute à la loi n° 60-30 une « SECTION I bis » et un **article 65 bis**, effet au 1er mai 1980. Son intitulé ne porte que « complétant la loi n° 60-30 » — **aucune recherche par titre ne pouvait l'atteindre**, ce qui explique qu'elle ait été réputée introuvable. Le décret n° 74-463, seul texte dont le titre porte l'expression, ne la contient pas dans son dispositif.

**La contribution aux frais de crèche** date de la loi n° 94-88 et du décret n° 95-114, effet au **1er octobre 1994** — soit trente-quatre ans après la date encodée.

## Ce qui n'est pas traité ici

Les corrections mettent au jour **quatre variables incalculables et deux formules fausses**, dont `af` lui-même. Elles font l'objet du ticket **#391**, pour ne pas mêler correction de données et changement de comportement. Aucune de ces variables n'est couverte par un test — la couverture et les pannes sont exactement complémentaires.

Deux lacunes assumées : la **revalorisation** de la majoration pour salaire unique et de la contribution crèche n'est pas établie. Aucun texte modificatif n'a été repéré ; les montants seraient nominalement gelés depuis 1980 et 1994, ce qui est plausible mais non vérifié. Les paramètres le disent.

## Tests

`uv run openfisca test --country-package openfisca_tunisia tests` : **135 passed**.

Cinq tests ajoutés, dont un qui vérifie que les paramètres bornés **n'existent pas** hors de leur période — c'est la seule façon d'empêcher qu'on réapplique un plafond de 1986 à un exercice de 1970.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2qMrmbL6BUDiEo3NmpU5m