### PR TITLE
Dater les cotisations du secteur privé sur leurs textes et les sourcer au JORT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.79 - [#398](https://github.com/openfisca/openfisca-tunisia/pull/398)
+
+* Correction d'un bug.
+* Périodes concernées : à partir du 1974-01-01.
+* Zones impactées : `parameters/prelevements_sociaux/cotisations_sociales/secteur_prive`.
+* Détails :
+  - Date les **37 valeurs du secteur privé qui portaient le 1er janvier 1960** sans aucune référence. La structure qu'elles décrivent n'existe pas avant 1997 : le taux du régime général est la somme des 18 % répartis 13/5 de l'article 41 (nouveau) de la **loi n° 97-4** (publiée le 4 février 1997), du fonds spécial de l'État de l'article 57 de la **loi n° 74-101** (1er janvier 1975) et de la cotisation propre du régime de pensions de l'article 9 (nouveau) du **décret n° 97-555** — soit 23,75 %, dont les 16,00 % et 7,75 % que porte le modèle avant assurance maladie. La dernière pièce est le **décret n° 2003-1212**, qui porte la quote-part des pensions à 7,25/20e au 1er janvier 2003.
+  - Date les autres régimes sur leurs textes : **1981-02-24** pour les salariés agricoles (loi n° 81-6, décret n° 81-224), **1989-10-01** pour le régime agricole amélioré (loi n° 89-73, art. 4 et 90), **1995-07-03** pour les travailleurs non salariés (décret n° 95-1166), **2002-12-31** pour les artistes (loi n° 2002-104), **1989-01-10** pour les Tunisiens à l'étranger (décret n° 89-107), **1995-04-01** pour le point transféré aux accidents du travail (décret n° 95-538), **1996-11-22** pour la protection sociale des travailleurs (loi n° 96-101) et **1974-01-01** pour la retraite complémentaire (arrêté du 18 novembre 1978).
+  - Ajoute la valeur manquante de la **cotisation des étudiants** : la série commençait à 5 dinars, alors que le décret n° 92-631 la fixe d'abord à **2 dinars**.
+  - Remplace **toutes** les références du secteur privé — dépôt GitLab personnel et, pour la perte d'emploi, un site commercial — par les fascicules du JORT sur pist.tn, avec numéro de fascicule, page et lien vers l'édition arabe. La référence de la perte d'emploi pointe vers l'édition arabe : l'édition française de ce fascicule répond 404, et c'est dans l'arabe que l'article 17 de la loi n° 2024-48 a été lu.
+  - Consigne dans les notes trois défauts de structure qui appellent des correctifs distincts : le point d'accidents du travail n'est pas le tarif d'accidents du travail (patronal, de 0,50 % à 5 % selon dix-huit classes) ; le seuil de 0,66 du régime des bas revenus est une assiette forfaitaire et non un plafond, et ses quatre valeurs croisent deux répartitions que les textes ne croisent jamais ; l'assiette de la retraite complémentaire est la fraction de salaire excédant la limite de calcul des prestations, et son taux de 9 % n'a aucune source publiée.
+  - **Aucune valeur de taux n'est modifiée** : les tableaux engendrés par le précis socio-fiscal sont identiques avant et après.
+
+<!-- -->
+
 ## 0.78 - [#397](https://github.com/openfisca/openfisca-tunisia/pull/397)
 
 * Correction d'un bug.

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/raci/cotisations_salarie/assurances_sociales/deces.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/raci/cotisations_salarie/assurances_sociales/deces.yaml
@@ -1,11 +1,18 @@
 description: Indemnités de décès et capital décès
 brackets:
 - threshold:
-    2003-01-01:
+    2002-12-31:
       value: 0
   rate:
-    2003-01-01:
+    2002-12-31:
       value: 0.0051
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    2002-12-31:
+    - title: "Loi n° 2002-104 du 30 décembre 2002 relative au régime de sécurité sociale des artistes, des créateurs et des intellectuels, article 7"
+      href: "https://www.pist.tn/jort/2002/2002F/Jo1062002.pdf"
+      note: "JORT n° 106, p. 3187-3190. Fixe le taux à 11 %, réparti 7 points de pensions et 4 points d'assurances sociales — architecture identique à celle des travailleurs non salariés. La loi ne comporte aucune clause d'entrée en vigueur ; la date retenue est celle de la publication. Édition arabe : https://www.pist.tn/jort/2002/2002A/Ja1062002.pdf"
+  official_journal_date:
+    2002-12-31: "2002-12-31"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/raci/cotisations_salarie/assurances_sociales/maladie.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/raci/cotisations_salarie/assurances_sociales/maladie.yaml
@@ -1,10 +1,10 @@
 description: Assurance Maladie
 brackets:
 - threshold:
-    2003-01-01:
+    2002-12-31:
       value: 0
   rate:
-    2003-01-01:
+    2002-12-31:
       value: 0.0304
     2007-07-01:
       value: 0.0397
@@ -17,3 +17,10 @@ brackets:
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    2002-12-31:
+    - title: "Loi n° 2002-104 du 30 décembre 2002 relative au régime de sécurité sociale des artistes, des créateurs et des intellectuels, article 7"
+      href: "https://www.pist.tn/jort/2002/2002F/Jo1062002.pdf"
+      note: "JORT n° 106, p. 3187-3190. Fixe le taux à 11 %, réparti 7 points de pensions et 4 points d'assurances sociales — architecture identique à celle des travailleurs non salariés. La loi ne comporte aucune clause d'entrée en vigueur ; la date retenue est celle de la publication. Édition arabe : https://www.pist.tn/jort/2002/2002A/Ja1062002.pdf"
+  official_journal_date:
+    2002-12-31: "2002-12-31"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/raci/cotisations_salarie/assurances_sociales/maternite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/raci/cotisations_salarie/assurances_sociales/maternite.yaml
@@ -1,11 +1,18 @@
 description: Indemnités de maladie et maternité
 brackets:
 - threshold:
-    2003-01-01:
+    2002-12-31:
       value: 0
   rate:
-    2003-01-01:
+    2002-12-31:
       value: 0.0045
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    2002-12-31:
+    - title: "Loi n° 2002-104 du 30 décembre 2002 relative au régime de sécurité sociale des artistes, des créateurs et des intellectuels, article 7"
+      href: "https://www.pist.tn/jort/2002/2002F/Jo1062002.pdf"
+      note: "JORT n° 106, p. 3187-3190. Fixe le taux à 11 %, réparti 7 points de pensions et 4 points d'assurances sociales — architecture identique à celle des travailleurs non salariés. La loi ne comporte aucune clause d'entrée en vigueur ; la date retenue est celle de la publication. Édition arabe : https://www.pist.tn/jort/2002/2002A/Ja1062002.pdf"
+  official_journal_date:
+    2002-12-31: "2002-12-31"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/raci/cotisations_salarie/index.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/raci/cotisations_salarie/index.yaml
@@ -1,4 +1,6 @@
 description: Régime des créateurs, artistes et intellectuels
 metadata:
   reference:
-    title: Loi n°2002-104 du 30 décembre 2002, relative au régime de sécurité sociale des artistes, des créateurs et des intellectuels.
+    title: "Loi n° 2002-104 du 30 décembre 2002 relative au régime de sécurité sociale des artistes, des créateurs et des intellectuels"
+    href: "https://www.pist.tn/jort/2002/2002F/Jo1062002.pdf"
+    note: "JORT n° 106, p. 3187-3190. Édition arabe : https://www.pist.tn/jort/2002/2002A/Ja1062002.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/raci/cotisations_salarie/retraite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/raci/cotisations_salarie/retraite.yaml
@@ -1,11 +1,18 @@
 description: Pensions
 brackets:
 - threshold:
-    2003-01-01:
+    2002-12-31:
       value: 0
   rate:
-    2003-01-01:
+    2002-12-31:
       value: 0.07
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    2002-12-31:
+    - title: "Loi n° 2002-104 du 30 décembre 2002 relative au régime de sécurité sociale des artistes, des créateurs et des intellectuels, article 7"
+      href: "https://www.pist.tn/jort/2002/2002F/Jo1062002.pdf"
+      note: "JORT n° 106, p. 3187-3190. Fixe le taux à 11 %, réparti 7 points de pensions et 4 points d'assurances sociales — architecture identique à celle des travailleurs non salariés. La loi ne comporte aucune clause d'entrée en vigueur ; la date retenue est celle de la publication. Édition arabe : https://www.pist.tn/jort/2002/2002A/Ja1062002.pdf"
+  official_journal_date:
+    2002-12-31: "2002-12-31"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/re/cotisation.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/re/cotisation.yaml
@@ -1,8 +1,17 @@
 description: Montant de la cotisation
 values:
+  1992-03-23:
+    value: 2
   2003-07-02:
     value: 5
 metadata:
   unit: currency
   reference:
-    title: Décret n°92-631 du 23 mars 1992 tel que modifié par le décret n°2003-1544 du 2 juillet 2003, fixant les conditions de bénéfice du régime de sécurité sociale des étudiants.
+    1992-03-23:
+    - title: "Décret n° 92-631 du 23 mars 1992 fixant les conditions de bénéfice du régime de sécurité sociale des étudiants, article 2"
+      href: "https://www.pist.tn/jort/1992/1992F/Jo02192.pdf"
+      note: "JORT n° 21, p. 426-427. Fixe la cotisation forfaitaire annuelle à 2 dinars — valeur que ce fichier ignorait, sa série commençant directement à 5 dinars. Le décret n'énonce pas de date d'effet ; la date retenue est celle de sa signature. Les branches couvertes par le régime ne sont énoncées ni par ce décret ni par celui de 2003 : elles supposent l'ouverture de la loi n° 65-17, qui n'a pas été faite. Édition arabe : https://www.pist.tn/jort/1992/1992A/Ja02192.pdf"
+    2003-07-02:
+    - title: "Décret n° 2003-1544 du 2 juillet 2003 modifiant le décret n° 92-631 du 23 mars 1992"
+      href: "https://www.pist.tn/jort/2003/2003F/Jo0552003.pdf"
+      note: "JORT n° 55, p. 2132. Porte la cotisation forfaitaire de 2 à 5 dinars. Le décret n'énonce pas de date d'effet ; la date retenue est celle de sa signature. Édition arabe : https://www.pist.tn/jort/2003/2003A/Ja0552003.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/re/index.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/re/index.yaml
@@ -1,4 +1,6 @@
 description: Régime des étudiants
 metadata:
   reference:
-    title: Loi n° 65-17 du 28 juin 1965 (28 safar 1385), étendant les régimes de sécurité sociale aux étudiants.
+    title: "Loi n° 65-17 du 28 juin 1965 étendant les régimes de sécurité sociale aux étudiants"
+    href: "https://www.pist.tn/jort/1965/1965F/Jo03465.pdf"
+    note: "JORT n° 34 de 1965, p. 787. Texte non ouvert : les branches que ce régime couvre restent à établir sur lui. Édition arabe : https://www.pist.tn/jort/1965/1965A/Ja03465.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_employeur/assurances_sociales/deces.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_employeur/assurances_sociales/deces.yaml
@@ -1,11 +1,19 @@
 description: Indemnités de décès et capital décès
 brackets:
 - threshold:
-    1960-01-01:
+    1981-02-24:
       value: 0
   rate:
-    1960-01-01:
+    1981-02-24:
       value: 0.000375
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1981-02-24:
+    - title: "Décret n° 81-224 du 24 février 1981 fixant la répartition des cotisations de sécurité sociale dans le secteur agricole"
+      href: "https://www.pist.tn/jort/1981/1981F/Jo01381.pdf"
+      note: "JORT n° 13, p. 425-426. Répartit les 6,45 % en 1,20 % d'assurances sociales et 5,25 % de pensions. Le partage interne des 1,20 % entre maladie, maternité et décès n'est fixé par aucun texte identifié : seule la part maladie de 0,91 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1981/1981A/Ja01381.pdf"
+    - title: "Loi n° 81-6 du 12 février 1981 organisant les régimes de sécurité sociale dans le secteur agricole, article 18"
+      href: "https://www.pist.tn/jort/1981/1981F/Jo00981.pdf"
+      note: "JORT n° 9, p. 265-273. Fixe le taux global du régime des salariés agricoles à 6,45 %. La loi n'énonce pas de date d'effet. Édition arabe : https://www.pist.tn/jort/1981/1981A/Ja00981.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_employeur/assurances_sociales/maladie.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_employeur/assurances_sociales/maladie.yaml
@@ -1,10 +1,10 @@
 description: Assurance maladie
 brackets:
 - threshold:
-    1960-01-01:
+    1981-02-24:
       value: 0
   rate:
-    1960-01-01:
+    1981-02-24:
       value: 0.0068
     2007-07-01:
       value: 0.013
@@ -19,3 +19,11 @@ brackets:
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1981-02-24:
+    - title: "Décret n° 81-224 du 24 février 1981 fixant la répartition des cotisations de sécurité sociale dans le secteur agricole"
+      href: "https://www.pist.tn/jort/1981/1981F/Jo01381.pdf"
+      note: "JORT n° 13, p. 425-426. Répartit les 6,45 % en 1,20 % d'assurances sociales et 5,25 % de pensions. Le partage interne des 1,20 % entre maladie, maternité et décès n'est fixé par aucun texte identifié : seule la part maladie de 0,91 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1981/1981A/Ja01381.pdf"
+    - title: "Loi n° 81-6 du 12 février 1981 organisant les régimes de sécurité sociale dans le secteur agricole, article 18"
+      href: "https://www.pist.tn/jort/1981/1981F/Jo00981.pdf"
+      note: "JORT n° 9, p. 265-273. Fixe le taux global du régime des salariés agricoles à 6,45 %. La loi n'énonce pas de date d'effet. Édition arabe : https://www.pist.tn/jort/1981/1981A/Ja00981.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_employeur/assurances_sociales/maternite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_employeur/assurances_sociales/maternite.yaml
@@ -1,11 +1,19 @@
 description: Indemnités de maladie et maternité
 brackets:
 - threshold:
-    1960-01-01:
+    1981-02-24:
       value: 0
   rate:
-    1960-01-01:
+    1981-02-24:
       value: 0.0018
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1981-02-24:
+    - title: "Décret n° 81-224 du 24 février 1981 fixant la répartition des cotisations de sécurité sociale dans le secteur agricole"
+      href: "https://www.pist.tn/jort/1981/1981F/Jo01381.pdf"
+      note: "JORT n° 13, p. 425-426. Répartit les 6,45 % en 1,20 % d'assurances sociales et 5,25 % de pensions. Le partage interne des 1,20 % entre maladie, maternité et décès n'est fixé par aucun texte identifié : seule la part maladie de 0,91 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1981/1981A/Ja01381.pdf"
+    - title: "Loi n° 81-6 du 12 février 1981 organisant les régimes de sécurité sociale dans le secteur agricole, article 18"
+      href: "https://www.pist.tn/jort/1981/1981F/Jo00981.pdf"
+      note: "JORT n° 9, p. 265-273. Fixe le taux global du régime des salariés agricoles à 6,45 %. La loi n'énonce pas de date d'effet. Édition arabe : https://www.pist.tn/jort/1981/1981A/Ja00981.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_employeur/retraite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_employeur/retraite.yaml
@@ -1,11 +1,19 @@
 description: Pensions
 brackets:
 - threshold:
-    1960-01-01:
+    1981-02-24:
       value: 0
   rate:
-    1960-01-01:
+    1981-02-24:
       value: 0.035
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1981-02-24:
+    - title: "Décret n° 81-224 du 24 février 1981 fixant la répartition des cotisations de sécurité sociale dans le secteur agricole"
+      href: "https://www.pist.tn/jort/1981/1981F/Jo01381.pdf"
+      note: "JORT n° 13, p. 425-426. Répartit les 6,45 % en 1,20 % d'assurances sociales et 5,25 % de pensions. Le partage interne des 1,20 % entre maladie, maternité et décès n'est fixé par aucun texte identifié : seule la part maladie de 0,91 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1981/1981A/Ja01381.pdf"
+    - title: "Loi n° 81-6 du 12 février 1981 organisant les régimes de sécurité sociale dans le secteur agricole, article 18"
+      href: "https://www.pist.tn/jort/1981/1981F/Jo00981.pdf"
+      note: "JORT n° 9, p. 265-273. Fixe le taux global du régime des salariés agricoles à 6,45 %. La loi n'énonce pas de date d'effet. Édition arabe : https://www.pist.tn/jort/1981/1981A/Ja00981.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_salarie/assurances_sociales/deces.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_salarie/assurances_sociales/deces.yaml
@@ -1,11 +1,19 @@
 description: Indemnités de décès et capital décès
 brackets:
 - threshold:
-    1960-01-01:
+    1981-02-24:
       value: 0
   rate:
-    1960-01-01:
+    1981-02-24:
       value: 0.000125
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1981-02-24:
+    - title: "Décret n° 81-224 du 24 février 1981 fixant la répartition des cotisations de sécurité sociale dans le secteur agricole"
+      href: "https://www.pist.tn/jort/1981/1981F/Jo01381.pdf"
+      note: "JORT n° 13, p. 425-426. Répartit les 6,45 % en 1,20 % d'assurances sociales et 5,25 % de pensions. Le partage interne des 1,20 % entre maladie, maternité et décès n'est fixé par aucun texte identifié : seule la part maladie de 0,91 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1981/1981A/Ja01381.pdf"
+    - title: "Loi n° 81-6 du 12 février 1981 organisant les régimes de sécurité sociale dans le secteur agricole, article 18"
+      href: "https://www.pist.tn/jort/1981/1981F/Jo00981.pdf"
+      note: "JORT n° 9, p. 265-273. Fixe le taux global du régime des salariés agricoles à 6,45 %. La loi n'énonce pas de date d'effet. Édition arabe : https://www.pist.tn/jort/1981/1981A/Ja00981.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_salarie/assurances_sociales/maladie.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_salarie/assurances_sociales/maladie.yaml
@@ -1,10 +1,10 @@
 description: Assurance Maladie
 brackets:
 - threshold:
-    1981-01-01:
+    1981-02-24:
       value: 0
   rate:
-    1981-01-01:
+    1981-02-24:
       value: 0.0023
     2007-07-01:
       value: 0.0023
@@ -19,3 +19,11 @@ brackets:
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1981-02-24:
+    - title: "Décret n° 81-224 du 24 février 1981 fixant la répartition des cotisations de sécurité sociale dans le secteur agricole"
+      href: "https://www.pist.tn/jort/1981/1981F/Jo01381.pdf"
+      note: "JORT n° 13, p. 425-426. Répartit les 6,45 % en 1,20 % d'assurances sociales et 5,25 % de pensions. Le partage interne des 1,20 % entre maladie, maternité et décès n'est fixé par aucun texte identifié : seule la part maladie de 0,91 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1981/1981A/Ja01381.pdf"
+    - title: "Loi n° 81-6 du 12 février 1981 organisant les régimes de sécurité sociale dans le secteur agricole, article 18"
+      href: "https://www.pist.tn/jort/1981/1981F/Jo00981.pdf"
+      note: "JORT n° 9, p. 265-273. Fixe le taux global du régime des salariés agricoles à 6,45 %. La loi n'énonce pas de date d'effet. Édition arabe : https://www.pist.tn/jort/1981/1981A/Ja00981.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_salarie/assurances_sociales/maternite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_salarie/assurances_sociales/maternite.yaml
@@ -1,11 +1,19 @@
 description: Indemnités de maladie et maternité
 brackets:
 - threshold:
-    1960-01-01:
+    1981-02-24:
       value: 0
   rate:
-    1960-01-01:
+    1981-02-24:
       value: 0.0006
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1981-02-24:
+    - title: "Décret n° 81-224 du 24 février 1981 fixant la répartition des cotisations de sécurité sociale dans le secteur agricole"
+      href: "https://www.pist.tn/jort/1981/1981F/Jo01381.pdf"
+      note: "JORT n° 13, p. 425-426. Répartit les 6,45 % en 1,20 % d'assurances sociales et 5,25 % de pensions. Le partage interne des 1,20 % entre maladie, maternité et décès n'est fixé par aucun texte identifié : seule la part maladie de 0,91 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1981/1981A/Ja01381.pdf"
+    - title: "Loi n° 81-6 du 12 février 1981 organisant les régimes de sécurité sociale dans le secteur agricole, article 18"
+      href: "https://www.pist.tn/jort/1981/1981F/Jo00981.pdf"
+      note: "JORT n° 9, p. 265-273. Fixe le taux global du régime des salariés agricoles à 6,45 %. La loi n'énonce pas de date d'effet. Édition arabe : https://www.pist.tn/jort/1981/1981A/Ja00981.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_salarie/retraite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_salarie/retraite.yaml
@@ -1,11 +1,19 @@
 description: Pensions
 brackets:
 - threshold:
-    1960-01-01:
+    1981-02-24:
       value: 0
   rate:
-    1960-01-01:
+    1981-02-24:
       value: 0.0175
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1981-02-24:
+    - title: "Décret n° 81-224 du 24 février 1981 fixant la répartition des cotisations de sécurité sociale dans le secteur agricole"
+      href: "https://www.pist.tn/jort/1981/1981F/Jo01381.pdf"
+      note: "JORT n° 13, p. 425-426. Répartit les 6,45 % en 1,20 % d'assurances sociales et 5,25 % de pensions. Le partage interne des 1,20 % entre maladie, maternité et décès n'est fixé par aucun texte identifié : seule la part maladie de 0,91 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1981/1981A/Ja01381.pdf"
+    - title: "Loi n° 81-6 du 12 février 1981 organisant les régimes de sécurité sociale dans le secteur agricole, article 18"
+      href: "https://www.pist.tn/jort/1981/1981F/Jo00981.pdf"
+      note: "JORT n° 9, p. 265-273. Fixe le taux global du régime des salariés agricoles à 6,45 %. La loi n'énonce pas de date d'effet. Édition arabe : https://www.pist.tn/jort/1981/1981A/Ja00981.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_employeur/assurances_sociales/deces.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_employeur/assurances_sociales/deces.yaml
@@ -1,11 +1,16 @@
 description: Indemnités de décès et capital décès
 brackets:
 - threshold:
-    1960-01-01:
+    1989-10-01:
       value: 0
   rate:
-    1960-01-01:
+    1989-10-01:
       value: 0.0008
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1989-10-01:
+    - title: "Loi n° 89-73 du 2 septembre 1989 modifiant et complétant la loi n° 81-6 du 12 février 1981, articles 4 et 90"
+      href: "https://www.pist.tn/jort/1989/1989F/Jo06089.pdf"
+      note: "JORT n° 60, p. 1338-1339. Ajoute à la loi de 1981 le titre III instituant le régime agricole amélioré, avec effet au 1er octobre 1989 (article 4). L'article 90 fixe le taux global à 15 %, réparti 10 % employeur et 5 % salarié, et renvoie sa ventilation par branche à un décret QUI N'A PAS ÉTÉ IDENTIFIÉ : seule la part maladie de 2,28 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1989/1989A/Ja06089.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_employeur/assurances_sociales/maladie.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_employeur/assurances_sociales/maladie.yaml
@@ -1,10 +1,10 @@
 description: Assurance Maladie
 brackets:
 - threshold:
-    1990-01-01:
+    1989-10-01:
       value: 0
   rate:
-    1990-01-01:
+    1989-10-01:
       value: 0.0152
     2007-07-01:
       value: 0.0214
@@ -17,3 +17,8 @@ brackets:
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1989-10-01:
+    - title: "Loi n° 89-73 du 2 septembre 1989 modifiant et complétant la loi n° 81-6 du 12 février 1981, articles 4 et 90"
+      href: "https://www.pist.tn/jort/1989/1989F/Jo06089.pdf"
+      note: "JORT n° 60, p. 1338-1339. Ajoute à la loi de 1981 le titre III instituant le régime agricole amélioré, avec effet au 1er octobre 1989 (article 4). L'article 90 fixe le taux global à 15 %, réparti 10 % employeur et 5 % salarié, et renvoie sa ventilation par branche à un décret QUI N'A PAS ÉTÉ IDENTIFIÉ : seule la part maladie de 2,28 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1989/1989A/Ja06089.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_employeur/assurances_sociales/maternite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_employeur/assurances_sociales/maternite.yaml
@@ -1,11 +1,16 @@
 description: Indemnités de maladie et maternité
 brackets:
 - threshold:
-    1977-01-01:
+    1989-10-01:
       value: 0
   rate:
-    1977-01-01:
+    1989-10-01:
       value: 0.004
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1989-10-01:
+    - title: "Loi n° 89-73 du 2 septembre 1989 modifiant et complétant la loi n° 81-6 du 12 février 1981, articles 4 et 90"
+      href: "https://www.pist.tn/jort/1989/1989F/Jo06089.pdf"
+      note: "JORT n° 60, p. 1338-1339. Ajoute à la loi de 1981 le titre III instituant le régime agricole amélioré, avec effet au 1er octobre 1989 (article 4). L'article 90 fixe le taux global à 15 %, réparti 10 % employeur et 5 % salarié, et renvoie sa ventilation par branche à un décret QUI N'A PAS ÉTÉ IDENTIFIÉ : seule la part maladie de 2,28 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1989/1989A/Ja06089.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_employeur/famille.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_employeur/famille.yaml
@@ -1,11 +1,16 @@
 description: Prestations familiales
 brackets:
 - threshold:
-    1960-01-01:
+    1989-10-01:
       value: 0
   rate:
-    1960-01-01:
+    1989-10-01:
       value: 0.03
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1989-10-01:
+    - title: "Loi n° 89-73 du 2 septembre 1989 modifiant et complétant la loi n° 81-6 du 12 février 1981, articles 4 et 90"
+      href: "https://www.pist.tn/jort/1989/1989F/Jo06089.pdf"
+      note: "JORT n° 60, p. 1338-1339. Ajoute à la loi de 1981 le titre III instituant le régime agricole amélioré, avec effet au 1er octobre 1989 (article 4). L'article 90 fixe le taux global à 15 %, réparti 10 % employeur et 5 % salarié, et renvoie sa ventilation par branche à un décret QUI N'A PAS ÉTÉ IDENTIFIÉ : seule la part maladie de 2,28 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1989/1989A/Ja06089.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_employeur/retraite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_employeur/retraite.yaml
@@ -1,11 +1,16 @@
 description: Pensions
 brackets:
 - threshold:
-    1990-01-01:
+    1989-10-01:
       value: 0
   rate:
-    1990-01-01:
+    1989-10-01:
       value: 0.05
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1989-10-01:
+    - title: "Loi n° 89-73 du 2 septembre 1989 modifiant et complétant la loi n° 81-6 du 12 février 1981, articles 4 et 90"
+      href: "https://www.pist.tn/jort/1989/1989F/Jo06089.pdf"
+      note: "JORT n° 60, p. 1338-1339. Ajoute à la loi de 1981 le titre III instituant le régime agricole amélioré, avec effet au 1er octobre 1989 (article 4). L'article 90 fixe le taux global à 15 %, réparti 10 % employeur et 5 % salarié, et renvoie sa ventilation par branche à un décret QUI N'A PAS ÉTÉ IDENTIFIÉ : seule la part maladie de 2,28 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1989/1989A/Ja06089.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_salarie/assurances_sociales/deces.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_salarie/assurances_sociales/deces.yaml
@@ -1,11 +1,16 @@
 description: Indemnités de décès et capital décès
 brackets:
 - threshold:
-    1960-01-01:
+    1989-10-01:
       value: 0
   rate:
-    1960-01-01:
+    1989-10-01:
       value: 0.0004
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1989-10-01:
+    - title: "Loi n° 89-73 du 2 septembre 1989 modifiant et complétant la loi n° 81-6 du 12 février 1981, articles 4 et 90"
+      href: "https://www.pist.tn/jort/1989/1989F/Jo06089.pdf"
+      note: "JORT n° 60, p. 1338-1339. Ajoute à la loi de 1981 le titre III instituant le régime agricole amélioré, avec effet au 1er octobre 1989 (article 4). L'article 90 fixe le taux global à 15 %, réparti 10 % employeur et 5 % salarié, et renvoie sa ventilation par branche à un décret QUI N'A PAS ÉTÉ IDENTIFIÉ : seule la part maladie de 2,28 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1989/1989A/Ja06089.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_salarie/assurances_sociales/maladie.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_salarie/assurances_sociales/maladie.yaml
@@ -1,10 +1,10 @@
 description: Assurance Maladie
 brackets:
 - threshold:
-    1960-01-01:
+    1989-10-01:
       value: 0
   rate:
-    1960-01-01:
+    1989-10-01:
       value: 0.0076
     2008-07-01:
       value: 0.0143
@@ -15,3 +15,8 @@ brackets:
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1989-10-01:
+    - title: "Loi n° 89-73 du 2 septembre 1989 modifiant et complétant la loi n° 81-6 du 12 février 1981, articles 4 et 90"
+      href: "https://www.pist.tn/jort/1989/1989F/Jo06089.pdf"
+      note: "JORT n° 60, p. 1338-1339. Ajoute à la loi de 1981 le titre III instituant le régime agricole amélioré, avec effet au 1er octobre 1989 (article 4). L'article 90 fixe le taux global à 15 %, réparti 10 % employeur et 5 % salarié, et renvoie sa ventilation par branche à un décret QUI N'A PAS ÉTÉ IDENTIFIÉ : seule la part maladie de 2,28 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1989/1989A/Ja06089.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_salarie/assurances_sociales/maternite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_salarie/assurances_sociales/maternite.yaml
@@ -1,11 +1,16 @@
 description: Indemnités de maladie et maternité
 brackets:
 - threshold:
-    1977-01-01:
+    1989-10-01:
       value: 0
   rate:
-    1977-01-01:
+    1989-10-01:
       value: 0.002
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1989-10-01:
+    - title: "Loi n° 89-73 du 2 septembre 1989 modifiant et complétant la loi n° 81-6 du 12 février 1981, articles 4 et 90"
+      href: "https://www.pist.tn/jort/1989/1989F/Jo06089.pdf"
+      note: "JORT n° 60, p. 1338-1339. Ajoute à la loi de 1981 le titre III instituant le régime agricole amélioré, avec effet au 1er octobre 1989 (article 4). L'article 90 fixe le taux global à 15 %, réparti 10 % employeur et 5 % salarié, et renvoie sa ventilation par branche à un décret QUI N'A PAS ÉTÉ IDENTIFIÉ : seule la part maladie de 2,28 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1989/1989A/Ja06089.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_salarie/famille.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_salarie/famille.yaml
@@ -1,11 +1,16 @@
 description: Prestations familiales
 brackets:
 - threshold:
-    1960-01-01:
+    1989-10-01:
       value: 0
   rate:
-    1960-01-01:
+    1989-10-01:
       value: 0.015
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1989-10-01:
+    - title: "Loi n° 89-73 du 2 septembre 1989 modifiant et complétant la loi n° 81-6 du 12 février 1981, articles 4 et 90"
+      href: "https://www.pist.tn/jort/1989/1989F/Jo06089.pdf"
+      note: "JORT n° 60, p. 1338-1339. Ajoute à la loi de 1981 le titre III instituant le régime agricole amélioré, avec effet au 1er octobre 1989 (article 4). L'article 90 fixe le taux global à 15 %, réparti 10 % employeur et 5 % salarié, et renvoie sa ventilation par branche à un décret QUI N'A PAS ÉTÉ IDENTIFIÉ : seule la part maladie de 2,28 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1989/1989A/Ja06089.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_salarie/retraite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsaa/cotisations_salarie/retraite.yaml
@@ -1,11 +1,16 @@
 description: Pensions
 brackets:
 - threshold:
-    1990-01-01:
+    1989-10-01:
       value: 0
   rate:
-    1990-01-01:
+    1989-10-01:
       value: 0.025
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1989-10-01:
+    - title: "Loi n° 89-73 du 2 septembre 1989 modifiant et complétant la loi n° 81-6 du 12 février 1981, articles 4 et 90"
+      href: "https://www.pist.tn/jort/1989/1989F/Jo06089.pdf"
+      note: "JORT n° 60, p. 1338-1339. Ajoute à la loi de 1981 le titre III instituant le régime agricole amélioré, avec effet au 1er octobre 1989 (article 4). L'article 90 fixe le taux global à 15 %, réparti 10 % employeur et 5 % salarié, et renvoie sa ventilation par branche à un décret QUI N'A PAS ÉTÉ IDENTIFIÉ : seule la part maladie de 2,28 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1989/1989A/Ja06089.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/accident_du_travail.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/accident_du_travail.yaml
@@ -1,11 +1,16 @@
 description: Accidents du travail - Maladies professionelles
 brackets:
 - threshold:
-    1960-01-01:
+    1995-04-01:
       value: 0
   rate:
-    1960-01-01:
+    1995-04-01:
       value: 0.007222
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1995-04-01:
+    - title: "Décret n° 95-538 du 1er avril 1995 relatif à la fixation des taux de cotisations au régime de réparation des préjudices résultant des accidents du travail et des maladies professionnelles, article 2"
+      href: "https://www.pist.tn/jort/1995/1995F/Jo03095.pdf"
+      note: "JORT n° 30, p. 690-693. Opère le transfert d'un point des cotisations du régime général vers le régime de réparation des accidents du travail. ATTENTION : ce point transféré n'est PAS la cotisation d'accidents du travail elle-même, qui est patronale et varie de 0,50 % à 5 % selon dix-huit classes d'activité. Ce paramètre décrit le transfert, non le tarif. Édition arabe : https://www.pist.tn/jort/1995/1995A/Ja03095.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/assurances_sociales/deces.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/assurances_sociales/deces.yaml
@@ -1,11 +1,18 @@
 description: Indemnités de décès et capital décès
 brackets:
 - threshold:
-    1960-01-01:
+    1997-02-04:
       value: 0
   rate:
-    1960-01-01:
+    1997-02-04:
       value: 0.004694
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1997-02-04:
+    - title: "Loi n° 97-4 du 3 février 1997 modifiant la loi n° 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale, article 41 (nouveau)"
+      href: "https://www.pist.tn/jort/1997/1997F/Jo01097.pdf"
+      note: "JORT n° 10, p. 155. L'article 41 (nouveau) porte le taux global des régimes de la loi n° 60-30 à 18 %, réparti 13 % à la charge de l'employeur et 5 % à la charge du travailleur. La loi n'énonce pas de date d'effet pour ce taux : la seule date qu'elle fixe, le 1er octobre 1996, porte sur la réduction conventionnelle de deux points du paragraphe 2. La date retenue ici est celle de la publication. Édition arabe : https://www.pist.tn/jort/1997/1997A/Ja01097.pdf"
+  official_journal_date:
+    1997-02-04: "1997-02-04"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/assurances_sociales/maladie.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/assurances_sociales/maladie.yaml
@@ -1,13 +1,20 @@
 description: Assurance Maladie
 brackets:
 - threshold:
-    1960-01-01:
+    1997-02-04:
       value: 0
   rate:
-    1960-01-01:
+    1997-02-04:
       value: 0.034306
     2007-07-01:
       value: 0.040006
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1997-02-04:
+    - title: "Loi n° 97-4 du 3 février 1997 modifiant la loi n° 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale, article 41 (nouveau)"
+      href: "https://www.pist.tn/jort/1997/1997F/Jo01097.pdf"
+      note: "JORT n° 10, p. 155. L'article 41 (nouveau) porte le taux global des régimes de la loi n° 60-30 à 18 %, réparti 13 % à la charge de l'employeur et 5 % à la charge du travailleur. La loi n'énonce pas de date d'effet pour ce taux : la seule date qu'elle fixe, le 1er octobre 1996, porte sur la réduction conventionnelle de deux points du paragraphe 2. La date retenue ici est celle de la publication. Édition arabe : https://www.pist.tn/jort/1997/1997A/Ja01097.pdf"
+  official_journal_date:
+    1997-02-04: "1997-02-04"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/assurances_sociales/maternite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/assurances_sociales/maternite.yaml
@@ -1,11 +1,18 @@
 description: Indemnités de maladie et maternité
 brackets:
 - threshold:
-    1960-01-01:
+    1997-02-04:
       value: 0
   rate:
-    1960-01-01:
+    1997-02-04:
       value: 0.006139
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1997-02-04:
+    - title: "Loi n° 97-4 du 3 février 1997 modifiant la loi n° 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale, article 41 (nouveau)"
+      href: "https://www.pist.tn/jort/1997/1997F/Jo01097.pdf"
+      note: "JORT n° 10, p. 155. L'article 41 (nouveau) porte le taux global des régimes de la loi n° 60-30 à 18 %, réparti 13 % à la charge de l'employeur et 5 % à la charge du travailleur. La loi n'énonce pas de date d'effet pour ce taux : la seule date qu'elle fixe, le 1er octobre 1996, porte sur la réduction conventionnelle de deux points du paragraphe 2. La date retenue ici est celle de la publication. Édition arabe : https://www.pist.tn/jort/1997/1997A/Ja01097.pdf"
+  official_journal_date:
+    1997-02-04: "1997-02-04"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/famille.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/famille.yaml
@@ -1,11 +1,19 @@
 description: Prestations familiales
 brackets:
 - threshold:
-    1960-01-01:
+    2003-01-01:
       value: 0
   rate:
-    1960-01-01:
+    2003-01-01:
       value: 0.022111
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    2003-01-01:
+    - title: "Décret n° 2003-1212 du 2 juin 2003 modifiant le décret n° 74-499 du 27 avril 1974 relatif au régime de pension de vieillesse, d'invalidité et de survivants dans le secteur non agricole, article 5 b) nouveau"
+      href: "https://www.pist.tn/jort/2003/2003F/Jo0462003.pdf"
+      note: "JORT n° 46, p. 1834-1835. Porte à 7,25/20e la quote-part du taux global affectée au régime de pensions, avec effet au 1er janvier 2003 (article 2). C'est la dernière pièce de la construction : avant elle, la ventilation par branche du taux global n'est pas celle que porte ce paramètre. Édition arabe : https://www.pist.tn/jort/2003/2003A/Ja0462003.pdf"
+    - title: "Loi n° 97-4 du 3 février 1997 modifiant la loi n° 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale, article 41 (nouveau)"
+      href: "https://www.pist.tn/jort/1997/1997F/Jo01097.pdf"
+      note: "JORT n° 10, p. 155. L'article 41 (nouveau) porte le taux global des régimes de la loi n° 60-30 à 18 %, réparti 13 % à la charge de l'employeur et 5 % à la charge du travailleur. La loi n'énonce pas de date d'effet pour ce taux : la seule date qu'elle fixe, le 1er octobre 1996, porte sur la réduction conventionnelle de deux points du paragraphe 2. La date retenue ici est celle de la publication. Édition arabe : https://www.pist.tn/jort/1997/1997A/Ja01097.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/fonds_special_etat.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/fonds_special_etat.yaml
@@ -1,11 +1,16 @@
 description: Fond spécial de l'Etat
 brackets:
 - threshold:
-    1960-01-01:
+    1975-01-01:
       value: 0
   rate:
-    1960-01-01:
+    1975-01-01:
       value: 0.005
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1975-01-01:
+    - title: "Loi n° 74-101 du 25 décembre 1974 portant loi de finances pour la gestion 1975, articles 57 et 58"
+      href: "https://www.pist.tn/jort/1974/1974F/Jo08074.pdf"
+      note: "JORT n° 80, p. 2919. Majore de 0,5 % la cotisation patronale de l'article 41 de la loi n° 60-30 « à compter du 1er janvier 1975 » ; l'article 58 en affecte le produit au fonds spécial. Édition arabe : https://www.pist.tn/jort/1974/1974A/Ja08074.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/perte_d_emploi.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/perte_d_emploi.yaml
@@ -12,7 +12,8 @@ metadata:
   threshold_unit: currency
   reference:
     2025-01-01:
-      - title: Loi 2024-48 du 9 décembre 2024 portant loi de finances pour 2025
-        href: https://facture-tunisie.com/411/fr/38/reglementations/principales-dispositions-du-projet-de-la-loi-de-finances-2025
+    - title: "Loi n° 2024-48 du 9 décembre 2024 portant loi de finances pour l'année 2025, article 17"
+      href: "https://www.pist.tn/jort/2024/2024A/Ja1492024.pdf"
+      note: "JORT n° 149 du 10 décembre 2024, p. 6418 ; le paragraphe 2 de l'article 17 institue une cotisation de 0,5 % à la charge de l'employeur et de 0,5 % à la charge du salarié, assise sur la masse salariale déclarée à la CNSS. L'URL est celle de l'ÉDITION ARABE : l'édition française de ce fascicule répond 404 sur pist.tn, et c'est dans l'édition arabe que l'article a été lu. L'article n'énonce pas de date d'effet ; le 1er janvier 2025 se déduit du rattachement à la loi de finances, et son décret d'application n'est pas recensé à ce jour."
   official_journal_date:
     2025-01-01: '2024-12-10'

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/protection_sociale_travailleurs.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/protection_sociale_travailleurs.yaml
@@ -1,11 +1,18 @@
 description: Protection sociale des travailleurs
 brackets:
 - threshold:
-    1960-01-01:
+    1996-11-22:
       value: 0
   rate:
-    1960-01-01:
+    1996-11-22:
       value: 0.002889
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1996-11-22:
+    - title: "Loi n° 96-101 du 18 novembre 1996 relative à la protection sociale des travailleurs, article 5"
+      href: "https://www.pist.tn/jort/1996/1996F/Jo09496.pdf"
+      note: "JORT n° 94, p. 2319-2320. Institue « une cotisation complémentaire de 0,4 % des salaires à prélever sur le taux global des cotisations de sécurité sociale fixé par la loi n° 60-30 ». La loi n'énonce pas de date d'effet ; la date retenue est celle de la publication. Édition arabe : https://www.pist.tn/jort/1996/1996A/Ja09496.pdf"
+  official_journal_date:
+    1996-11-22: "1996-11-22"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/retraite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/retraite.yaml
@@ -1,11 +1,19 @@
 description: Pensions de retraite
 brackets:
 - threshold:
-    1960-01-01:
+    2003-01-01:
       value: 0
   rate:
-    1960-01-01:
+    2003-01-01:
       value: 0.077639
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    2003-01-01:
+    - title: "Décret n° 2003-1212 du 2 juin 2003 modifiant le décret n° 74-499 du 27 avril 1974 relatif au régime de pension de vieillesse, d'invalidité et de survivants dans le secteur non agricole, article 5 b) nouveau"
+      href: "https://www.pist.tn/jort/2003/2003F/Jo0462003.pdf"
+      note: "JORT n° 46, p. 1834-1835. Porte à 7,25/20e la quote-part du taux global affectée au régime de pensions, avec effet au 1er janvier 2003 (article 2). C'est la dernière pièce de la construction : avant elle, la ventilation par branche du taux global n'est pas celle que porte ce paramètre. Édition arabe : https://www.pist.tn/jort/2003/2003A/Ja0462003.pdf"
+    - title: "Loi n° 97-4 du 3 février 1997 modifiant la loi n° 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale, article 41 (nouveau)"
+      href: "https://www.pist.tn/jort/1997/1997F/Jo01097.pdf"
+      note: "JORT n° 10, p. 155. L'article 41 (nouveau) porte le taux global des régimes de la loi n° 60-30 à 18 %, réparti 13 % à la charge de l'employeur et 5 % à la charge du travailleur. La loi n'énonce pas de date d'effet pour ce taux : la seule date qu'elle fixe, le 1er octobre 1996, porte sur la réduction conventionnelle de deux points du paragraphe 2. La date retenue ici est celle de la publication. Édition arabe : https://www.pist.tn/jort/1997/1997A/Ja01097.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/retraite_complementaire.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/retraite_complementaire.yaml
@@ -1,11 +1,16 @@
 description: Cotisation au régime complémentaire de retraite (ex-CAVIS)
 brackets:
 - threshold:
-    1960-01-01:
+    1974-01-01:
       value: 0
   rate:
-    1960-01-01:
+    1974-01-01:
       value: 0.06
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1974-01-01:
+    - title: "Arrêté du ministre des affaires sociales du 18 novembre 1978 portant publication du règlement du régime complémentaire de pension de vieillesse, d'invalidité et de survivants"
+      href: "https://www.pist.tn/jort/1978/1978F/Jo07978.pdf"
+      note: "JORT n° 79, p. 3374-3379. Le règlement « entre en application à compter du 1er janvier 1974 ». DEUX RÉSERVES SUR CE PARAMÈTRE. Le taux : le règlement fixe un taux d'appel initial de 4,5 %, et confie ses révisions à une décision du comité de gestion de la CAVIS non publiée au Journal officiel — le passage à 9 % ne peut donc être ni sourcé ni daté ; seule la clé de répartition deux tiers / un tiers est attestée. L'assiette : l'article 6 du règlement la définit comme « la fraction de salaire excédant la limite fixée par le régime légal pour le calcul des prestations », et non comme le salaire entier auquel ce paramètre s'applique. Édition arabe : https://www.pist.tn/jort/1978/1978A/Ja07978.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/accident_du_travail.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/accident_du_travail.yaml
@@ -1,11 +1,16 @@
 description: Accidents du travail - Maladies professionelles
 brackets:
 - threshold:
-    1960-01-01:
+    1995-04-01:
       value: 0
   rate:
-    1960-01-01:
+    1995-04-01:
       value: 0.002778
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1995-04-01:
+    - title: "Décret n° 95-538 du 1er avril 1995 relatif à la fixation des taux de cotisations au régime de réparation des préjudices résultant des accidents du travail et des maladies professionnelles, article 2"
+      href: "https://www.pist.tn/jort/1995/1995F/Jo03095.pdf"
+      note: "JORT n° 30, p. 690-693. Opère le transfert d'un point des cotisations du régime général vers le régime de réparation des accidents du travail. ATTENTION : ce point transféré n'est PAS la cotisation d'accidents du travail elle-même, qui est patronale et varie de 0,50 % à 5 % selon dix-huit classes d'activité. Ce paramètre décrit le transfert, non le tarif. Édition arabe : https://www.pist.tn/jort/1995/1995A/Ja03095.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/assurances_sociales/deces.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/assurances_sociales/deces.yaml
@@ -1,11 +1,18 @@
 description: Indemnités de décès et capital décès
 brackets:
 - threshold:
-    1960-01-01:
+    1997-02-04:
       value: 0
   rate:
-    1960-01-01:
+    1997-02-04:
       value: 0.001806
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1997-02-04:
+    - title: "Loi n° 97-4 du 3 février 1997 modifiant la loi n° 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale, article 41 (nouveau)"
+      href: "https://www.pist.tn/jort/1997/1997F/Jo01097.pdf"
+      note: "JORT n° 10, p. 155. L'article 41 (nouveau) porte le taux global des régimes de la loi n° 60-30 à 18 %, réparti 13 % à la charge de l'employeur et 5 % à la charge du travailleur. La loi n'énonce pas de date d'effet pour ce taux : la seule date qu'elle fixe, le 1er octobre 1996, porte sur la réduction conventionnelle de deux points du paragraphe 2. La date retenue ici est celle de la publication. Édition arabe : https://www.pist.tn/jort/1997/1997A/Ja01097.pdf"
+  official_journal_date:
+    1997-02-04: "1997-02-04"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/assurances_sociales/maladie.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/assurances_sociales/maladie.yaml
@@ -1,10 +1,10 @@
 description: Assurance Maladie
 brackets:
 - threshold:
-    1960-01-01:
+    1997-02-04:
       value: 0
   rate:
-    1960-01-01:
+    1997-02-04:
       value: 0.013194
     2008-07-01:
       value: 0.020394
@@ -13,3 +13,10 @@ brackets:
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1997-02-04:
+    - title: "Loi n° 97-4 du 3 février 1997 modifiant la loi n° 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale, article 41 (nouveau)"
+      href: "https://www.pist.tn/jort/1997/1997F/Jo01097.pdf"
+      note: "JORT n° 10, p. 155. L'article 41 (nouveau) porte le taux global des régimes de la loi n° 60-30 à 18 %, réparti 13 % à la charge de l'employeur et 5 % à la charge du travailleur. La loi n'énonce pas de date d'effet pour ce taux : la seule date qu'elle fixe, le 1er octobre 1996, porte sur la réduction conventionnelle de deux points du paragraphe 2. La date retenue ici est celle de la publication. Édition arabe : https://www.pist.tn/jort/1997/1997A/Ja01097.pdf"
+  official_journal_date:
+    1997-02-04: "1997-02-04"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/assurances_sociales/maternite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/assurances_sociales/maternite.yaml
@@ -1,11 +1,18 @@
 description: Indemnités de maladie et maternité
 brackets:
 - threshold:
-    1960-01-01:
+    1997-02-04:
       value: 0
   rate:
-    1960-01-01:
+    1997-02-04:
       value: 0.002361
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1997-02-04:
+    - title: "Loi n° 97-4 du 3 février 1997 modifiant la loi n° 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale, article 41 (nouveau)"
+      href: "https://www.pist.tn/jort/1997/1997F/Jo01097.pdf"
+      note: "JORT n° 10, p. 155. L'article 41 (nouveau) porte le taux global des régimes de la loi n° 60-30 à 18 %, réparti 13 % à la charge de l'employeur et 5 % à la charge du travailleur. La loi n'énonce pas de date d'effet pour ce taux : la seule date qu'elle fixe, le 1er octobre 1996, porte sur la réduction conventionnelle de deux points du paragraphe 2. La date retenue ici est celle de la publication. Édition arabe : https://www.pist.tn/jort/1997/1997A/Ja01097.pdf"
+  official_journal_date:
+    1997-02-04: "1997-02-04"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/famille.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/famille.yaml
@@ -1,11 +1,19 @@
 description: Prestations familiales
 brackets:
 - threshold:
-    1960-01-01:
+    2003-01-01:
       value: 0
   rate:
-    1960-01-01:
+    2003-01-01:
       value: 0.008889
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    2003-01-01:
+    - title: "Décret n° 2003-1212 du 2 juin 2003 modifiant le décret n° 74-499 du 27 avril 1974 relatif au régime de pension de vieillesse, d'invalidité et de survivants dans le secteur non agricole, article 5 b) nouveau"
+      href: "https://www.pist.tn/jort/2003/2003F/Jo0462003.pdf"
+      note: "JORT n° 46, p. 1834-1835. Porte à 7,25/20e la quote-part du taux global affectée au régime de pensions, avec effet au 1er janvier 2003 (article 2). C'est la dernière pièce de la construction : avant elle, la ventilation par branche du taux global n'est pas celle que porte ce paramètre. Édition arabe : https://www.pist.tn/jort/2003/2003A/Ja0462003.pdf"
+    - title: "Loi n° 97-4 du 3 février 1997 modifiant la loi n° 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale, article 41 (nouveau)"
+      href: "https://www.pist.tn/jort/1997/1997F/Jo01097.pdf"
+      note: "JORT n° 10, p. 155. L'article 41 (nouveau) porte le taux global des régimes de la loi n° 60-30 à 18 %, réparti 13 % à la charge de l'employeur et 5 % à la charge du travailleur. La loi n'énonce pas de date d'effet pour ce taux : la seule date qu'elle fixe, le 1er octobre 1996, porte sur la réduction conventionnelle de deux points du paragraphe 2. La date retenue ici est celle de la publication. Édition arabe : https://www.pist.tn/jort/1997/1997A/Ja01097.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/perte_d_emploi.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/perte_d_emploi.yaml
@@ -12,7 +12,8 @@ metadata:
   threshold_unit: currency
   reference:
     2025-01-01:
-      - title: Loi 2024-48 du 9 décembre 2024 portant loi de finances pour 2025
-        href: https://facture-tunisie.com/411/fr/38/reglementations/principales-dispositions-du-projet-de-la-loi-de-finances-2025
+    - title: "Loi n° 2024-48 du 9 décembre 2024 portant loi de finances pour l'année 2025, article 17"
+      href: "https://www.pist.tn/jort/2024/2024A/Ja1492024.pdf"
+      note: "JORT n° 149 du 10 décembre 2024, p. 6418 ; le paragraphe 2 de l'article 17 institue une cotisation de 0,5 % à la charge de l'employeur et de 0,5 % à la charge du salarié, assise sur la masse salariale déclarée à la CNSS. L'URL est celle de l'ÉDITION ARABE : l'édition française de ce fascicule répond 404 sur pist.tn, et c'est dans l'édition arabe que l'article a été lu. L'article n'énonce pas de date d'effet ; le 1er janvier 2025 se déduit du rattachement à la loi de finances, et son décret d'application n'est pas recensé à ce jour."
   official_journal_date:
     2025-01-01: '2024-12-10'

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/protection_sociale_travailleurs.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/protection_sociale_travailleurs.yaml
@@ -1,11 +1,18 @@
 description: Protection sociale des travailleurs
 brackets:
 - threshold:
-    1960-01-01:
+    1996-11-22:
       value: 0
   rate:
-    1960-01-01:
+    1996-11-22:
       value: 0.001111
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1996-11-22:
+    - title: "Loi n° 96-101 du 18 novembre 1996 relative à la protection sociale des travailleurs, article 5"
+      href: "https://www.pist.tn/jort/1996/1996F/Jo09496.pdf"
+      note: "JORT n° 94, p. 2319-2320. Institue « une cotisation complémentaire de 0,4 % des salaires à prélever sur le taux global des cotisations de sécurité sociale fixé par la loi n° 60-30 ». La loi n'énonce pas de date d'effet ; la date retenue est celle de la publication. Édition arabe : https://www.pist.tn/jort/1996/1996A/Ja09496.pdf"
+  official_journal_date:
+    1996-11-22: "1996-11-22"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/retraite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/retraite.yaml
@@ -1,11 +1,19 @@
 description: Pensions
 brackets:
 - threshold:
-    1960-01-01:
+    2003-01-01:
       value: 0
   rate:
-    1960-01-01:
+    2003-01-01:
       value: 0.047361
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    2003-01-01:
+    - title: "Décret n° 2003-1212 du 2 juin 2003 modifiant le décret n° 74-499 du 27 avril 1974 relatif au régime de pension de vieillesse, d'invalidité et de survivants dans le secteur non agricole, article 5 b) nouveau"
+      href: "https://www.pist.tn/jort/2003/2003F/Jo0462003.pdf"
+      note: "JORT n° 46, p. 1834-1835. Porte à 7,25/20e la quote-part du taux global affectée au régime de pensions, avec effet au 1er janvier 2003 (article 2). C'est la dernière pièce de la construction : avant elle, la ventilation par branche du taux global n'est pas celle que porte ce paramètre. Édition arabe : https://www.pist.tn/jort/2003/2003A/Ja0462003.pdf"
+    - title: "Loi n° 97-4 du 3 février 1997 modifiant la loi n° 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale, article 41 (nouveau)"
+      href: "https://www.pist.tn/jort/1997/1997F/Jo01097.pdf"
+      note: "JORT n° 10, p. 155. L'article 41 (nouveau) porte le taux global des régimes de la loi n° 60-30 à 18 %, réparti 13 % à la charge de l'employeur et 5 % à la charge du travailleur. La loi n'énonce pas de date d'effet pour ce taux : la seule date qu'elle fixe, le 1er octobre 1996, porte sur la réduction conventionnelle de deux points du paragraphe 2. La date retenue ici est celle de la publication. Édition arabe : https://www.pist.tn/jort/1997/1997A/Ja01097.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/retraite_complementaire.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/retraite_complementaire.yaml
@@ -1,11 +1,16 @@
 description: Cotisation au régime complémentaire de retraite (ex-CAVIS)
 brackets:
 - threshold:
-    1960-01-01:
+    1974-01-01:
       value: 0
   rate:
-    1960-01-01:
+    1974-01-01:
       value: 0.03
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1974-01-01:
+    - title: "Arrêté du ministre des affaires sociales du 18 novembre 1978 portant publication du règlement du régime complémentaire de pension de vieillesse, d'invalidité et de survivants"
+      href: "https://www.pist.tn/jort/1978/1978F/Jo07978.pdf"
+      note: "JORT n° 79, p. 3374-3379. Le règlement « entre en application à compter du 1er janvier 1974 ». DEUX RÉSERVES SUR CE PARAMÈTRE. Le taux : le règlement fixe un taux d'appel initial de 4,5 %, et confie ses révisions à une décision du comité de gestion de la CAVIS non publiée au Journal officiel — le passage à 9 % ne peut donc être ni sourcé ni daté ; seule la clé de répartition deux tiers / un tiers est attestée. L'assiette : l'article 6 du règlement la définit comme « la fraction de salaire excédant la limite fixée par le régime légal pour le calcul des prestations », et non comme le salaire entier auquel ce paramètre s'applique. Édition arabe : https://www.pist.tn/jort/1978/1978A/Ja07978.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtfr/cotisations_employeur/retraite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtfr/cotisations_employeur/retraite.yaml
@@ -15,3 +15,11 @@ brackets:
 metadata:
   rate_unit: /1
   threshold_unit: smig
+  reference:
+    2002-03-12:
+    - title: "Loi n° 2002-32 du 12 mars 2002 relative au régime de sécurité sociale pour certaines catégories de travailleurs dans les secteurs agricole et non agricole, article 7"
+      href: "https://www.pist.tn/jort/2002/2002F/Jo0222002.pdf"
+      note: "JORT n° 22, p. 603. L'article fixe en une phrase le taux global de 7,5 %, l'assiette — les deux tiers du SMIG ou du SMAG selon la catégorie — et la clé deux tiers employeur / un tiers salarié. La loi n'énonce pas de date d'effet ; la date retenue est celle de sa signature. ATTENTION : le seuil de 0,66 encodé ici traduit cette ASSIETTE FORFAITAIRE des deux tiers, et non un plafond au-delà duquel le prélèvement cesserait. Édition arabe : https://www.pist.tn/jort/2002/2002A/Ja0222002.pdf"
+    - title: "Décret n° 2002-916 du 22 avril 2002 fixant les modalités d'application de la loi n° 2002-32, articles 13 à 15"
+      href: "https://www.pist.tn/jort/2002/2002F/Jo0352002.pdf"
+      note: "JORT n° 35, p. 1058-1061. L'article 14 ventile les 7,5 % par branche — 2,5 points de soins et 5 points de pensions — et l'article 15 par payeur — 5 points employeur et 2,5 points salarié. LES DEUX RÉPARTITIONS NE SONT JAMAIS CROISÉES PAR UN TEXTE : les quatre valeurs de ce régime (3,3333 / 1,6667 / 1,6667 / 0,8333) résultent d'un croisement opéré par le modèle. Édition arabe : https://www.pist.tn/jort/2002/2002A/Ja0352002.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtfr/cotisations_employeur/soin.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtfr/cotisations_employeur/soin.yaml
@@ -17,7 +17,11 @@ metadata:
   threshold_unit: smig
   reference:
     2002-03-12:
-      title: Décret n° 2002-916 du 22 avril 2002, relatif aux modalités d'application de la loi n° 2002-32 du 12 mars 2002, relative au régime de sécurité sociale pour certaines catégories de travailleurs dans les secteurs agricole et non agricole
-      href: https://www.pist.tn/jort/2002/2002F/Jo0352002.pdf
+    - title: "Loi n° 2002-32 du 12 mars 2002 relative au régime de sécurité sociale pour certaines catégories de travailleurs dans les secteurs agricole et non agricole, article 7"
+      href: "https://www.pist.tn/jort/2002/2002F/Jo0222002.pdf"
+      note: "JORT n° 22, p. 603. L'article fixe en une phrase le taux global de 7,5 %, l'assiette — les deux tiers du SMIG ou du SMAG selon la catégorie — et la clé deux tiers employeur / un tiers salarié. La loi n'énonce pas de date d'effet ; la date retenue est celle de sa signature. ATTENTION : le seuil de 0,66 encodé ici traduit cette ASSIETTE FORFAITAIRE des deux tiers, et non un plafond au-delà duquel le prélèvement cesserait. Édition arabe : https://www.pist.tn/jort/2002/2002A/Ja0222002.pdf"
+    - title: "Décret n° 2002-916 du 22 avril 2002 fixant les modalités d'application de la loi n° 2002-32, articles 13 à 15"
+      href: "https://www.pist.tn/jort/2002/2002F/Jo0352002.pdf"
+      note: "JORT n° 35, p. 1058-1061. L'article 14 ventile les 7,5 % par branche — 2,5 points de soins et 5 points de pensions — et l'article 15 par payeur — 5 points employeur et 2,5 points salarié. LES DEUX RÉPARTITIONS NE SONT JAMAIS CROISÉES PAR UN TEXTE : les quatre valeurs de ce régime (3,3333 / 1,6667 / 1,6667 / 0,8333) résultent d'un croisement opéré par le modèle. Édition arabe : https://www.pist.tn/jort/2002/2002A/Ja0352002.pdf"
   official_journal_date:
     2002-03-12: "2002-04-30"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtfr/cotisations_salarie/retraite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtfr/cotisations_salarie/retraite.yaml
@@ -15,3 +15,11 @@ brackets:
 metadata:
   rate_unit: /1
   threshold_unit: smig
+  reference:
+    2002-03-12:
+    - title: "Loi n° 2002-32 du 12 mars 2002 relative au régime de sécurité sociale pour certaines catégories de travailleurs dans les secteurs agricole et non agricole, article 7"
+      href: "https://www.pist.tn/jort/2002/2002F/Jo0222002.pdf"
+      note: "JORT n° 22, p. 603. L'article fixe en une phrase le taux global de 7,5 %, l'assiette — les deux tiers du SMIG ou du SMAG selon la catégorie — et la clé deux tiers employeur / un tiers salarié. La loi n'énonce pas de date d'effet ; la date retenue est celle de sa signature. ATTENTION : le seuil de 0,66 encodé ici traduit cette ASSIETTE FORFAITAIRE des deux tiers, et non un plafond au-delà duquel le prélèvement cesserait. Édition arabe : https://www.pist.tn/jort/2002/2002A/Ja0222002.pdf"
+    - title: "Décret n° 2002-916 du 22 avril 2002 fixant les modalités d'application de la loi n° 2002-32, articles 13 à 15"
+      href: "https://www.pist.tn/jort/2002/2002F/Jo0352002.pdf"
+      note: "JORT n° 35, p. 1058-1061. L'article 14 ventile les 7,5 % par branche — 2,5 points de soins et 5 points de pensions — et l'article 15 par payeur — 5 points employeur et 2,5 points salarié. LES DEUX RÉPARTITIONS NE SONT JAMAIS CROISÉES PAR UN TEXTE : les quatre valeurs de ce régime (3,3333 / 1,6667 / 1,6667 / 0,8333) résultent d'un croisement opéré par le modèle. Édition arabe : https://www.pist.tn/jort/2002/2002A/Ja0352002.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtfr/cotisations_salarie/soin.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtfr/cotisations_salarie/soin.yaml
@@ -15,3 +15,11 @@ brackets:
 metadata:
   rate_unit: /1
   threshold_unit: smig
+  reference:
+    2002-03-12:
+    - title: "Loi n° 2002-32 du 12 mars 2002 relative au régime de sécurité sociale pour certaines catégories de travailleurs dans les secteurs agricole et non agricole, article 7"
+      href: "https://www.pist.tn/jort/2002/2002F/Jo0222002.pdf"
+      note: "JORT n° 22, p. 603. L'article fixe en une phrase le taux global de 7,5 %, l'assiette — les deux tiers du SMIG ou du SMAG selon la catégorie — et la clé deux tiers employeur / un tiers salarié. La loi n'énonce pas de date d'effet ; la date retenue est celle de sa signature. ATTENTION : le seuil de 0,66 encodé ici traduit cette ASSIETTE FORFAITAIRE des deux tiers, et non un plafond au-delà duquel le prélèvement cesserait. Édition arabe : https://www.pist.tn/jort/2002/2002A/Ja0222002.pdf"
+    - title: "Décret n° 2002-916 du 22 avril 2002 fixant les modalités d'application de la loi n° 2002-32, articles 13 à 15"
+      href: "https://www.pist.tn/jort/2002/2002F/Jo0352002.pdf"
+      note: "JORT n° 35, p. 1058-1061. L'article 14 ventile les 7,5 % par branche — 2,5 points de soins et 5 points de pensions — et l'article 15 par payeur — 5 points employeur et 2,5 points salarié. LES DEUX RÉPARTITIONS NE SONT JAMAIS CROISÉES PAR UN TEXTE : les quatre valeurs de ce régime (3,3333 / 1,6667 / 1,6667 / 0,8333) résultent d'un croisement opéré par le modèle. Édition arabe : https://www.pist.tn/jort/2002/2002A/Ja0352002.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtns/cotisations_salarie/assurances_sociales/deces.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtns/cotisations_salarie/assurances_sociales/deces.yaml
@@ -1,11 +1,16 @@
 description: Indemnités de décès et capital décès
 brackets:
 - threshold:
-    1960-01-01:
+    1995-07-03:
       value: 0
   rate:
-    1960-01-01:
+    1995-07-03:
       value: 0.0045
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1995-07-03:
+    - title: "Décret n° 95-1166 du 3 juillet 1995 relatif à la sécurité sociale des travailleurs non salariés dans les secteurs agricole et non agricole, article 9"
+      href: "https://www.pist.tn/jort/1995/1995F/Jo05595.pdf"
+      note: "JORT n° 55, p. 1486-1489. Fixe le taux à 11 %, réparti 7 points de pensions et 4 points d'assurances sociales. Le décret n'énonce pas de date d'effet. Le partage interne des 4 % n'est fixé par aucun texte identifié : seule la part maladie de 3,04 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1995/1995A/Ja05595.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtns/cotisations_salarie/assurances_sociales/maladie.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtns/cotisations_salarie/assurances_sociales/maladie.yaml
@@ -1,10 +1,10 @@
 description: Assurance Maladie
 brackets:
 - threshold:
-    1960-01-01:
+    1995-07-03:
       value: 0
   rate:
-    1960-01-01:
+    1995-07-03:
       value: 0.0304
     2007-07-01:
       value: 0.0397
@@ -17,3 +17,8 @@ brackets:
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1995-07-03:
+    - title: "Décret n° 95-1166 du 3 juillet 1995 relatif à la sécurité sociale des travailleurs non salariés dans les secteurs agricole et non agricole, article 9"
+      href: "https://www.pist.tn/jort/1995/1995F/Jo05595.pdf"
+      note: "JORT n° 55, p. 1486-1489. Fixe le taux à 11 %, réparti 7 points de pensions et 4 points d'assurances sociales. Le décret n'énonce pas de date d'effet. Le partage interne des 4 % n'est fixé par aucun texte identifié : seule la part maladie de 3,04 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1995/1995A/Ja05595.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtns/cotisations_salarie/assurances_sociales/maternite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtns/cotisations_salarie/assurances_sociales/maternite.yaml
@@ -1,11 +1,16 @@
 description: Indemnités de maladie et maternité
 brackets:
 - threshold:
-    1960-01-01:
+    1995-07-03:
       value: 0
   rate:
-    1960-01-01:
+    1995-07-03:
       value: 0.0051
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1995-07-03:
+    - title: "Décret n° 95-1166 du 3 juillet 1995 relatif à la sécurité sociale des travailleurs non salariés dans les secteurs agricole et non agricole, article 9"
+      href: "https://www.pist.tn/jort/1995/1995F/Jo05595.pdf"
+      note: "JORT n° 55, p. 1486-1489. Fixe le taux à 11 %, réparti 7 points de pensions et 4 points d'assurances sociales. Le décret n'énonce pas de date d'effet. Le partage interne des 4 % n'est fixé par aucun texte identifié : seule la part maladie de 3,04 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1995/1995A/Ja05595.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtns/cotisations_salarie/retraite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtns/cotisations_salarie/retraite.yaml
@@ -1,11 +1,16 @@
 description: Pensions
 brackets:
 - threshold:
-    1960-01-01:
+    1995-07-03:
       value: 0
   rate:
-    1960-01-01:
+    1995-07-03:
       value: 0.07
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1995-07-03:
+    - title: "Décret n° 95-1166 du 3 juillet 1995 relatif à la sécurité sociale des travailleurs non salariés dans les secteurs agricole et non agricole, article 9"
+      href: "https://www.pist.tn/jort/1995/1995F/Jo05595.pdf"
+      note: "JORT n° 55, p. 1486-1489. Fixe le taux à 11 %, réparti 7 points de pensions et 4 points d'assurances sociales. Le décret n'énonce pas de date d'effet. Le partage interne des 4 % n'est fixé par aucun texte identifié : seule la part maladie de 3,04 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1995/1995A/Ja05595.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtte/cotisations_salarie/assurances_sociales/deces.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtte/cotisations_salarie/assurances_sociales/deces.yaml
@@ -1,11 +1,16 @@
 description: Indemnités de décès et capital décès
 brackets:
 - threshold:
-    1960-01-01:
+    1989-01-10:
       value: 0
   rate:
-    1960-01-01:
+    1989-01-10:
       value: 0.0056
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1989-01-10:
+    - title: "Décret n° 89-107 du 10 janvier 1989 étendant le régime de sécurité sociale aux travailleurs tunisiens à l'étranger, article 7"
+      href: "https://www.pist.tn/jort/1989/1989F/Jo00489.pdf"
+      note: "JORT n° 4, p. 98-99. Fixe le taux à 10,65 %, réparti 5,25 points de pensions et 5,40 points d'assurances sociales. Le décret n'énonce pas de date d'effet. Le partage interne des 5,40 % n'est fixé par aucun texte identifié : seule la part maladie de 4,10 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1989/1989A/Ja00489.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtte/cotisations_salarie/assurances_sociales/maladie.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtte/cotisations_salarie/assurances_sociales/maladie.yaml
@@ -1,10 +1,10 @@
 description: Assurance Maladie
 brackets:
 - threshold:
-    1960-01-01:
+    1989-01-10:
       value: 0
   rate:
-    1960-01-01:
+    1989-01-10:
       value: 0.041
     2007-07-01:
       value: 0.0499
@@ -15,3 +15,8 @@ brackets:
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1989-01-10:
+    - title: "Décret n° 89-107 du 10 janvier 1989 étendant le régime de sécurité sociale aux travailleurs tunisiens à l'étranger, article 7"
+      href: "https://www.pist.tn/jort/1989/1989F/Jo00489.pdf"
+      note: "JORT n° 4, p. 98-99. Fixe le taux à 10,65 %, réparti 5,25 points de pensions et 5,40 points d'assurances sociales. Le décret n'énonce pas de date d'effet. Le partage interne des 5,40 % n'est fixé par aucun texte identifié : seule la part maladie de 4,10 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1989/1989A/Ja00489.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtte/cotisations_salarie/assurances_sociales/maternite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtte/cotisations_salarie/assurances_sociales/maternite.yaml
@@ -1,11 +1,16 @@
 description: Indemnités de maladie et maternité
 brackets:
 - threshold:
-    1960-01-01:
+    1989-01-10:
       value: 0
   rate:
-    1960-01-01:
+    1989-01-10:
       value: 0.0074
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1989-01-10:
+    - title: "Décret n° 89-107 du 10 janvier 1989 étendant le régime de sécurité sociale aux travailleurs tunisiens à l'étranger, article 7"
+      href: "https://www.pist.tn/jort/1989/1989F/Jo00489.pdf"
+      note: "JORT n° 4, p. 98-99. Fixe le taux à 10,65 %, réparti 5,25 points de pensions et 5,40 points d'assurances sociales. Le décret n'énonce pas de date d'effet. Le partage interne des 5,40 % n'est fixé par aucun texte identifié : seule la part maladie de 4,10 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1989/1989A/Ja00489.pdf"

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtte/cotisations_salarie/retraite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rtte/cotisations_salarie/retraite.yaml
@@ -1,11 +1,16 @@
 description: Pensions
 brackets:
 - threshold:
-    1960-01-01:
+    1989-01-10:
       value: 0
   rate:
-    1960-01-01:
+    1989-01-10:
       value: 0.0525
 metadata:
   rate_unit: /1
   threshold_unit: currency
+  reference:
+    1989-01-10:
+    - title: "Décret n° 89-107 du 10 janvier 1989 étendant le régime de sécurité sociale aux travailleurs tunisiens à l'étranger, article 7"
+      href: "https://www.pist.tn/jort/1989/1989F/Jo00489.pdf"
+      note: "JORT n° 4, p. 98-99. Fixe le taux à 10,65 %, réparti 5,25 points de pensions et 5,40 points d'assurances sociales. Le décret n'énonce pas de date d'effet. Le partage interne des 5,40 % n'est fixé par aucun texte identifié : seule la part maladie de 4,10 % est attestée, par le décret n° 2007-1406. Édition arabe : https://www.pist.tn/jort/1989/1989A/Ja00489.pdf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-Tunisia"
-version = "0.78"
+version = "0.79"
 description = "OpenFisca Rules as Code model for Tunisia."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "tunisia"]

--- a/tests/test_cotisations_secteur_prive.py
+++ b/tests/test_cotisations_secteur_prive.py
@@ -1,0 +1,113 @@
+"""Les cotisations du secteur privé, à leurs dates et à leurs valeurs.
+
+Deux choses sont gardées ici. D'abord les TOTAUX, qui sont le seul point sur lequel
+le paramétrage se recoupe avec une source publiée : hors retraite complémentaire et hors
+cotisation de perte d'emploi, le régime général doit rendre 9,18 % pour le salarié et
+16,57 % pour l'employeur, chiffres de la CNSS — et ces totaux doivent survivre à la
+datation. Ensuite les DATES elles-mêmes : aucune valeur du secteur privé ne peut porter
+le 1er janvier 1960, la structure que ces valeurs décrivent n'existant pas avant 1997.
+"""
+
+import datetime
+from pathlib import Path
+
+import yaml
+
+from openfisca_tunisia import TunisiaTaxBenefitSystem
+
+
+tax_benefit_system = TunisiaTaxBenefitSystem()
+
+PRIVE = "prelevements_sociaux.cotisations_sociales.secteur_prive"
+RACINE = Path(__file__).parent.parent / "openfisca_tunisia" / "parameters"
+DOSSIER_PRIVE = RACINE / "prelevements_sociaux" / "cotisations_sociales" / "secteur_prive"
+
+# Écartées du total obligatoire : la complémentaire est facultative et conventionnelle,
+# la perte d'emploi n'existe qu'à partir de 2025.
+HORS_TOTAL = ("retraite_complementaire", "perte_d_emploi")
+
+
+def _taux(chemin, date):
+    noeud = tax_benefit_system.get_parameters_at_instant(date)
+    for element in chemin.split("."):
+        noeud = getattr(noeud, element)
+    return noeud.rates[0]
+
+
+def _total_cote(regime, cote, date):
+    base = DOSSIER_PRIVE / regime / f"cotisations_{cote}"
+    somme = 0.0
+    for fichier in sorted(base.rglob("*.yaml")):
+        if fichier.name == "index.yaml" or any(x in fichier.name for x in HORS_TOTAL):
+            continue
+        relatif = fichier.relative_to(base).with_suffix("")
+        chemin = f"{PRIVE}.{regime}.cotisations_{cote}." + ".".join(relatif.parts)
+        somme += _taux(chemin, date)
+    return round(somme, 4)
+
+
+def test_le_regime_general_rend_les_taux_publies_par_la_cnss():
+    assert _total_cote("rsna", "salarie", "2024-06-30") == 0.0918
+    assert _total_cote("rsna", "employeur", "2024-06-30") == 0.1657
+
+
+def test_aucune_valeur_du_secteur_prive_ne_porte_plus_1960():
+    fautifs = [
+        str(f.relative_to(DOSSIER_PRIVE))
+        for f in DOSSIER_PRIVE.rglob("*.yaml")
+        if "1960-01-01" in f.read_text(encoding="utf-8")
+    ]
+    assert fautifs == [], (
+        "La structure décrite par ces valeurs n'existe pas avant 1997 : "
+        f"{fautifs}"
+    )
+
+
+def test_chaque_valeur_du_secteur_prive_porte_une_reference():
+    sans_reference = []
+    for fichier in sorted(DOSSIER_PRIVE.rglob("*.yaml")):
+        if fichier.name == "index.yaml":
+            continue
+        contenu = yaml.safe_load(fichier.read_text(encoding="utf-8"))
+        references = (contenu.get("metadata") or {}).get("reference")
+        if not references:
+            sans_reference.append(str(fichier.relative_to(DOSSIER_PRIVE)))
+    assert sans_reference == [], sans_reference
+
+
+def test_toutes_les_references_du_secteur_prive_pointent_vers_le_jort():
+    hors_jort = []
+    for fichier in sorted(DOSSIER_PRIVE.rglob("*.yaml")):
+        contenu = yaml.safe_load(fichier.read_text(encoding="utf-8"))
+        references = (contenu.get("metadata") or {}).get("reference") or {}
+        # Deux formes coexistent : une référence datée (un dictionnaire de dates vers
+        # des listes) et, sur les `index.yaml`, une référence unique sans date.
+        entrees = []
+        if "title" in references:
+            entrees = [references]
+        else:
+            for valeur in references.values():
+                entrees.extend(valeur if isinstance(valeur, list) else [valeur])
+        for entree in entrees:
+            if "pist.tn" not in entree.get("href", ""):
+                hors_jort.append((str(fichier.relative_to(DOSSIER_PRIVE)), entree.get("href")))
+    assert hors_jort == [], hors_jort
+
+
+def test_la_cotisation_des_etudiants_commence_a_deux_dinars():
+    montant = tax_benefit_system.get_parameters_at_instant("1995-01-01")
+    for element in f"{PRIVE}.re.cotisation".split("."):
+        montant = getattr(montant, element)
+    assert montant == 2
+
+
+def test_les_dates_retenues_sont_celles_des_textes():
+    # Le taux global de 18 % vient de la loi n° 97-4, publiée le 4 février 1997 ; la
+    # ventilation par branche n'est complète qu'avec le décret n° 2003-1212.
+    assert _taux(f"{PRIVE}.rsna.cotisations_salarie.retraite", "2003-01-01") > 0
+    assert _taux(f"{PRIVE}.rsna.cotisations_salarie.assurances_sociales.maladie", "1997-02-04") > 0
+    # Le régime agricole amélioré prend effet au 1er octobre 1989 (loi n° 89-73, art. 4).
+    assert _taux(f"{PRIVE}.rsaa.cotisations_salarie.retraite", "1989-10-01") > 0
+    # Le fonds spécial de l'État date de la loi de finances 1975.
+    assert _taux(f"{PRIVE}.rsna.cotisations_employeur.fonds_special_etat", "1975-01-01") > 0
+    assert datetime.date(1975, 1, 1) < datetime.date.today()

--- a/uv.lock
+++ b/uv.lock
@@ -1524,7 +1524,7 @@ web-api = [
 
 [[package]]
 name = "openfisca-tunisia"
-version = "0.77"
+version = "0.78"
 source = { editable = "." }
 dependencies = [
     { name = "openfisca-core", extra = ["web-api"] },

--- a/uv.lock
+++ b/uv.lock
@@ -1524,7 +1524,7 @@ web-api = [
 
 [[package]]
 name = "openfisca-tunisia"
-version = "0.78"
+version = "0.79"
 source = { editable = "." }
 dependencies = [
     { name = "openfisca-core", extra = ["web-api"] },


### PR DESCRIPTION
Trente-sept valeurs du secteur privé portaient le **1er janvier 1960** sans aucune référence, et onze fichiers seulement en avaient une — vers un dépôt GitLab personnel ou, pour la cotisation de perte d'emploi, vers un **site commercial**.

## Pourquoi 1960 est impossible

Le dépouillement des fascicules du JORT établit que la structure décrite par ces valeurs n'existe pas avant 1997. Le taux du régime général se lit comme la **somme de trois textes** :

| Bloc | Texte | Taux | Employeur | Salarié |
|---|---|---:|---:|---:|
| Taux global des régimes de la loi n° 60-30 | loi n° 97-4, art. 41 (nouveau) | 18,00 % | 13,00 | 5,00 |
| Fonds spécial de l'État | loi n° 74-101 (LF 1975), art. 57 | 0,50 % | 0,50 | — |
| Cotisation propre du régime de pensions | décret n° 97-555, art. 9 (nouveau) | 5,25 % | 2,50 | 2,75 |
| **Total** | | **23,75 %** | **16,00** | **7,75** |

16,00 % et 7,75 % sont exactement les totaux que porte ce modèle avant assurance maladie ; avec elle, 16,57 % et 9,18 %, les chiffres publiés par la CNSS. Les décimales le confirment : 4,7361, 7,7639, 2,2111 sont la clé 13/5 appliquée branche par branche, tous multiples de 1/360 de point. La dernière pièce est de **2003** — le décret n° 2003-1212 porte à 7,25/20e la quote-part affectée aux pensions, avec effet au 1er janvier.

## Ce que la PR change

Chaque valeur porte sa date et sa référence, en édition française avec l'édition arabe en note, fascicule et page indiqués. **Aucune valeur n'a changé** : les tableaux publiés par le précis sont identiques avant et après, ce qui a été vérifié en régénérant ses snapshots.

Deux valeurs manquaient. La cotisation des **étudiants** commençait à 5 dinars alors que le décret n° 92-631 la fixe d'abord à **2 dinars** ; la série est complétée. Et la référence de la cotisation de **perte d'emploi** pointe maintenant vers le fascicule du JORT — en édition **arabe**, l'édition française de ce fascicule répondant 404 sur pist.tn, et c'est bien dans l'arabe que l'article 17 de la loi de finances 2025 a été lu.

## Ce que les notes disent, faute de pouvoir le corriger ici

Trois défauts sont de structure, pas de datation, et méritent des tickets distincts plutôt que d'alourdir cette PR :

- le **point d'accidents du travail** (0,7222 / 0,2778) n'est pas la cotisation d'accidents du travail, mais le point transféré par le décret n° 95-538 ; le vrai tarif est patronal et varie de 0,50 % à 5 % selon dix-huit classes d'activité ;
- le seuil de **0,66 du régime des bas revenus** est l'assiette forfaitaire des deux tiers du SMIG posée par l'article 7 de la loi n° 2002-32, non un plafond ; et ses quatre valeurs croisent deux répartitions — par branche et par payeur — que les textes ne croisent jamais ;
- l'assiette de la **retraite complémentaire** est la fraction de salaire excédant la limite de calcul des prestations du régime légal, non le salaire entier ; et son taux de 9 % n'a aucune source publiée, l'arrêté du 18 novembre 1978 fixant un taux d'appel de 4,5 % et confiant ses révisions à une décision non publiée du comité de gestion de la CAVIS.

S'y ajoutent l'inversion maternité/décès entre les travailleurs non salariés et les artistes, les assiettes forfaitaires non modélisées, et la variante conventionnelle à 11 % en vigueur de 1996 à 2007.

## Ce qui reste non établi

Les parts de prestations familiales (3,10 %), d'indemnités maladie-maternité (0,85 %) et de décès (0,65 %) du régime général ne sont fixées par aucun texte lu : elles sont obtenues par solde. De même pour les partages internes des assurances sociales des autres régimes, dont seule la part maladie est attestée à chaque fois par le décret n° 2007-1406. Et treize textes ne comportent aucune clause d'entrée en vigueur : leurs dates sont celles de la publication ou de la signature, ce que les notes disent.

## Tests

`tests/test_cotisations_secteur_prive.py` garde les totaux publiés par la CNSS, interdit le retour d'une date de 1960, et exige que chaque valeur porte une référence pointant vers pist.tn. Le garde-fou sur 1960 a été éprouvé par test négatif avant de proposer la PR. 163 tests passent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2qMrmbL6BUDiEo3NmpU5m