### PR TITLE
fix(params): date les aides ponctuelles de l'AMEN et ajoute l'appui d'urgence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.77 - [#PRNUM](https://github.com/openfisca/openfisca-tunisia/pull/PRNUM)
+## 0.77 - [#396](https://github.com/openfisca/openfisca-tunisia/pull/396)
 
 * Correction d'un bug.
 * Périodes concernées : à partir du 2020-05-20.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.77 - [#PRNUM](https://github.com/openfisca/openfisca-tunisia/pull/PRNUM)
+
+* Correction d'un bug.
+* Périodes concernées : à partir du 2020-05-20.
+* Zones impactées : `parameters/prestations/non_contributives/amen_social/aides_ponctuelles`.
+* Détails :
+  - Date les cinq aides ponctuelles de l'AMEN social sur leur texte. Elles portaient le 1er janvier **2019**, qui n'est la date d'aucun texte : l'appui financier occasionnel est fixé par l'arrêté conjoint du **19 mai 2020**, publié au JORT n° 45 du 20 mai 2020, p. 1097. Les montants — 60 D pour le Ramadan, l'Aïd al-Fitr et l'Aïd al-Idha, 50 D par enfant à la rentrée scolaire, 120 D dans le supérieur — étaient exacts. Aucun des cinq ne portait de référence ; tous en ont désormais deux, l'arrêté du 8 décembre 2022 ayant abrogé celui de 2020 en reprenant les mêmes montants.
+  - Ajoute l'**appui pour dépenses exceptionnelles** créé par l'arrêté du 8 décembre 2022, absent du modèle. Son montant n'est pas fixe : il est compris **entre 60 et 200 dinars** selon la situation financière de la famille, et servi **quatre fois par an au plus**. D'où trois paramètres — deux bornes et un compte — plutôt qu'une valeur unique qui aurait inventé un barème.
+  - Documente ce qui n'est **pas** modélisé et pourquoi : la prise en charge des abonnements de transport scolaire et universitaire n'a pas de montant propre, le texte renvoyant aux tarifs des entreprises de transport public.
+
+<!-- -->
+
 ## 0.76 - [#395](https://github.com/openfisca/openfisca-tunisia/pull/395)
 
 * Correction d'un bug.

--- a/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/aides_ponctuelles/fetes_religieuses/aid_al_adha.yaml
+++ b/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/aides_ponctuelles/fetes_religieuses/aid_al_adha.yaml
@@ -1,7 +1,27 @@
 description: Montant de l'aide ponctuelle du programme Amen social délivrée à l'occasion de l'Aïd Al Adha
 values:
-  2019-01-01:
+  2020-05-20:
     value: 60
 metadata:
   short_label: Aïd Al Adha
   unit: currency
+  reference:
+    2020-05-20:
+      title: Article 4 de l'arrêté conjoint du ministre des affaires sociales et de la ministre des finances du 19 mai 2020, fixant les cas de l'octroi et les montants de l'appui financier occasionnel au profit des catégories pauvres et des catégories à revenu limité, JORT n° 45 du 20 mai 2020, p. 1097
+      href: https://www.pist.tn/jort/2020/2020F/Jo0452020.pdf
+    2022-12-09:
+      title: Article 4 de l'arrêté conjoint du 8 décembre 2022, JORT n° 136 du 9 décembre 2022, p. 3446-3447 ; son article 5 abroge l'arrêté du 19 mai 2020 et reprend les mêmes montants
+      href: https://www.pist.tn/jort/2022/2022F/Jo1362022.pdf
+documentation: |
+  DATE CORRIGÉE. La valeur était datée du 1er janvier 2019 sans référence. Le montant est
+  exact, mais 2019 n'est la date d'aucun texte : l'appui financier occasionnel est fixé par
+  l'arrêté conjoint du 19 mai 2020, pris sur le fondement de l'article 12 de la loi organique
+  n° 2019-10, et publié au JORT n° 45 du 20 mai 2020.
+
+  L'arrêté conjoint du 8 décembre 2022 ABROGE celui de 2020 (art. 5) et REPREND le même
+  montant. La valeur ne change donc pas au 9 décembre 2022, mais son fondement, si : c'est
+  pourquoi la date figure dans les références.
+
+  CHAMP D'APPLICATION, non modélisé ici : l'appui des fêtes religieuses est réservé aux
+  catégories pauvres (art. 2), tandis que les aides de rentrée sont ouvertes aux catégories
+  pauvres ET aux catégories à revenu limité (art. 3).

--- a/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/aides_ponctuelles/fetes_religieuses/aid_al_fitr.yaml
+++ b/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/aides_ponctuelles/fetes_religieuses/aid_al_fitr.yaml
@@ -1,7 +1,27 @@
 description: Montant de l'aide ponctuelle du programme Amen social délivrée à l'occasion de l'Aïd Al Fitr
 values:
-  2019-01-01:
+  2020-05-20:
     value: 60
 metadata:
   short_label: Aïd Al Fitr
   unit: currency
+  reference:
+    2020-05-20:
+      title: Article 4 de l'arrêté conjoint du ministre des affaires sociales et de la ministre des finances du 19 mai 2020, fixant les cas de l'octroi et les montants de l'appui financier occasionnel au profit des catégories pauvres et des catégories à revenu limité, JORT n° 45 du 20 mai 2020, p. 1097
+      href: https://www.pist.tn/jort/2020/2020F/Jo0452020.pdf
+    2022-12-09:
+      title: Article 4 de l'arrêté conjoint du 8 décembre 2022, JORT n° 136 du 9 décembre 2022, p. 3446-3447 ; son article 5 abroge l'arrêté du 19 mai 2020 et reprend les mêmes montants
+      href: https://www.pist.tn/jort/2022/2022F/Jo1362022.pdf
+documentation: |
+  DATE CORRIGÉE. La valeur était datée du 1er janvier 2019 sans référence. Le montant est
+  exact, mais 2019 n'est la date d'aucun texte : l'appui financier occasionnel est fixé par
+  l'arrêté conjoint du 19 mai 2020, pris sur le fondement de l'article 12 de la loi organique
+  n° 2019-10, et publié au JORT n° 45 du 20 mai 2020.
+
+  L'arrêté conjoint du 8 décembre 2022 ABROGE celui de 2020 (art. 5) et REPREND le même
+  montant. La valeur ne change donc pas au 9 décembre 2022, mais son fondement, si : c'est
+  pourquoi la date figure dans les références.
+
+  CHAMP D'APPLICATION, non modélisé ici : l'appui des fêtes religieuses est réservé aux
+  catégories pauvres (art. 2), tandis que les aides de rentrée sont ouvertes aux catégories
+  pauvres ET aux catégories à revenu limité (art. 3).

--- a/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/aides_ponctuelles/fetes_religieuses/ramadan.yaml
+++ b/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/aides_ponctuelles/fetes_religieuses/ramadan.yaml
@@ -1,7 +1,27 @@
 description: Montant de l'aide ponctuelle du programme Amen social délivrée à l'occasion du début du mois de Ramadan
 values:
-  2019-01-01:
+  2020-05-20:
     value: 60
 metadata:
   short_label: Ramadan
   unit: currency
+  reference:
+    2020-05-20:
+      title: Article 4 de l'arrêté conjoint du ministre des affaires sociales et de la ministre des finances du 19 mai 2020, fixant les cas de l'octroi et les montants de l'appui financier occasionnel au profit des catégories pauvres et des catégories à revenu limité, JORT n° 45 du 20 mai 2020, p. 1097
+      href: https://www.pist.tn/jort/2020/2020F/Jo0452020.pdf
+    2022-12-09:
+      title: Article 4 de l'arrêté conjoint du 8 décembre 2022, JORT n° 136 du 9 décembre 2022, p. 3446-3447 ; son article 5 abroge l'arrêté du 19 mai 2020 et reprend les mêmes montants
+      href: https://www.pist.tn/jort/2022/2022F/Jo1362022.pdf
+documentation: |
+  DATE CORRIGÉE. La valeur était datée du 1er janvier 2019 sans référence. Le montant est
+  exact, mais 2019 n'est la date d'aucun texte : l'appui financier occasionnel est fixé par
+  l'arrêté conjoint du 19 mai 2020, pris sur le fondement de l'article 12 de la loi organique
+  n° 2019-10, et publié au JORT n° 45 du 20 mai 2020.
+
+  L'arrêté conjoint du 8 décembre 2022 ABROGE celui de 2020 (art. 5) et REPREND le même
+  montant. La valeur ne change donc pas au 9 décembre 2022, mais son fondement, si : c'est
+  pourquoi la date figure dans les références.
+
+  CHAMP D'APPLICATION, non modélisé ici : l'appui des fêtes religieuses est réservé aux
+  catégories pauvres (art. 2), tandis que les aides de rentrée sont ouvertes aux catégories
+  pauvres ET aux catégories à revenu limité (art. 3).

--- a/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/aides_ponctuelles/index.yaml
+++ b/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/aides_ponctuelles/index.yaml
@@ -4,3 +4,12 @@ metadata:
   order:
   - fetes_religieuses
   - scolarite
+  - urgence
+documentation: |
+  Appui financier occasionnel prévu par l'article 12 de la loi organique n° 2019-10, par
+  opposition au transfert monétaire permanent de l'article 11.
+
+  NON MODÉLISÉ : la prise en charge des abonnements annuels de transport scolaire et
+  universitaire, créée par l'arrêté du 8 décembre 2022. Elle n'a pas de montant propre — le
+  texte renvoie « aux tarifs pratiqués par les entreprises de transport public » —, et
+  l'encoder par une valeur reviendrait à inventer un barème que le texte ne fixe pas.

--- a/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/aides_ponctuelles/scolarite/rentree_scolaire.yaml
+++ b/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/aides_ponctuelles/scolarite/rentree_scolaire.yaml
@@ -1,7 +1,27 @@
 description: Montant de l'aide ponctuelle du programme Amen social délivrée pour la rentrée scolaire
 values:
-  2019-01-01:
+  2020-05-20:
     value: 50
 metadata:
   short_label: Rentrée scolaire
   unit: currency
+  reference:
+    2020-05-20:
+      title: Article 4 de l'arrêté conjoint du ministre des affaires sociales et de la ministre des finances du 19 mai 2020, fixant les cas de l'octroi et les montants de l'appui financier occasionnel au profit des catégories pauvres et des catégories à revenu limité, JORT n° 45 du 20 mai 2020, p. 1097
+      href: https://www.pist.tn/jort/2020/2020F/Jo0452020.pdf
+    2022-12-09:
+      title: Article 4 de l'arrêté conjoint du 8 décembre 2022, JORT n° 136 du 9 décembre 2022, p. 3446-3447 ; son article 5 abroge l'arrêté du 19 mai 2020 et reprend les mêmes montants
+      href: https://www.pist.tn/jort/2022/2022F/Jo1362022.pdf
+documentation: |
+  DATE CORRIGÉE. La valeur était datée du 1er janvier 2019 sans référence. Le montant est
+  exact, mais 2019 n'est la date d'aucun texte : l'appui financier occasionnel est fixé par
+  l'arrêté conjoint du 19 mai 2020, pris sur le fondement de l'article 12 de la loi organique
+  n° 2019-10, et publié au JORT n° 45 du 20 mai 2020.
+
+  L'arrêté conjoint du 8 décembre 2022 ABROGE celui de 2020 (art. 5) et REPREND le même
+  montant. La valeur ne change donc pas au 9 décembre 2022, mais son fondement, si : c'est
+  pourquoi la date figure dans les références.
+
+  CHAMP D'APPLICATION, non modélisé ici : l'appui des fêtes religieuses est réservé aux
+  catégories pauvres (art. 2), tandis que les aides de rentrée sont ouvertes aux catégories
+  pauvres ET aux catégories à revenu limité (art. 3).

--- a/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/aides_ponctuelles/scolarite/rentree_universitaire.yaml
+++ b/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/aides_ponctuelles/scolarite/rentree_universitaire.yaml
@@ -1,7 +1,27 @@
 description: Montant de l'aide ponctuelle du programme Amen social délivrée pour la rentrée universitaire
 values:
-  2019-01-01:
+  2020-05-20:
     value: 120
 metadata:
   short_label: Rentrée universitaire
   unit: currency
+  reference:
+    2020-05-20:
+      title: Article 4 de l'arrêté conjoint du ministre des affaires sociales et de la ministre des finances du 19 mai 2020, fixant les cas de l'octroi et les montants de l'appui financier occasionnel au profit des catégories pauvres et des catégories à revenu limité, JORT n° 45 du 20 mai 2020, p. 1097
+      href: https://www.pist.tn/jort/2020/2020F/Jo0452020.pdf
+    2022-12-09:
+      title: Article 4 de l'arrêté conjoint du 8 décembre 2022, JORT n° 136 du 9 décembre 2022, p. 3446-3447 ; son article 5 abroge l'arrêté du 19 mai 2020 et reprend les mêmes montants
+      href: https://www.pist.tn/jort/2022/2022F/Jo1362022.pdf
+documentation: |
+  DATE CORRIGÉE. La valeur était datée du 1er janvier 2019 sans référence. Le montant est
+  exact, mais 2019 n'est la date d'aucun texte : l'appui financier occasionnel est fixé par
+  l'arrêté conjoint du 19 mai 2020, pris sur le fondement de l'article 12 de la loi organique
+  n° 2019-10, et publié au JORT n° 45 du 20 mai 2020.
+
+  L'arrêté conjoint du 8 décembre 2022 ABROGE celui de 2020 (art. 5) et REPREND le même
+  montant. La valeur ne change donc pas au 9 décembre 2022, mais son fondement, si : c'est
+  pourquoi la date figure dans les références.
+
+  CHAMP D'APPLICATION, non modélisé ici : l'appui des fêtes religieuses est réservé aux
+  catégories pauvres (art. 2), tandis que les aides de rentrée sont ouvertes aux catégories
+  pauvres ET aux catégories à revenu limité (art. 3).

--- a/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/aides_ponctuelles/urgence/index.yaml
+++ b/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/aides_ponctuelles/urgence/index.yaml
@@ -1,0 +1,7 @@
+description: Appui pour dépenses exceptionnelles d'urgence sanitaire ou sociale
+metadata:
+  short_label: Appui d'urgence
+  order:
+  - montant_min
+  - montant_max
+  - nombre_max_par_an

--- a/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/aides_ponctuelles/urgence/montant_max.yaml
+++ b/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/aides_ponctuelles/urgence/montant_max.yaml
@@ -1,0 +1,17 @@
+description: Montant maximal de l'appui pour dépenses exceptionnelles
+values:
+  2022-12-09:
+    value: 200
+metadata:
+  unit: currency
+  reference:
+    2022-12-09:
+      title: Article 3 de l'arrêté conjoint du ministre des affaires sociales et de la ministre des finances du 8 décembre 2022, JORT n° 136 du 9 décembre 2022, p. 3446-3447
+      href: https://www.pist.tn/jort/2022/2022F/Jo1362022.pdf
+documentation: |
+  PARAMÈTRE AJOUTÉ. Borne haute de l'appui pour dépenses exceptionnelles, modulé entre 60 et
+  200 dinars selon la situation financière de la famille.
+
+  Cette borne, comme le nombre maximal de versements annuels, peut être DÉPASSÉE « dans des
+  cas exceptionnels » sur autorisation du comité général de la promotion sociale : c'est un
+  plafond de droit commun, non une limite absolue.

--- a/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/aides_ponctuelles/urgence/montant_min.yaml
+++ b/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/aides_ponctuelles/urgence/montant_min.yaml
@@ -1,0 +1,19 @@
+description: Montant minimal de l'appui pour dépenses exceptionnelles
+values:
+  2022-12-09:
+    value: 60
+metadata:
+  unit: currency
+  reference:
+    2022-12-09:
+      title: Article 3 de l'arrêté conjoint du ministre des affaires sociales et de la ministre des finances du 8 décembre 2022, JORT n° 136 du 9 décembre 2022, p. 3446-3447
+      href: https://www.pist.tn/jort/2022/2022F/Jo1362022.pdf
+documentation: |
+  PARAMÈTRE AJOUTÉ. L'arrêté conjoint du 8 décembre 2022 crée un appui destiné aux dépenses
+  exceptionnelles nécessitées par des conditions sanitaires ou sociales d'urgence, ou pour
+  appuyer la prise en charge des enfants scolarisés exposés à l'inadaptation sociale et au
+  décrochage scolaire.
+
+  Son montant n'est pas fixe : il est compris entre 60 et 200 dinars selon la situation
+  financière de la famille. C'est le seul appui du dispositif dont le montant relève d'une
+  appréciation, ce qui interdit de le modéliser par une valeur unique — d'où deux bornes.

--- a/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/aides_ponctuelles/urgence/nombre_max_par_an.yaml
+++ b/openfisca_tunisia/parameters/prestations/non_contributives/amen_social/aides_ponctuelles/urgence/nombre_max_par_an.yaml
@@ -1,0 +1,13 @@
+description: Nombre maximal de versements de l'appui pour dépenses exceptionnelles, par an
+values:
+  2022-12-09:
+    value: 4
+metadata:
+  reference:
+    2022-12-09:
+      title: Article 3 de l'arrêté conjoint du ministre des affaires sociales et de la ministre des finances du 8 décembre 2022, JORT n° 136 du 9 décembre 2022, p. 3446-3447
+      href: https://www.pist.tn/jort/2022/2022F/Jo1362022.pdf
+documentation: |
+  PARAMÈTRE AJOUTÉ. L'appui pour dépenses exceptionnelles est servi au maximum quatre fois
+  par an. Comme le plafond de 200 dinars, cette limite peut être dépassée dans des cas
+  exceptionnels sur autorisation du comité général de la promotion sociale.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-Tunisia"
-version = "0.76"
+version = "0.77"
 description = "OpenFisca Rules as Code model for Tunisia."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "tunisia"]

--- a/tests/test_prestations_assistance.py
+++ b/tests/test_prestations_assistance.py
@@ -91,3 +91,32 @@ def test_amen_allocation_de_base_prend_effet_a_la_publication():
     with pytest.raises(ParameterNotFoundError):
         nc("2020-05-19").amen_social.allocation_base
     assert nc("2020-05-20").amen_social.allocation_base == 180
+
+
+def test_aides_ponctuelles_datees_de_2020_et_non_de_2019():
+    """L'appui financier occasionnel est fixé par l'arrêté conjoint du 19 mai 2020,
+    publié au JORT n° 45 du 20 mai 2020. L'année 2019 n'est la date d'aucun texte.
+    """
+    aides = nc("2020-05-20").amen_social.aides_ponctuelles
+    assert aides.fetes_religieuses.ramadan == 60
+    assert aides.fetes_religieuses.aid_al_fitr == 60
+    assert aides.fetes_religieuses.aid_al_adha == 60
+    assert aides.scolarite.rentree_scolaire == 50
+    assert aides.scolarite.rentree_universitaire == 120
+
+    with pytest.raises(ParameterNotFoundError):
+        nc("2019-06-01").amen_social.aides_ponctuelles.fetes_religieuses.ramadan
+
+
+def test_appui_urgence_est_un_intervalle_et_non_un_montant():
+    """L'arrêté du 8 décembre 2022 module l'appui entre 60 et 200 dinars selon la
+    situation de la famille : c'est le seul du dispositif à ne pas avoir de montant fixe.
+    """
+    urgence = nc("2023-01-01").amen_social.aides_ponctuelles.urgence
+    assert urgence.montant_min == 60
+    assert urgence.montant_max == 200
+    assert urgence.nombre_max_par_an == 4
+
+    # Un NŒUD de paramètres existe à toute date ; seule une feuille sans valeur lève.
+    with pytest.raises(ParameterNotFoundError):
+        nc("2022-12-08").amen_social.aides_ponctuelles.urgence.montant_min

--- a/uv.lock
+++ b/uv.lock
@@ -1524,7 +1524,7 @@ web-api = [
 
 [[package]]
 name = "openfisca-tunisia"
-version = "0.76"
+version = "0.77"
 source = { editable = "." }
 dependencies = [
     { name = "openfisca-core", extra = ["web-api"] },


### PR DESCRIPTION
Dernier point relevé par le dépouillement documentaire du chapitre « Prestations sociales », après #392, #393 et #395.

## Une date qui n'est celle d'aucun texte

Les cinq aides ponctuelles de l'AMEN social portaient le **1er janvier 2019**, sans référence. C'est le motif déjà corrigé quatre fois cette semaine : une valeur juste rattachée à une date inventée.

L'appui financier occasionnel est fixé par l'**arrêté conjoint du 19 mai 2020**, pris sur le fondement de l'article 12 de la loi organique n° 2019-10 et publié au **JORT n° 45 du 20 mai 2020, p. 1097**. Les montants, eux, étaient exacts : 60 D pour le Ramadan, l'Aïd al-Fitr et l'Aïd al-Idha, 50 D par enfant scolarisé à la rentrée, 120 D par enfant dans le supérieur.

Chacun porte désormais **deux références**, parce que l'**arrêté du 8 décembre 2022** (JORT n° 136 du 9 décembre 2022) abroge expressément celui de 2020 tout en reprenant les mêmes montants : la valeur ne bouge pas, son fondement si — et c'est le genre de chose qu'une série datée doit savoir dire.

## Une prestation absente du modèle

L'arrêté de 2022 crée un **appui pour dépenses exceptionnelles**, destiné aux situations sanitaires ou sociales d'urgence et à la prise en charge des enfants exposés au décrochage scolaire. Il ne figurait pas dans le modèle.

Son montant **n'est pas fixe** : il est compris entre **60 et 200 dinars** selon la situation financière de la famille, et servi **quatre fois par an au plus**. D'où trois paramètres — deux bornes et un compte — plutôt qu'une valeur unique qui aurait inventé un barème que le texte ne fixe pas. La documentation précise que ces deux limites peuvent être dépassées « dans des cas exceptionnels » sur autorisation du comité général de la promotion sociale : ce sont des plafonds de droit commun, non des maxima absolus.

## Ce qui reste hors du modèle, et pourquoi

La prise en charge des **abonnements de transport scolaire et universitaire**, créée par le même arrêté, n'a pas de montant propre : le texte renvoie « aux tarifs pratiqués par les entreprises de transport public ». L'encoder par une valeur reviendrait à fabriquer un barème. C'est documenté dans l'index du dispositif plutôt que passé sous silence.

De même, le champ d'application n'est pas modélisé : l'appui des fêtes est réservé aux catégories pauvres, les aides de rentrée sont ouvertes aux deux catégories.

## Vérification

Deux tests ajoutés — la date d'effet des cinq aides, et l'appui d'urgence comme intervalle. Localement : `ruff` vert, **153 tests openfisca**, 72 tests pytest, `uv lock --check` vert.

Le premier jet du second test était faux, et le dit : il attendait qu'un **nœud** de paramètres lève avant sa date d'existence, alors que seule une feuille sans valeur le fait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2qMrmbL6BUDiEo3NmpU5m