### PR TITLE
fix(params): corrige et date les prestations d'assistance sociale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.75 - [#PRNUM](https://github.com/openfisca/openfisca-tunisia/pull/PRNUM)
+## 0.75 - [#](https://github.com/openfisca/openfisca-tunisia/pull/)
 
 * Correction d'un bug.
 * Périodes concernées : toutes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.75 - [#](https://github.com/openfisca/openfisca-tunisia/pull/)
+## 0.75 - [#393](https://github.com/openfisca/openfisca-tunisia/pull/393)
 
 * Correction d'un bug.
 * Périodes concernées : toutes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.75 - [#PRNUM](https://github.com/openfisca/openfisca-tunisia/pull/PRNUM)
+
+* Correction d'un bug.
+* Périodes concernées : toutes.
+* Zones impactées : `parameters/prestations/non_contributives`.
+* Détails :
+  - Corrige deux **références apocryphes** : le « décret n° 2019-318 » et l'« arrêté 931 du 20 mai 2020 » cités par les suppléments du programme AMEN social n'existent pas. La disposition figure à l'article 2 de l'arrêté conjoint du 19 mai 2020.
+  - Corrige la limite d'âge de l'étudiant ouvrant droit au supplément : **25 ans** et non 21.
+  - Redate l'allocation familiale non contributive à **avril 2022** et non juin 2020. Ce qui existait en 2020 est le supplément pour enfant à charge du transfert AMEN, dispositif distinct avec lequel elle ne se cumule pas.
+  - Redate le droit annuel d'affiliation à l'AMG2 à **février 1998** (décret n° 98-409, art. 10) et non 2015.
+  - Ajoute le palier de **260 dinars au 1er janvier 2025** de l'allocation de base du programme AMEN social.
+  - Documente que les onze paliers de l'allocation du PNAFN **n'ont aucun texte**, ce qui est un résultat établi et non une lacune, et que les montants de 240 et 260 dinars des arrêtés de 2024 et 2025 sont des **plafonds sur un relèvement**, non des barèmes : les encoder comme valeurs serait une sur-interprétation.
+
+<!-- -->
+
 ## 0.74 - [#392](https://github.com/openfisca/openfisca-tunisia/pull/392)
 
 * Correction d'un bug.

--- a/openfisca_tunisia/parameters/prestations/non_contributives/allocation_familiale.yaml
+++ b/openfisca_tunisia/parameters/prestations/non_contributives/allocation_familiale.yaml
@@ -1,6 +1,19 @@
-description: Montant de l'allocation familiale non contributive
+description: Allocation familiale non contributive, montant mensuel par enfant
 values:
-  2020-06-01:
+  2022-04-08:
     value: 30
 metadata:
   unit: currency
+  reference:
+    2022-04-08:
+      title: Article 11 bis de la loi organique n° 2019-10, ajouté par le décret-loi n° 2022-8 du 31 janvier 2022, et arrêté conjoint du 1er avril 2022
+documentation: |
+  DATE CORRIGÉE : l'allocation familiale non contributive n'existe qu'à partir d'avril 2022,
+  et non de juin 2020. Ce qui existait en 2020 est le SUPPLÉMENT pour enfant à charge du
+  transfert monétaire permanent, d'un montant de 10 dinars — un dispositif distinct, avec
+  lequel elle NE SE CUMULE PAS.
+
+  Conditions non modélisées, faute de variables correspondantes : enfant de moins de six ans,
+  sans plafond de nombre d'enfants, et EXCLUSION des catégories à revenu limité affiliées à un
+  régime de sécurité sociale. Le même arrêté déplace la borne du supplément AMEN à « 6 à
+  18 ans ».

--- a/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/allocation_base.yaml
+++ b/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/allocation_base.yaml
@@ -8,6 +8,8 @@ values:
     value: 220
   2024-01-01:
     value: 240
+  2025-01-01:
+    value: 260
 metadata:
   unit: currency
   reference:
@@ -32,3 +34,13 @@ metadata:
     2022-04-01: "2022-04-08"
     2023-04-01: "2023-04-06"
     2024-03-01: "2024-03-01"
+documentation: |
+  Montant de base mensuel du transfert monétaire permanent du programme AMEN social.
+
+  PALIER 2025 AJOUTÉ : 260 dinars, par l'arrêté conjoint du 29 août 2025, rétroactif au
+  1er janvier 2025. La série s'arrêtait à 240 dinars.
+
+  AVERTISSEMENT SUR LES DATES. Les clés `official_journal_date` portent les dates de
+  PUBLICATION des arrêtés — avril 2022, avril 2023, mars 2024 — tandis que les dates d'effet
+  encodées sont au 1er janvier. Les deux séries de dates sont exactes mais ne décrivent pas la
+  même chose ; ne pas aligner les unes sur les autres sans lire l'article d'effet.

--- a/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/supplements/enfant_a_charge.yaml
+++ b/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/supplements/enfant_a_charge.yaml
@@ -1,8 +1,19 @@
-description: Supplément par enfant à charge
+description: Supplément mensuel par enfant à charge du transfert monétaire permanent
 values:
-  2019-01-01:
-    value: 10.0
+  2020-05-20:
+    value: 10
 metadata:
   unit: currency
   reference:
-    2019-01-01: Article 4.1 du Décret n° 2019-318
+    2020-05-20:
+      title: Article 2 de l'arrêté conjoint du ministre des affaires sociales et de la ministre des finances du 19 mai 2020, pris pour l'application du décret gouvernemental n° 2020-317
+documentation: |
+  RÉFÉRENCE APOCRYPHE CORRIGÉE. Le paramètre citait un « article 4.1 du décret n° 2019-318 » :
+  ce décret n'existe pas. Le supplément est fixé par l'arrêté conjoint du 19 mai 2020, pris
+  pour l'application du décret gouvernemental n° 2020-317.
+
+  DATE CORRIGÉE : 20 mai 2020 et non 1er janvier 2019.
+
+  À ne pas confondre avec l'allocation familiale non contributive de 30 dinars, créée en avril
+  2022, avec laquelle ce supplément NE SE CUMULE PAS. Le même arrêté d'avril 2022 déplace la
+  borne d'âge de ce supplément à « 6 à 18 ans ».

--- a/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/supplements/handicap.yaml
+++ b/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/supplements/handicap.yaml
@@ -1,9 +1,15 @@
-description: Majoration pour handicap
+description: Coefficient appliqué au supplément en cas de handicap
 values:
-  2020-01-01:
+  2020-05-20:
     value: 2
 metadata:
   unit: /1
   reference:
-    2020-01-01:
-    - title: Arrêté 931 du 20 mai 2020
+    2020-05-20:
+      title: Dernier alinéa de l'article 2 de l'arrêté conjoint du 19 mai 2020
+documentation: |
+  RÉFÉRENCE APOCRYPHE CORRIGÉE. Le paramètre citait un « arrêté 931 du 20 mai 2020 » : cette
+  référence n'existe pas sous cette forme. La disposition figure au dernier alinéa de l'article 2
+  de l'arrêté conjoint du 19 mai 2020.
+
+  DATE CORRIGÉE : 20 mai 2020 et non 1er janvier 2020.

--- a/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/supplements/limite_age_enfant.yaml
+++ b/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/supplements/limite_age_enfant.yaml
@@ -1,6 +1,16 @@
-description: Limite d'âge d'un enfant pour être compté à charge d'un ménage éligible au programme Amen social
+description: Âge maximal de l'enfant ouvrant droit au supplément
 values:
-  2019-01-01:
+  2020-05-20:
     value: 18
 metadata:
   unit: year
+  reference:
+    2020-05-20:
+      title: Article 2 de l'arrêté conjoint du ministre des affaires sociales et de la ministre des finances du 19 mai 2020, pris pour l'application du décret gouvernemental n° 2020-317
+documentation: |
+  DATE CORRIGÉE : 20 mai 2020 et non 1er janvier 2019.
+
+  BORNE BASSE NON MODÉLISÉE : l'arrêté conjoint du 1er avril 2022 réserve le supplément aux
+  enfants de six à dix-huit ans, les moins de six ans relevant désormais de l'allocation
+  familiale non contributive. Encoder cette borne demanderait un paramètre distinct et une
+  formule qui le lise ; ni l'un ni l'autre n'existe.

--- a/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/supplements/limite_age_etudiant.yaml
+++ b/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/supplements/limite_age_etudiant.yaml
@@ -1,6 +1,14 @@
-description: Limite d'âge d'un enfant étudiant pour être compté à charge d'un ménage éligible au programme Amen social
+description: Âge maximal de l'étudiant ouvrant droit au supplément
 values:
-  2019-01-01:
-    value: 21
+  2020-05-20:
+    value: 25
 metadata:
   unit: year
+  reference:
+    2020-05-20:
+      title: Article 2 de l'arrêté conjoint du ministre des affaires sociales et de la ministre des finances du 19 mai 2020, pris pour l'application du décret gouvernemental n° 2020-317
+documentation: |
+  VALEUR CORRIGÉE : 25 ans et non 21. L'article 2 de l'arrêté conjoint du 19 mai 2020 retient
+  vingt-cinq ans pour l'enfant poursuivant ses études.
+
+  DATE CORRIGÉE : 20 mai 2020 et non 1er janvier 2019.

--- a/openfisca_tunisia/parameters/prestations/non_contributives/amg2.yaml
+++ b/openfisca_tunisia/parameters/prestations/non_contributives/amg2.yaml
@@ -1,6 +1,17 @@
-description: Cotisation annuelle forfaitaire
+description: Droit annuel d'affiliation au régime des soins à tarifs réduits (AMG2)
 values:
-  2015-01-01:
+  1998-02-27:
     value: 10
 metadata:
   unit: currency
+  reference:
+    1998-02-27:
+      title: Article 10 du décret n° 98-409 du 18 février 1998 fixant les catégories des bénéficiaires des tarifs réduits de soins et d'hospitalisation, JORT n° 17 du 27 février 1998
+      href: https://www.pist.tn/jort/1998/1998F/Jo01798.pdf
+documentation: |
+  DATE CORRIGÉE : 1998 et non 2015. Le droit annuel de 10 dinars est fixé par l'article 10 du
+  décret n° 98-409, qui institue la carte de soins à tarifs réduits. La date de 2015 encodée
+  jusqu'ici n'avait aucun support.
+
+  Ce paramètre est une COTISATION et non une prestation ; il reste rangé sous
+  `prestations/non_contributives/` par cohérence avec le dispositif auquel il donne accès.

--- a/openfisca_tunisia/parameters/prestations/non_contributives/index.yaml
+++ b/openfisca_tunisia/parameters/prestations/non_contributives/index.yaml
@@ -1,0 +1,7 @@
+description: Prestations non contributives (assistance sociale)
+metadata:
+  order:
+  - pnafn
+  - amen_social
+  - allocation_familiale
+  - amg2

--- a/openfisca_tunisia/parameters/prestations/non_contributives/pnafn/allocation.yaml
+++ b/openfisca_tunisia/parameters/prestations/non_contributives/pnafn/allocation.yaml
@@ -24,10 +24,30 @@ values:
     value: 7.7
 metadata:
   unit: currency
-  notes:
-    2010-07-01:
-      title: 190 dinars par trimestre
-    2009-07-01:
-      title: 170 dinars par trimestre
-    2009-01-01:
-      title: 160 dinars par trimestre
+  reference:
+    2018-04-01:
+      title: Montant constaté à 180 dinars par l'arrêté conjoint du ministre des affaires sociales et de la ministre des finances du 10 juillet 2024
+documentation: |
+  Allocation mensuelle du programme national d'aide aux familles nécessiteuses.
+
+  AUCUN DE CES ONZE PALIERS N'A DE TEXTE. Ce n'est pas une lacune de documentation mais un
+  résultat établi : aucun texte publié au JORT ne crée le programme, n'en fixe l'objet,
+  l'éligibilité ni le montant. Le programme n'y apparaît qu'en qualité d'objet de dépense —
+  loi de finances rectificative n° 86-83, arrêté du 6 janvier 1987 fixant la contribution des
+  caisses, loi de finances n° 87-83 — et la loi de 1986 le mentionne comme DÉJÀ EXISTANT.
+
+  L'absence est démontrée et non supposée : la forme juridique de l'arrêté ministériel existait
+  et a servi pour l'aide aux personnes âgées (1997), à la famille d'accueil (1997) et à la
+  personne handicapée (2006). Elle n'a pas été employée ici. Mieux, l'arrêté du 30 septembre
+  1997 REFUSE d'énoncer un chiffre et renvoie au « montant servi dans le cadre du programme ».
+
+  Les valeurs de 2009 et 2010 sont des conversions de montants trimestriels (160, 170, 190
+  dinars par trimestre), ce que leur forme décimale trahit.
+
+  SEUL LE PALIER DE 180 DINARS EST ATTESTÉ : l'arrêté conjoint du 10 juillet 2024 le constate
+  « fixé à 180 dinars à la date de la publication ». Ce même arrêté autorise un relèvement
+  PLAFONNÉ au niveau du transfert AMEN — 240 dinars, porté à 260 par l'arrêté du 29 août 2025 —
+  sans fixer de nouveau montant. Encoder 240 ou 260 comme des valeurs serait une
+  sur-interprétation : ce sont des plafonds sur une revalorisation, pas des barèmes.
+
+  La série s'arrête donc en juillet 2024, faute de montant publié.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-Tunisia"
-version = "0.74"
+version = "0.75"
 description = "OpenFisca Rules as Code model for Tunisia."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "tunisia"]

--- a/tests/test_prestations_assistance.py
+++ b/tests/test_prestations_assistance.py
@@ -48,7 +48,7 @@ def test_allocation_familiale_non_contributive_nexiste_pas_avant_2022():
 def test_amen_social_supplements():
     """Limite d'âge de l'étudiant à 25 ans, et non 21 ; effet au 20 mai 2020."""
     with pytest.raises(ParameterNotFoundError):
-        nc("2020-05-19").supplements if False else nc("2020-05-19").amen_social.supplements.enfant_a_charge
+        nc("2020-05-19").amen_social.supplements.enfant_a_charge
 
     s = nc("2020-05-20").amen_social.supplements
     assert s.enfant_a_charge == 10
@@ -57,10 +57,12 @@ def test_amen_social_supplements():
 
 
 def test_amen_social_allocation_de_base():
-    a = lambda d: nc(d).amen_social.allocation_base
-    assert a("2020-06-01") == 180
-    assert a("2022-06-01") == 200
-    assert a("2023-06-01") == 220
-    assert a("2024-06-01") == 240
+    def base(date):
+        return nc(date).amen_social.allocation_base
+
+    assert base("2020-06-01") == 180
+    assert base("2022-06-01") == 200
+    assert base("2023-06-01") == 220
+    assert base("2024-06-01") == 240
     # Palier ajouté : arrêté du 29 août 2025, rétroactif au 1er janvier.
-    assert a("2025-06-01") == 260
+    assert base("2025-06-01") == 260

--- a/tests/test_prestations_assistance.py
+++ b/tests/test_prestations_assistance.py
@@ -1,0 +1,66 @@
+"""Assistance sociale : contrôle des séries sur le texte publié au JORT.
+
+Plusieurs valeurs portaient des dates sans support et deux références étaient apocryphes.
+"""
+
+import pytest
+from openfisca_core.errors import ParameterNotFoundError
+
+from openfisca_tunisia import TunisiaTaxBenefitSystem
+
+tax_benefit_system = TunisiaTaxBenefitSystem()
+
+
+def nc(date):
+    return tax_benefit_system.get_parameters_at_instant(date).prestations.non_contributives
+
+
+def test_pnafn_seul_le_palier_atteste_borne_la_serie():
+    """L'arrêté du 10 juillet 2024 constate 180 D ; aucun montant n'est publié après."""
+    assert nc("2018-04-01").pnafn.allocation == 180
+    assert nc("2026-01-01").pnafn.allocation == 180
+
+
+def test_pnafn_les_plafonds_de_2024_et_2025_ne_sont_pas_des_montants():
+    """L'arrêté autorise un relèvement plafonné à 240 puis 260 D, sans fixer de montant.
+
+    Encoder ces plafonds comme des valeurs serait une sur-interprétation : c'est le piège le
+    plus probable pour qui reprendrait la série.
+    """
+    assert nc("2025-01-01").pnafn.allocation not in (240, 260)
+
+
+def test_amg2_date_de_1998_et_non_de_2015():
+    """Article 10 du décret n° 98-409 du 18 février 1998."""
+    with pytest.raises(ParameterNotFoundError):
+        nc("1998-02-26").amg2
+    assert nc("1998-02-27").amg2 == 10
+    assert nc("2015-01-01").amg2 == 10
+
+
+def test_allocation_familiale_non_contributive_nexiste_pas_avant_2022():
+    """Décret-loi n° 2022-8 et arrêté du 1er avril 2022 ; ce qui existait en 2020 est autre."""
+    with pytest.raises(ParameterNotFoundError):
+        nc("2020-06-01").allocation_familiale
+    assert nc("2022-04-08").allocation_familiale == 30
+
+
+def test_amen_social_supplements():
+    """Limite d'âge de l'étudiant à 25 ans, et non 21 ; effet au 20 mai 2020."""
+    with pytest.raises(ParameterNotFoundError):
+        nc("2020-05-19").supplements if False else nc("2020-05-19").amen_social.supplements.enfant_a_charge
+
+    s = nc("2020-05-20").amen_social.supplements
+    assert s.enfant_a_charge == 10
+    assert s.limite_age_etudiant == 25
+    assert s.limite_age_enfant == 18
+
+
+def test_amen_social_allocation_de_base():
+    a = lambda d: nc(d).amen_social.allocation_base
+    assert a("2020-06-01") == 180
+    assert a("2022-06-01") == 200
+    assert a("2023-06-01") == 220
+    assert a("2024-06-01") == 240
+    # Palier ajouté : arrêté du 29 août 2025, rétroactif au 1er janvier.
+    assert a("2025-06-01") == 260

--- a/uv.lock
+++ b/uv.lock
@@ -1524,7 +1524,7 @@ web-api = [
 
 [[package]]
 name = "openfisca-tunisia"
-version = "0.74"
+version = "0.75"
 source = { editable = "." }
 dependencies = [
     { name = "openfisca-core", extra = ["web-api"] },


### PR DESCRIPTION
Empilée sur #392. Volet assistance des corrections issues du dossier documentaire des prestations sociales.

## Deux références apocryphes

Les suppléments du programme AMEN social citaient un « **décret n° 2019-318** » et un « **arrêté 931 du 20 mai 2020** ». **Ni l'un ni l'autre n'existe.** La disposition qu'ils étaient censés porter figure à l'article 2 de l'arrêté conjoint du 19 mai 2020.

C'est la première fois dans cette série de corrections qu'on rencontre non pas une référence absente ou imprécise, mais une référence **inventée** — qui donnait au paramètre une apparence de sourçage.

## Trois dates fausses

| Paramètre | Avant | Après | Fondement |
|---|---|---|---|
| `allocation_familiale` | juin 2020 | **avril 2022** | décret-loi n° 2022-8 et arrêté du 1er avril 2022 |
| `amg2` | 2015 | **février 1998** | décret n° 98-409, art. 10 |
| `supplements/*` | 2019 ou janvier 2020 | **20 mai 2020** | arrêté conjoint du 19 mai 2020 |

La première mérite un mot : ce qui existait en 2020 n'est pas l'allocation familiale non contributive mais le **supplément pour enfant à charge** du transfert AMEN, dispositif distinct avec lequel elle **ne se cumule pas**. Le modèle confondait les deux.

**Valeur corrigée** : la limite d'âge de l'étudiant passe de 21 à **25 ans**.

**Palier ajouté** : 260 dinars pour l'allocation de base AMEN, arrêté du 29 août 2025 rétroactif au 1er janvier.

## Deux choses qu'un encodage ne peut pas dire seul

**Les onze paliers du PNAFN n'ont aucun texte** — et c'est un résultat démontré, pas une lacune. La forme juridique de l'arrêté ministériel existait et a servi pour l'aide aux personnes âgées, à la famille d'accueil et aux personnes handicapées. Elle n'a pas été employée ici. Mieux : l'arrêté du 30 septembre 1997 **refuse d'énoncer un chiffre** et renvoie au « montant servi dans le cadre du programme ». La `documentation` du paramètre le dit, pour qu'on ne cherche pas indéfiniment un texte qui n'existe pas.

**Les 240 et 260 dinars des arrêtés de 2024 et 2025 sont des plafonds sur un relèvement, pas des barèmes.** L'arrêté du 10 juillet 2024 constate l'allocation « fixée à 180 dinars » et autorise une augmentation « sans que le montant ne dépasse » le niveau AMEN. Les encoder comme des valeurs serait une sur-interprétation — **un test le vérifie explicitement**, parce que c'est le piège le plus probable pour qui reprendrait la série.

## Ce qui est délibérément laissé en l'état

L'échelle « handicap lourd » de l'éligibilité. La portée de la majoration d'un demi-SMIG n'est pas tranchée par le décret gouvernemental n° 2020-317, et une correction partielle — deux lignes sur quatre — serait pire que l'incertitude documentée.

## Tests

**141 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2qMrmbL6BUDiEo3NmpU5m