### PR TITLE
Corriger et sourcer sur le JORT les cotisations du secteur public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.78 - [#397](https://github.com/openfisca/openfisca-tunisia/pull/397)
+
+* Correction d'un bug.
+* Périodes concernées : à partir du 1959-02-01.
+* Zones impactées : `parameters/prelevements_sociaux/cotisations_sociales/secteur_public`.
+* Détails :
+  - Supprime le palier salarié du **1er juin 2019** (8,7 %), que le texte contredit. L'article 4 de la loi n° 2019-37 (JORT n° 35, p. 1314) répartit les 3 points ainsi : « Au titre de l'employeur : 2 % à partir du premier jour du mois qui suit la date d'entrée en vigueur de la présente loi. Au titre de l'agent : 1 % à partir du premier janvier 2020. » La part salariale monte donc d'un point **en une seule fois** au 1er janvier 2020 ; la date de juin 2019 vaut pour la part patronale seule.
+  - Redate la deuxième marche patronale de la loi n° 2007-43 au **1er janvier 2008** : le texte (p. 2198) donne 0,60 point au 1er janvier 2007, 2008 et 2009 côté employeur, contre 0,40 au 1er juillet côté salarié. Le fichier datait 2007 et 2009 en janvier et 2008 en juillet, se contredisant lui-même.
+  - Fait commencer la **prévoyance sociale des pensionnés au 1er juillet 2007** au lieu de 1959. Le décret n° 2007-1406 (JORT n° 49, art. 2 p. 2156, art. 13 p. 2162) assied la cotisation sur le montant brut de la pension et échelonne le taux à 1, 2, 3 puis 4 %. Aucun texte antérieur établissant un prélèvement obligatoire sur la pension n'a pu être retrouvé.
+  - Redate le millésime de **1985 au 12 septembre**, six mois après la publication du 12 mars comme l'article 75 de la loi n° 85-12 le prescrit. Le taux est inchangé de part et d'autre : ce millésime marque la refonte du régime, non un mouvement de taux.
+  - Remplace **toutes** les références du secteur public — dépôt GitLab personnel et natlex — par les fascicules du JORT sur pist.tn, en éditions française et arabe, avec numéro de fascicule et page. Chaque URL a été vérifiée, et les deux éditions distinguées par la taille du fichier.
+  - Référence les quatre paliers de 2003, 2004, 2008 et 2009, qui n'avaient aucun texte en regard : ils sont programmés par les échéanciers pluriannuels de l'article 85 de la loi de finances 2002 et de l'article premier de la loi n° 2007-43, et non par des textes distincts.
+  - Corrige la date de création de la CNRPS dans les deux `index.yaml` : l'article 28 de la loi n° 75-83 du **30** décembre 1975 (et non du 31) « transforme en un établissement public à caractère financier » la CNR et la CPS.
+  - Signale dans la note du paramètre que la date du **1er février 1959 n'a aucun appui textuel** : la loi n° 59-18 n'énonce pas d'effet pour son article 5, et sa seule date — le 1er avril 1959 — porte sur l'ouverture des droits à pension.
+
+<!-- -->
+
 ## 0.77 - [#396](https://github.com/openfisca/openfisca-tunisia/pull/396)
 
 * Correction d'un bug.

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_public/pensionne_cnrps/index.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_public/pensionne_cnrps/index.yaml
@@ -1,5 +1,8 @@
 description: Cotisations des agents pensionnés de l'Etat
 documentation: |-
-  La C.N.R.P.S a été créée, par la loi n° 75-83 du 31 décembre 1975 portant loi de finances pour la gestion 1976,
-  en remplacement de la Caisse nationale de retraite (CNR) et de la Caisse de prévoyance sociale (CPS)
-  créées respectivement par la loi n°59-19 du 5 février 1959 et la loi n° 59-45 du 15 avril 1959.
+  La C.N.R.P.S est née de l'article 28 de la loi n° 75-83 du 30 décembre 1975 portant loi de finances
+  pour la gestion 1976 (JORT n° 87, p. 2854), qui « transforme en un établissement public à caractère
+  financier » la Caisse nationale de retraite (CNR) et la Caisse de prévoyance sociale (CPS), créées
+  respectivement par la loi n° 59-19 du 5 février 1959 et la loi n° 59-45 du 15 avril 1959. Le régime
+  lui-même, et l'appellation de Caisse nationale de retraites, procèdent de la loi n° 59-18 du même jour.
+  Le fascicule date la loi de finances du 30 décembre 1975, et non du 31.

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_public/pensionne_cnrps/prevoyance_sociale.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_public/pensionne_cnrps/prevoyance_sociale.yaml
@@ -1,10 +1,10 @@
 description: Prévoyance sociale
 brackets:
 - threshold:
-    1959-02-01:
+    2007-07-01:
       value: 0
   rate:
-    1959-02-01:
+    2007-07-01:
       value: 0.01
     2008-07-01:
       value: 0.02
@@ -14,20 +14,26 @@ brackets:
       value: 0.04
 metadata:
   reference:
+    2007-07-01:
+    - title: "Décret n° 2007-1406 du 18 juin 2007 fixant l'assiette de calcul des taux de cotisations dues au titre du régime de base d'assurance maladie et ses étapes d'application, articles 2 et 13"
+      href: "https://www.pist.tn/jort/2007/2007F/Jo0492007.pdf"
+      note: "JORT n° 49 du 19 juin 2007, article 2 p. 2156, article 13 p. 2162. L'assiette est le montant brut de la pension ; l'article 13 échelonne le taux des titulaires de pension affiliés à la CNRPS au titre du régime obligatoire : 1 % au 1er juillet 2007, 2 % en 2008, 3 % en 2009, 4 % en 2010. La date de 1959 que portait ce fichier était sans appui textuel — aucun texte antérieur établissant un prélèvement obligatoire sur la pension n'a pu être retrouvé."
+    - title: "أمر عدد 1406 لسنة 2007 مؤرخ في 18 جوان 2007 يتعلق بضبط قاعدة احتساب نسب الاشتراكات المستوجبة بعنوان النظام القاعدي للتأمين على المرض ومرحلية تطبيقها، الفصلان 2 و13"
+      href: "https://www.pist.tn/jort/2007/2007A/Ja0492007.pdf"
     2008-07-01:
     - title: Décret n° 2007-1406 du 18 juin 2007, fixant l’assiette de calcul des taux de cotisations dues au titre de régime de base d’assurance maladie et ses étapes d’application.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/décret_2007_1406_fr.pdf
+      href: https://www.pist.tn/jort/2007/2007F/Jo0492007.pdf
     - title: امر عدد 1406 لسنة 2007 مؤرخ في 18 جوان 2007 يتعلق بضبط قاعدة احتساب نسب الاشتراكات المستوجبة بعنوان النظام القاعدي للتأمين على المرض ومرحلية تطبيقها
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/Décret_2007_1406__ar.pdf
+      href: https://www.pist.tn/jort/2007/2007A/Ja0492007.pdf
     2009-07-01:
     - title: Décret n° 2007-1406 du 18 juin 2007, fixant l’assiette de calcul des taux de cotisations dues au titre de régime de base d’assurance maladie et ses étapes d’application.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/décret_2007_1406_fr.pdf
+      href: https://www.pist.tn/jort/2007/2007F/Jo0492007.pdf
     - title: امر عدد 1406 لسنة 2007 مؤرخ في 18 جوان 2007 يتعلق بضبط قاعدة احتساب نسب الاشتراكات المستوجبة بعنوان النظام القاعدي للتأمين على المرض ومرحلية تطبيقها
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/Décret_2007_1406__ar.pdf
+      href: https://www.pist.tn/jort/2007/2007A/Ja0492007.pdf
     2010-07-01:
     - title: Décret n° 2007-1406 du 18 juin 2007, fixant l’assiette de calcul des taux de cotisations dues au titre de régime de base d’assurance maladie et ses étapes d’application.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/décret_2007_1406_fr.pdf
+      href: https://www.pist.tn/jort/2007/2007F/Jo0492007.pdf
     - title: امر عدد 1406 لسنة 2007 مؤرخ في 18 جوان 2007 يتعلق بضبط قاعدة احتساب نسب الاشتراكات المستوجبة بعنوان النظام القاعدي للتأمين على المرض ومرحلية تطبيقها
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/Décret_2007_1406__ar.pdf
+      href: https://www.pist.tn/jort/2007/2007A/Ja0492007.pdf
   rate_unit: /1
   threshold_unit: currency

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_public/salarie_cnrps/cotisations_employeur/retraite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_public/salarie_cnrps/cotisations_employeur/retraite.yaml
@@ -22,7 +22,7 @@ brackets:
       value: 0.097
     2007-01-01:
       value: 0.103
-    2008-07-01:
+    2008-01-01:
       value: 0.109
     2009-01-01:
       value: 0.115
@@ -32,70 +32,100 @@ brackets:
       value: 0.145
 metadata:
   reference:
+    1959-02-01:
+    - title: "Loi n° 59-18 du 5 février 1959 fixant le régime des pensions civiles et militaires de retraite, article 8"
+      href: "https://www.pist.tn/jort/1959/1959F/Jo00859.pdf"
+      note: "JORT n° 8, fascicule des 3-6 février 1959, p. 93. L'article 8 met à la charge de l'État une subvention au taux uniforme de 10 % par an. La loi n'énonce pas de date d'effet pour cet article."
+    - title: "قانون عدد 18 لسنة 1959 مؤرخ في 5 فيفري 1959 يتعلق بضبط نظام جرايات التقاعد المدني والعسكري، الفصل 8"
+      href: "https://www.pist.tn/jort/1959/1959A/Ja00859.pdf"
+    1975-01-01:
+    - title: "Loi n° 74-101 du 25 décembre 1974 portant loi de finances pour l'année 1975, article 39"
+      href: "https://www.pist.tn/jort/1974/1974F/Jo08074.pdf"
+      note: "JORT n° 80 du 31 décembre 1974, p. 2918. L'article 39 remplace le deuxième alinéa de l'article 8 de la loi 59-18 : la subvention de l'État passe de 10 % à 7 %, assise sur les mêmes éléments de rémunération que la retenue salariale. L'article ne porte pas de date d'effet ; le 1er janvier 1975 se déduit du rattachement à la gestion 1975."
+    - title: "قانون عدد 101 لسنة 1974 مؤرخ في 25 ديسمبر 1974 يتعلق بقانون المالية لسنة 1975، الفصل 39"
+      href: "https://www.pist.tn/jort/1974/1974A/Ja08074.pdf"
     1995-07-01:
     - title: Loi 94-71 du 27 juin 1994 relative à la révision des taux de la contribution aux régimes de retraite dans le secteur public
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1994/loi_94_71_fr.pdf
+      href: https://www.pist.tn/jort/1994/1994F/Jo05094.pdf
       note: Les taux de contribution sont relevés de 1,2 point de pourcentage de la base de calcul de la contribution, à la charge de l'employeur et ce à partir du premier juillet 1995
     - title: القانون عدد 71 لسنة 1994 مؤرخ في 27 جوان 1994  يتعلق بتعديل نسب المساهمات في انظمة التقاعد في القطاع العمومي
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1994/loi_94_71_ar.pdf
+      href: https://www.pist.tn/jort/1994/1994A/Ja05094.pdf
       note: ترفع نسب المساهمات ب1،2 بالمائة ابتداء من غرة جويلية 1995
     2002-07-01:
     - title: loi 2001-123 du 28 décembre 2001 portant loi de finances 2002 (article 85)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_fr.pdf
+      href: https://www.pist.tn/jort/2001/2001F/Jo1042001.pdf
       note: Les taux de la contribution au régime des pensions civiles et militaires de retraite et des survivants dans le secteur public et des régimes de retraite des membres du gouvernement, des députés et des gouverneurs sont relevés de 1.5 point de pourcentage de la base de calcul de la contribution à la charge de l’employeur et ce comme suit :0.50 point de pourcentage à partir du 1er juillet 2002, 0.25 point de pourcentage à partir du 1er juillet 2003, 0.25 point de pourcentage à partir du 1er juillet 2004, 0.25 point de pourcentage à partir du 1er juillet 2005, 0.25 point de pourcentage à partir du 1er juillet 2006
     - title: قانون عدد 123 لسنة 2001 مؤرخ في 28 ديسمبر 2001 يتعلق بقانون المالية لسنة  2002 (الفصل 85)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_ar.pdf
+      href: https://www.pist.tn/jort/2001/2001A/Ja1042001.pdf
       note: "ترفع نسب المساهمات بنظام الجرايات المدنية والعسكرية للتقاعد والباقين على قيد الحياة في القطاع العمومي وبأنظمة التقاعد لأعضاء الحكومة وأعضاء مجلس النواب والولاّة كما يلي : 1.5 بالمائة من قاعدة احتساب الاشتراك على كاهل المؤجر وذلك على النــحو التالي :0.50 بالمائة ابتداء من غرة جويلية 2002 ، 0.25  بالمائة ابتداء من غرة جويلية 2003، 0.25  بالمائة ابتداء من غرة جويلية 2004 ، 0.25  بالمائة ابتداء من غرة جويلية 2005، 0.25  بالمائة ابتداء من غرة جويلية 2006"
     2003-07-01:
     - title: loi 2001-123 du 28 décembre 2001 portant loi de finances 2002 (article 85)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_fr.pdf
+      href: https://www.pist.tn/jort/2001/2001F/Jo1042001.pdf
     - title: قانون عدد 123 لسنة 2001 مؤرخ في 28 ديسمبر 2001 يتعلق بقانون المالية لسنة  2002 (الفصل 85)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_ar.pdf
+      href: https://www.pist.tn/jort/2001/2001A/Ja1042001.pdf
     2004-07-01:
     - title: loi 2001-123 du 28 décembre 2001 portant loi de finances 2002 (article 85)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_fr.pdf
+      href: https://www.pist.tn/jort/2001/2001F/Jo1042001.pdf
     - title: قانون عدد 123 لسنة 2001 مؤرخ في 28 ديسمبر 2001 يتعلق بقانون المالية لسنة  2002 (الفصل 85)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_ar.pdf
+      href: https://www.pist.tn/jort/2001/2001A/Ja1042001.pdf
     2005-07-01:
     - title: loi 2001-123 du 28 décembre 2001 portant loi de finances 2002 (article 85)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_fr.pdf
+      href: https://www.pist.tn/jort/2001/2001F/Jo1042001.pdf
     - title: قانون عدد 123 لسنة 2001 مؤرخ في 28 ديسمبر 2001 يتعلق بقانون المالية لسنة  2002 (الفصل 85)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_ar.pdf
+      href: https://www.pist.tn/jort/2001/2001A/Ja1042001.pdf
     2006-07-01:
     - title: loi 2001-123 du 28 décembre 2001 portant loi de finances 2002 (article 85)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_fr.pdf
+      href: https://www.pist.tn/jort/2001/2001F/Jo1042001.pdf
     - title: قانون عدد 123 لسنة 2001 مؤرخ في 28 ديسمبر 2001 يتعلق بقانون المالية لسنة  2002 (الفصل 85)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_ar.pdf
+      href: https://www.pist.tn/jort/2001/2001A/Ja1042001.pdf
     2007-01-01:
     - title: Loi 2007-43 du 25 juin 2007, modifiant et complétant les lois régissant les pensions servies au titre des régimes de retraite, d’invalidité et de survivants dans les secteurs public et privé et des régimes spéciaux
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/loi_2007_43_fr.pdf
+      href: https://www.pist.tn/jort/2007/2007F/Jo0512007.pdf
       note: "Les taux des contributions au régime des pensions civiles et militaires de retraite et de survivants dans le secteur public et aux régimes de retraite des membres du gouvernement, de la chambre des députés, de la chambre des conseillers et des gouverneurs sont relevés à raison de  1,8 point de pourcentage de l’assiette de calcul de cotisation, à la charge de l’employeur, et ce, comme suit: 0,60 point de pourcentage à partir du 1er janvier 2007, 0,60 point de pourcentage à partir du 1er janvier 2008, 0,60 point de pourcentage à partir du 1er janvier 2009."
     - title: القانون عدد 43 لسنة 2007 المؤرخ في 25 جوان 2007
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/loi_2007_43_ar.pdf
+      href: https://www.pist.tn/jort/2007/2007A/Ja0512007.pdf
       note: ترفع نسب المساهمات بنظام الجرايات المدنية والعسكرية للتقاعد والباقين على قيد الحياة في القطاع العمومي وبأنظمة التقاعد لأعضاء الحكومة وأعضاء مجلس النواب وأعضاء مجلس المستشارين والولاة كما يلي :1,8  بالمائة من قاعدة احتساب الاشتراك على كاهل المؤجر وذلك على النحو التالي :0,60     بالمائة ابتداء من أول جانفي 2007   0,60  بالمائة ابتداء من أول جانفي 2008 0,60  بالمائة ابتداء من أول جانفي 2009
-    2008-07-01:
-    - title: Loi 2007-43 du 25 juin 2007, modifiant et complétant les lois régissant les pensions servies au titre des régimes de retraite, d’invalidité et de survivants dans les secteurs public et privé et des régimes spéciaux
-    - title: القانون عدد 43 لسنة 2007 المؤرخ في 25 جوان 2007
+    2008-01-01:
+    - title: "Loi n° 2007-43 du 25 juin 2007, article premier (échéancier)"
+      href: "https://www.pist.tn/jort/2007/2007F/Jo0512007.pdf"
+      note: "Marche de l'échéancier patronal : 0,60 point. Les trois marches de la part patronale sont datées du 1er janvier 2007, 2008 et 2009, là où celles de la part salariale tombent en juillet."
+    - title: "قانون عدد 43 لسنة 2007 مؤرخ في 25 جوان 2007، الفصل الأول"
+      href: "https://www.pist.tn/jort/2007/2007A/Ja0512007.pdf"
     2009-01-01:
+    - title: "Loi n° 2007-43 du 25 juin 2007, article premier (échéancier)"
+      href: "https://www.pist.tn/jort/2007/2007F/Jo0512007.pdf"
+      note: "Marche de l'échéancier patronal : 0,60 point. Les trois marches de la part patronale sont datées du 1er janvier 2007, 2008 et 2009, là où celles de la part salariale tombent en juillet."
+    - title: "قانون عدد 43 لسنة 2007 مؤرخ في 25 جوان 2007، الفصل الأول"
+      href: "https://www.pist.tn/jort/2007/2007A/Ja0512007.pdf"
     - title: Loi 2007-43 du 25 juin 2007, modifiant et complétant les lois régissant les pensions servies au titre des régimes de retraite, d’invalidité et de survivants dans les secteurs public et privé et des régimes spéciaux
+      href: https://www.pist.tn/jort/2007/2007F/Jo0512007.pdf
     - title: القانون عدد 43 لسنة 2007 المؤرخ في 25 جوان 2007
-    - title: Loi 2007-43 du 25 juin 2007, modifiant et complétant les lois régissant les pensions servies au titre des régimes de retraite, d’invalidité et de survivants dans les secteurs public et privé et des régimes spéciaux
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/loi_2007_43_fr.pdf
-    - title: القانون عدد 43 لسنة 2007 المؤرخ في 25 جوان 2007
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/loi_2007_43_ar.pdf
+      href: https://www.pist.tn/jort/2007/2007A/Ja0512007.pdf
     2011-07-01:
     - title: Décret-loi n° 2011-48 du 4 juin 2011, modifiant les lois régissant les pensions civiles et militaires de retraite et des survivants dans le secteur public, le régime de retraite des membres du gouvernement et le régime de retraite des gouverneurs
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2011/décret_loi_2011_48_fr.pdf
+      href: https://www.pist.tn/jort/2011/2011F/Jo0412011.pdf
     - title: مرسوم عدد 48 لسنة 2011 مؤرخ في 4 جوان 2011 يتعلق بتنقيح القوانين المنظمة للجرايات المدنية والعسكرية للتقاعد وللباقين على قيد الحياة في القطاع العمومي ولنظام تقاعد أعضاء الحكومة ولنظام تقاعد الولاة
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2011/décret_loi_2011_48_ar.pdf
+      href: https://www.pist.tn/jort/2011/2011A/Ja0412011.pdf
     2019-06-01:
     - title: Loi 2019-37 du 30 avril 2019, modifiant et complétant la loi n°85-12 du 5 mars 1985, relative au régime des pensions civiles et militaires de retraite et des survivants dans le secteur public.(article 4)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2019/loi_2019_37__fr.pdf
+      href: https://www.pist.tn/jort/2019/2019F/Jo0352019.pdf
       note: Les taux des contributions dues au titre de la retraite définis par la loi 85-12 du 5 mars 1985 sont majorés de 2 point de pourcentage au titre de l’employeur à partir du premier jour du mois qui suit la date d’entrée en vigueur de la loi 2019-37
     - title: قانون عدد 37 لسنة 2019 مؤرخ في 30 أفريل 2019 يتعلّق بتنقيح وإتمام القانون عدد 12 لسنة 1985 المؤرخ في 5 مارس 1985 المتعلق بنظام الجرايات المدنية والعسكرية للتقاعد وللباقين على قيد الحياة في القطاع العمومي
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2019/loi_2019_37_ar.pdf
+      href: https://www.pist.tn/jort/2019/2019A/Ja0352019.pdf
       note: تم الترفــــيع في المساهمـــات المستوجبة بعنوان التقاعد المضـــــبوطة بالقانون عدد 12 لسنة 1985 المؤرخ في 5 مارس 1985  2 بالمائة (2%) بالنسبة للمشغل بداية من اليوم الأول من الشهر الموالي لتاريخ دخول القانون 2019-37 حيز النفاذ
   official_journal_date:
+    1959-02-01: "1959-02-03"
+    1975-01-01: "1974-12-31"
+    1995-07-01: "1994-06-28"
+    2002-07-01: "2001-12-28"
+    2003-07-01: "2001-12-28"
+    2004-07-01: "2001-12-28"
+    2005-07-01: "2001-12-28"
+    2006-07-01: "2001-12-28"
+    2007-01-01: "2007-06-26"
+    2008-01-01: "2007-06-26"
+    2009-01-01: "2007-06-26"
+    2011-07-01: "2011-06-07"
     2019-06-01: "2019-04-30"
   rate_unit: /1
   threshold_unit: currency

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_public/salarie_cnrps/cotisations_salarie/retraite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_public/salarie_cnrps/cotisations_salarie/retraite.yaml
@@ -8,7 +8,7 @@ brackets:
       value: 0.07
     1975-01-01:
       value: 0.05
-    1985-10-01:
+    1985-09-12:
       value: 0.05
     1994-07-01:
       value: 0.06
@@ -24,62 +24,95 @@ brackets:
       value: 0.078
     2009-07-01:
       value: 0.082
-    2019-06-01:
-      value: 0.087
     2020-01-01:
       value: 0.092
 metadata:
   last_value_still_valid_on: "2025-06-05"
   reference:
     1959-02-01:
-    - title: loi n°59-18 du 5 février 1959 fixant le régime des pensions civiles et militaires de retraite
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1959/loi_59_18_fr.pdf
-      note: Ce montant a été ramené à 5% par l’article 38 de la loi 74-101 du 25/12/1974 portant loi des finances pour l’année 1975. Les dispositions de la loi n°59-18 du 5 février 1959 fixant le régime des pensions civiles et militaires de retraite sont abrogées sauf les dispositions de la section II concernant l’invalidité ne résultant pas de l'exercice des fonctions non abrogées et ce par la loi n°85-12 du 5 mars 1985
-    - title: قانون عدد 18 لسنة 1959 مؤرخ في 5 فيفري 1959 بتعلق بضبط نظام جرايات التقاعد المدني والعسكري
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1959/loi_59_18_ar.pdf
-      note: تعديل المساهمة إلى 5 يالمائة بمقتضى الفصل 38 من القانون عدد 101 لسنة 1974 المؤرخ في 25/12/1974 -   بمقتضى القانون عدد 12 لسنة 1985 المؤرخ في  5 مارس  1985 ألغيت جميع الأحكام السابقة المخالفة لهذا القانون وخاصة القانون عدد 18 لسنة 1959 المؤرخ ‏في 5 فيفري 1959 وجميع النصوص التي نقحته أو تممته باستثناء الأحكام المتعلقة بالسقوط ‏البدني
+    - title: Loi n° 59-18 du 5 février 1959 fixant le régime des pensions civiles et militaires de retraite, article 5-I
+      href: https://www.pist.tn/jort/1959/1959F/Jo00859.pdf
+      note: "JORT n° 8, fascicule des 3-6 février 1959, p. 93. La loi n'énonce aucune date d'effet pour l'article 5 : la seule date qu'elle fixe, le 1er avril 1959 (article 52), porte sur l'ouverture des droits à pension. Le 1er février 1959 retenu ici n'est pas énoncé par le texte. Le taux reste à 7 % jusqu'en 1974 ; la loi n° 73-71 du 19 novembre 1973 (JORT n° 43, p. 1852) remplace l'article 5 en maintenant le taux et en élargissant l'assiette. La loi n° 85-12 du 5 mars 1985 abroge la loi 59-18, à l'exception des dispositions sur l'invalidité ne résultant pas de l'exercice des fonctions."
+    - title: قانون عدد 18 لسنة 1959 مؤرخ في 5 فيفري 1959 يتعلق بضبط نظام جرايات التقاعد المدني والعسكري، الفصل 5
+      href: https://www.pist.tn/jort/1959/1959A/Ja00859.pdf
+      note: "الرائد الرسمي عدد 8 بتاريخ 3-6 فيفري 1959. لا ينص القانون على تاريخ لبداية سريان الفصل 5."
     1975-01-01:
-    - title: Loi n° 74 - 101 du 25 décembre 1974 portant loi de finances pour l'année 1975
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1974/loi_74-101_fr.pdf
-      note: Conformément à la loi 85-12 du 05/03/1985 sont abrogées toutes dispositions antérieures contradictoires à cette loi
-    - title: قانون عدد 101 لسنة 1974 مؤرخ في 25 ديسمبر 1974 يتعلّق بقانون المالية 1974
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1974/loi_74-101_ar.pdf
-      note: بمقتضى القانون عدد 12 لسنة 1985 المؤرخ في  5 مارس  1985 ألغيت جميع الأحكام السابقة المخالفة لهذا القانون
-    1985-10-01:
-    - title: Loi 85-12 du 5 mars 1985, portant régime des pensions civiles et militaires de retraite et des survivants dans le secteur public
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1985/loi_85_12_fr.pdf
-      note: "L’application des cotisations est partir du 01/10/1985 et ce conformément aux dispositions de l’article 75 de la loi 85-12 paru dans le journal officiel à la date du 12 mars 1985. La présente loi entre en vigueur à l'expiration d'un délai de six (6) mois à compter de la date de sa publication au Journal Officiel de la République Tunisienne."
-    - title: "قانون عدد 12 لسنة 1985 مؤرخ في 5  مارس 1985 يتعلق بنظام الجرايات المدنية والعسكرية للتقاعد وللباقين على قيد الحياة في القطاع العمومي"
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1985/loi_85_12_ar.pdf
-      note: "عملا بمقتضيات الفصل 75 من هذا القانون يدخل هذا القانون حيز النفاذ بانتهاء ستة اشهر من تاريخ نشره بالرائد الرسمي للجمهورية التونسية"
+    - title: Loi n° 74-101 du 25 décembre 1974 portant loi de finances pour l'année 1975, article 38
+      href: https://www.pist.tn/jort/1974/1974F/Jo08074.pdf
+      note: "JORT n° 80 du 31 décembre 1974, p. 2917. L'article 38 abroge et remplace l'article 5 de la loi 59-18 : le prélèvement passe à 5 %, mais l'assiette s'élargit simultanément aux émoluments globaux indiciaires, primes et indemnités entrant dans le calcul de la pension. La baisse de deux points ne se lit donc pas comme une baisse nette du prélèvement. L'article ne porte aucune date d'effet ; le 1er janvier 1975 se déduit du rattachement à la gestion 1975."
+    - title: قانون عدد 101 لسنة 1974 مؤرخ في 25 ديسمبر 1974 يتعلق بقانون المالية لسنة 1975، الفصل 38
+      href: https://www.pist.tn/jort/1974/1974A/Ja08074.pdf
+      note: "الرائد الرسمي عدد 80 بتاريخ 31 ديسمبر 1974. لا ينص الفصل على تاريخ لبداية السريان."
+    1985-09-12:
+    - title: Loi n° 85-12 du 5 mars 1985 portant régime des pensions civiles et militaires de retraite et des survivants dans le secteur public, article 9
+      href: https://www.pist.tn/jort/1985/1985F/Jo02085.pdf
+      note: "JORT n° 20 du 12 mars 1985, p. 359 ; article 75 p. 365. Le taux est inchangé, à 5 % : ce millésime marque la refonte du régime, non un mouvement de taux. L'article 75 fait entrer la loi en vigueur à l'expiration d'un délai de six mois à compter de la publication, soit le 12 septembre 1985 — date déduite, non énoncée telle quelle."
+    - title: قانون عدد 12 لسنة 1985 مؤرخ في 5 مارس 1985 يتعلق بنظام الجرايات المدنية والعسكرية للتقاعد وللباقين على قيد الحياة في القطاع العمومي، الفصل 9
+      href: https://www.pist.tn/jort/1985/1985A/Ja02085.pdf
+      note: "الرائد الرسمي عدد 20 بتاريخ 12 مارس 1985. يدخل القانون حيز النفاذ بانتهاء ستة أشهر من تاريخ نشره عملا بالفصل 75."
     1994-07-01:
-    - title: Loi 94-71 du 27 juin 1994 relative à la révision des taux de la contribution aux régimes de retraite dans le secteur public
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1994/loi_94_71_fr.pdf
-    - title: قانون عدد  71 لسنة  1994 المؤرخ في 27 جوان 1994 يتعلق بتعديل نسب المساهمات في أنظمة التقاعد في القطاع العمومي
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1994/loi_94_71_ar.pdf
+    - title: Loi n° 94-71 du 27 juin 1994 relative à la révision des taux de la contribution aux régimes de retraite dans le secteur public, article unique
+      href: https://www.pist.tn/jort/1994/1994F/Jo05094.pdf
+      note: "JORT n° 50 du 28 juin 1994, p. 1086. Le relèvement de la part salariale prend effet au 1er juillet 1994 ; celui de la part patronale, au 1er juillet 1995."
+    - title: قانون عدد 71 لسنة 1994 مؤرخ في 27 جوان 1994 يتعلق بتعديل نسب المساهمات في أنظمة التقاعد في القطاع العمومي
+      href: https://www.pist.tn/jort/1994/1994A/Ja05094.pdf
+      note: "الرائد الرسمي عدد 50 بتاريخ 28 جوان 1994."
     2002-07-01:
-    - title: Loi 2001-123 du 28 décembre 2001 portant loi de finances 2002 (article 85)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_fr.pdf
-      note: "Les taux de la contribution au régime des pensions civiles et militaires de retraite et des survivants dans le secteur public et des régimes de retraite des membres du gouvernement, des députés et des gouverneurs sont relevés comme suit :  de 1 de pourcentage de la base de calcul de la contribution à la charge de l’assuré social et ce comme suit : 0.50 point de pourcentage à partir du 1er juillet 2002 , 0.25 point de pourcentage  à partir du 1er juillet 2003, 0.25 point de pourcentage à partir du 1er juillet 2004"
-    - title: قانون عدد 123 لسنــة 2001 مؤرخ في 28 ديسمبر 2001 يتعلق بقانون المالية لسنة 2002
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_ar.pdf
-      note: "ترفع نسب المساهمات بنظام الجرايات المدنية والعسكرية للتقاعد والباقين على قيد الحياة في القطاع العمومي وبأنظمة التقاعد لأعضاء الحكومة وأعضاء مجلس النواب والولاّة كما يلي :   1 بالمائة من قاعدة احتساب الاشتراك على كاهل المضمون الاجتماعي وذلك على النحو التالي : 0.50 بالمائة ابتداء من غرة جويلية ‏2002‏‏ ،  0.25  بالمائة ابتداء من غرة جويلية 2003 ، 0.25  بالمائة ابتداء من غرة جويلية 2004"
+    - title: Loi n° 2001-123 du 28 décembre 2001 portant loi de finances pour l'année 2002, article 85
+      href: https://www.pist.tn/jort/2001/2001F/Jo1042001.pdf
+      note: "JORT n° 104 du 28 décembre 2001, p. 4260. L'article porte un échéancier pluriannuel : la part de l'assuré social est relevée de 1 point, réparti en 0,50 point au 1er juillet 2002, 0,25 au 1er juillet 2003 et 0,25 au 1er juillet 2004. Les trois millésimes qui suivent relèvent donc de ce seul article."
+    - title: قانون عدد 123 لسنة 2001 مؤرخ في 28 ديسمبر 2001 يتعلق بقانون المالية لسنة 2002، الفصل 85
+      href: https://www.pist.tn/jort/2001/2001A/Ja1042001.pdf
+      note: "الرائد الرسمي عدد 104 بتاريخ 28 ديسمبر 2001. يضبط الفصل رزنامة متعددة السنوات."
+    2003-07-01:
+    - title: Loi n° 2001-123 du 28 décembre 2001 portant loi de finances pour l'année 2002, article 85 (échéancier)
+      href: https://www.pist.tn/jort/2001/2001F/Jo1042001.pdf
+      note: "Deuxième marche de l'échéancier de l'article 85 : 0,25 point au 1er juillet 2003. Aucun texte distinct ne fixe ce palier."
+    - title: قانون عدد 123 لسنة 2001 مؤرخ في 28 ديسمبر 2001 يتعلق بقانون المالية لسنة 2002، الفصل 85
+      href: https://www.pist.tn/jort/2001/2001A/Ja1042001.pdf
+    2004-07-01:
+    - title: Loi n° 2001-123 du 28 décembre 2001 portant loi de finances pour l'année 2002, article 85 (échéancier)
+      href: https://www.pist.tn/jort/2001/2001F/Jo1042001.pdf
+      note: "Troisième marche de l'échéancier de l'article 85 : 0,25 point au 1er juillet 2004. Aucun texte distinct ne fixe ce palier."
+    - title: قانون عدد 123 لسنة 2001 مؤرخ في 28 ديسمبر 2001 يتعلق بقانون المالية لسنة 2002، الفصل 85
+      href: https://www.pist.tn/jort/2001/2001A/Ja1042001.pdf
     2007-07-01:
-    - title: Loi 2007-43 du 25 juin 2007, modifiant et complétant les lois régissant les pensions servies au titre des régimes de retraite, d’invalidité et de survivants dans les secteurs public et privé et des régimes spéciaux.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/loi_2007_43_fr.pdf
-      note: "Le taux de la cotisation à la charge de l’assuré social augemte de 1,2 point de pourcentage,  et ce, comme suit : 0,40 à partir du 1er juillet 2007, 0,40 à partir du 1er juillet 2008 et 0,40 point de pourcentage à partir du 1er juillet 2009."
-    - title: قانون  عدد 43 لسنة 2007 مؤرخ في 25 جوان 2007 يتعلق بتنقيح وإتمام القوانين المنظمة للجرايات المسندة بعنوان أنظمة التقاعد والعجز والباقين على قيد الحياة في القطاعين العمومي والخاص والأنظمة الخصوصية
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/loi_2007_43_ar.pdf
-      note: "2 بالمائة من قاعدة احتساب الاشتراك على كاهل المضمون الاجتماعي وذلك على النحو التالي :  0,40 بالمائة ابتداء من أوّل جويلية 2007،  0,40 بالمائة ابتداء من أوّل جويلية 2008،  0,40 بالمائة ابتداء من أوّل جويلية 2009"
-    2019-06-01:
-    - title: Loi 2019-37 du 30 avril 2019, modifiant et complétant la loi 85-12 du 5 mars 1985, relative au régime des pensions civiles et militaires de retraite et des survivants dans le secteur public.
-      href: https://natlex.ilo.org/dyn/natlex2/natlex2/files/download/112573/TUN-112573.pdf
-      note: Majoration de la cotisation salariale de 1%, répartie en 0,5% le mois suivant l'entrée en vigueur (juin 2019) et 0,5% en janvier 2020.
+    - title: Loi n° 2007-43 du 25 juin 2007 modifiant et complétant les lois régissant les pensions servies au titre des régimes de retraite, d'invalidité et de survivants dans les secteurs public et privé et des régimes spéciaux, article premier
+      href: https://www.pist.tn/jort/2007/2007F/Jo0512007.pdf
+      note: "JORT n° 51 du 26 juin 2007, p. 2198. Second échéancier pluriannuel : la part de l'assuré social est relevée de 1,2 point, réparti en 0,40 point au 1er juillet 2007, 2008 et 2009. La part patronale suit un calendrier distinct, en janvier."
+    - title: قانون عدد 43 لسنة 2007 مؤرخ في 25 جوان 2007 يتعلق بتنقيح وإتمام القوانين المنظمة للجرايات المسندة بعنوان أنظمة التقاعد والعجز والباقين على قيد الحياة في القطاعين العمومي والخاص والأنظمة الخصوصية، الفصل الأول
+      href: https://www.pist.tn/jort/2007/2007A/Ja0512007.pdf
+      note: "الرائد الرسمي عدد 51 بتاريخ 26 جوان 2007."
+    2008-07-01:
+    - title: Loi n° 2007-43 du 25 juin 2007, article premier (échéancier)
+      href: https://www.pist.tn/jort/2007/2007F/Jo0512007.pdf
+      note: "Deuxième marche de l'échéancier : 0,40 point au 1er juillet 2008. Aucun texte distinct ne fixe ce palier."
+    - title: قانون عدد 43 لسنة 2007 مؤرخ في 25 جوان 2007، الفصل الأول
+      href: https://www.pist.tn/jort/2007/2007A/Ja0512007.pdf
+    2009-07-01:
+    - title: Loi n° 2007-43 du 25 juin 2007, article premier (échéancier)
+      href: https://www.pist.tn/jort/2007/2007F/Jo0512007.pdf
+      note: "Troisième marche de l'échéancier : 0,40 point au 1er juillet 2009. Aucun texte distinct ne fixe ce palier."
+    - title: قانون عدد 43 لسنة 2007 مؤرخ في 25 جوان 2007، الفصل الأول
+      href: https://www.pist.tn/jort/2007/2007A/Ja0512007.pdf
     2020-01-01:
-    - title: Loi 2019-37 du 30 avril 2019, modifiant et complétant la loi 85-12 du 5 mars 1985, relative au régime des pensions civiles et militaires de retraite et des survivants dans le secteur public.
-      href: https://natlex.ilo.org/dyn/natlex2/natlex2/files/download/112573/TUN-112573.pdf
+    - title: Loi n° 2019-37 du 30 avril 2019 modifiant et complétant la loi n° 85-12 du 5 mars 1985 relative au régime des pensions civiles et militaires de retraite et des survivants dans le secteur public, article 4
+      href: https://www.pist.tn/jort/2019/2019F/Jo0352019.pdf
+      note: "JORT n° 35 du 30 avril 2019, p. 1314. L'article 4 majore les taux de 3 points au total, répartis ainsi : « Au titre de l'employeur : 2 % à partir du premier jour du mois qui suit la date d'entrée en vigueur de la présente loi. Au titre de l'agent : 1 % à partir du premier janvier 2020. » La part salariale monte donc d'un point en une seule fois au 1er janvier 2020. Le palier intermédiaire au 1er juin 2019 (8,7 %) que portait ce fichier est contredit par le texte : cette date vaut pour la part patronale seule."
+    - title: قانون عدد 37 لسنة 2019 مؤرخ في 30 أفريل 2019 يتعلق بتنقيح وإتمام القانون عدد 12 لسنة 1985 المؤرخ في 5 مارس 1985 المتعلق بنظام الجرايات المدنية والعسكرية للتقاعد وللباقين على قيد الحياة في القطاع العمومي، الفصل 4
+      href: https://www.pist.tn/jort/2019/2019A/Ja0352019.pdf
+      note: "الرائد الرسمي عدد 35 بتاريخ 30 أفريل 2019. ترفع مساهمة العون بنقطة واحدة ابتداء من غرة جانفي 2020."
   official_journal_date:
-    2019-06-01: "2019-04-30"
+    1959-02-01: "1959-02-03"
+    1975-01-01: "1974-12-31"
+    1985-09-12: "1985-03-12"
+    1994-07-01: "1994-06-28"
+    2002-07-01: "2001-12-28"
+    2003-07-01: "2001-12-28"
+    2004-07-01: "2001-12-28"
+    2007-07-01: "2007-06-26"
+    2008-07-01: "2007-06-26"
+    2009-07-01: "2007-06-26"
     2020-01-01: "2019-04-30"
   rate_unit: /1
   threshold_unit: currency

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_public/salarie_cnrps/index.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_public/salarie_cnrps/index.yaml
@@ -4,9 +4,12 @@ metadata:
   - cotisations_salarie
   - cotisations_employeur
 documentation: |-
-  La C.N.R.P.S a été créée, par la loi n° 75-83 du 31 décembre 1975 portant loi de finances pour la gestion 1976,
-  en remplacement de la Caisse nationale de retraite (CNR) et de la Caisse de prévoyance sociale (CPS)
-  créées respectivement par la loi n°59-19 du 5 février 1959 et la loi n° 59-45 du 15 avril 1959.
+  La C.N.R.P.S est née de l'article 28 de la loi n° 75-83 du 30 décembre 1975 portant loi de finances
+  pour la gestion 1976 (JORT n° 87, p. 2854), qui « transforme en un établissement public à caractère
+  financier » la Caisse nationale de retraite (CNR) et la Caisse de prévoyance sociale (CPS), créées
+  respectivement par la loi n° 59-19 du 5 février 1959 et la loi n° 59-45 du 15 avril 1959. Le régime
+  lui-même, et l'appellation de Caisse nationale de retraites, procèdent de la loi n° 59-18 du même jour.
+  Le fascicule date la loi de finances du 30 décembre 1975, et non du 31.
 
   La C.N.R.P.S assure la gestion des régimes de retraite, de prévoyance sociale et du capital décès.
   La couverture sociale concerne les agents de l’Etat, des établissements publics, des collectivités locales

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-Tunisia"
-version = "0.77"
+version = "0.78"
 description = "OpenFisca Rules as Code model for Tunisia."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "tunisia"]

--- a/tests/test_cotisations_cnrps.py
+++ b/tests/test_cotisations_cnrps.py
@@ -1,0 +1,64 @@
+"""La série des taux de retraite CNRPS, telle que les textes la fixent.
+
+Le point vérifié ici est celui qu'un fichier de paramètres ne peut pas défendre seul :
+l'article 4 de la loi n° 2019-37 du 30 avril 2019 (JORT n° 35, p. 1314) majore la part
+de l'agent de « 1 % à partir du premier janvier 2020 », en une seule fois. Le fichier
+portait un palier intermédiaire au 1er juin 2019 — cette date est celle de la part
+patronale, et le test l'interdit désormais de revenir.
+"""
+
+import datetime
+
+from openfisca_tunisia import TunisiaTaxBenefitSystem
+
+
+tax_benefit_system = TunisiaTaxBenefitSystem()
+
+RETRAITE_SALARIE = (
+    "prelevements_sociaux.cotisations_sociales.secteur_public.salarie_cnrps"
+    ".cotisations_salarie.retraite"
+)
+RETRAITE_EMPLOYEUR = (
+    "prelevements_sociaux.cotisations_sociales.secteur_public.salarie_cnrps"
+    ".cotisations_employeur.retraite"
+)
+
+
+def _taux(chemin, date):
+    parametres = tax_benefit_system.get_parameters_at_instant(date)
+    noeud = parametres
+    for element in chemin.split("."):
+        noeud = getattr(noeud, element)
+    return noeud.rates[0]
+
+
+def test_le_point_de_2019_tombe_en_une_fois_au_1er_janvier_2020():
+    assert _taux(RETRAITE_SALARIE, "2019-05-31") == 0.082
+    assert _taux(RETRAITE_SALARIE, "2019-12-31") == 0.082
+    assert _taux(RETRAITE_SALARIE, "2020-01-01") == 0.092
+
+
+def test_les_echeanciers_pluriannuels_de_2002_et_2007():
+    # Loi de finances 2002, article 85 : 0,50 / 0,25 / 0,25 en juillet.
+    assert _taux(RETRAITE_SALARIE, "2002-06-30") == 0.06
+    assert _taux(RETRAITE_SALARIE, "2002-07-01") == 0.065
+    assert _taux(RETRAITE_SALARIE, "2003-07-01") == 0.0675
+    assert _taux(RETRAITE_SALARIE, "2004-07-01") == 0.07
+    # Loi 2007-43, article premier : 0,40 trois fois, en juillet.
+    assert _taux(RETRAITE_SALARIE, "2007-07-01") == 0.074
+    assert _taux(RETRAITE_SALARIE, "2008-07-01") == 0.078
+    assert _taux(RETRAITE_SALARIE, "2009-07-01") == 0.082
+
+
+def test_les_marches_patronales_de_2007_tombent_en_janvier():
+    # Loi 2007-43 : 0,60 point au 1er janvier 2007, 2008 et 2009 — la part patronale
+    # suit un calendrier distinct de celui de la part salariale.
+    assert _taux(RETRAITE_EMPLOYEUR, "2007-01-01") == 0.103
+    assert _taux(RETRAITE_EMPLOYEUR, "2007-12-31") == 0.103
+    assert _taux(RETRAITE_EMPLOYEUR, "2008-01-01") == 0.109
+    assert _taux(RETRAITE_EMPLOYEUR, "2009-01-01") == 0.115
+
+
+def test_la_serie_reste_definie_sur_toute_sa_longueur():
+    for annee in range(1960, datetime.date.today().year + 1):
+        assert _taux(RETRAITE_SALARIE, f"{annee}-06-30") > 0


### PR DESCRIPTION
Les paramètres de cotisations du secteur public portaient les bonnes valeurs mais des liens vers un dépôt GitLab personnel — et deux dates que les textes contredisent. Chaque palier a été relu sur le fascicule du JORT ; les références pointent désormais vers pist.tn, en édition française **et** arabe, avec numéro de fascicule et page.

## Trois corrections de fond

**Le palier salarié du 1er juin 2019 n'existe pas.** L'article 4 de la loi n° 2019-37 (JORT n° 35 du 30 avril 2019, p. 1314) est sans ambiguïté :

> Au titre de l'employeur : — 2 % à partir du premier jour du mois qui suit la date d'entrée en vigueur de la présente loi.
> Au titre de l'agent : — 1 % à partir du premier janvier 2020

La part salariale monte donc d'un point **en une seule fois au 1er janvier 2020**, et non par deux demi-points en juin 2019 puis janvier 2020. La date de juin 2019 vaut pour la part patronale seule (12,5 % → 14,5 %).

**La deuxième marche patronale de 2008 tombe en janvier.** La loi n° 2007-43 (p. 2198) donne 0,60 point au 1er janvier 2007, 2008 et 2009 côté employeur, contre 0,40 au 1er juillet des mêmes années côté salarié. Le fichier datait 2007 et 2009 en janvier et 2008 en juillet : il se contredisait lui-même.

**La prévoyance sociale des pensionnés commençait en 1959 sans aucun texte.** Le décret n° 2007-1406 (JORT n° 49, art. 2 p. 2156, art. 13 p. 2162) assied la cotisation sur le montant brut de la pension et échelonne le taux — 1 % au 1er juillet 2007, puis 2, 3 et 4 %. Aucun texte antérieur établissant un prélèvement **obligatoire** sur la pension n'a pu être retrouvé : le seul candidat, le décret n° 73-91 du 12 mars 1973, loge son 2 % dans un article consacré au régime *facultatif* d'assurance-maladie, et un taux qui baisserait de 2 % à 1 % en trente-quatre ans ne se lit pas comme une même série. La série commence donc en 2007.

## Deux mises au point documentaires

**Les quatre paliers « sans texte » n'en ont jamais eu.** 2003, 2004, 2008 et 2009 sont programmés à l'avance par l'article 85 de la loi de finances 2002 et l'article premier de la loi 2007-43, qui portent chacun un échéancier pluriannuel dans un article unique. Ils sont désormais référencés comme tels, avec la mention explicite qu'aucun texte distinct ne les fixe.

**La CNRPS naît le 30 décembre 1975, non le 31.** L'article 28 de la loi n° 75-83 portant loi de finances pour la gestion 1976 (JORT n° 87, p. 2854) « transforme en un établissement public à caractère financier » la CNR et la CPS : la caisse procède d'une fusion, elle n'est pas une création *ex nihilo*. Les deux `index.yaml` le disent maintenant, et citent la page.

Le millésime de 1985 est redaté au **12 septembre** — six mois après la publication du 12 mars, comme l'article 75 le prescrit. Le taux est inchangé de part et d'autre : ce millésime marque la refonte du régime, pas un mouvement de taux.

## Ce qui reste ouvert

La date du 1er février 1959 est conservée faute de mieux, mais elle n'a aucun appui textuel : la loi n° 59-18 n'énonce pas de date d'effet pour son article 5, et la seule date qu'elle fixe — le 1er avril 1959, article 52 — porte sur l'ouverture des droits à pension. La note du paramètre le dit désormais plutôt que de laisser croire à une date établie.

Le palier patronal de juillet 2011 (décret-loi n° 2011-48) reste au niveau « métadonnées » : son URL pist.tn est vérifiée, son contenu n'a pas été lu.

## Tests

`tests/test_cotisations_cnrps.py` garde la série. Le premier cas échoue si le palier de juin 2019 revient — vérifié par test négatif avant de proposer la PR. 157 tests passent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2qMrmbL6BUDiEo3NmpU5m