### PR TITLE
SMIG et SMAG : séparer les indemnités spéciales de 1989-1991, compléter les séries jusqu'en 2028

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.81 - [#PRNUM](https://github.com/openfisca/openfisca-tunisia/pull/PRNUM)
+## 0.81 - [#404](https://github.com/openfisca/openfisca-tunisia/pull/404)
 
 * Évolution du système socio-fiscal.
 * Périodes concernées : du 1989-08-01 au 1992-04-30, du 2014-05-01 au 2017-06-04, et à partir du 2020-10-01.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.81 - [#PRNUM](https://github.com/openfisca/openfisca-tunisia/pull/PRNUM)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : du 1989-08-01 au 1992-04-30, du 2014-05-01 au 2017-06-04, et à partir du 2020-10-01.
+* Zones impactées : `parameters/marche_travail`.
+* Détails :
+  - **Sépare le SMIG de l'indemnité spéciale de 1989-1991.** Les quatre séries du SMIG portaient au 1er août 1989, au 1er janvier 1990 et au 1er août 1991 le SMIG augmenté de l'indemnité spéciale (123,016 D au lieu de 120,016 D en 1990, régime de 48 heures). Or l'indemnité n'est pas le SMIG : le décret n° 89-1551 l'institue « au profit des travailleurs payés au » SMIG, l'exclut de l'assiette des cotisations et des prestations de sécurité sociale (art. 5) et suspend à son titre les retenues d'impôt (art. 4) ; le décret n° 91-1316, qui la porte à 5 D, reprend les deux clauses (art. 4 et 5). Le SMIG légal est celui du décret n° 90-246 (JORT n° 13 du 16 février 1990, p. 252) : **120,016 D et 104,706 D par mois, 577 et 604 millimes l'heure**. Les valeurs du 1er août 1989 et du 1er août 1991, dates où seul le montant de l'indemnité change, sont supprimées. L'indemnité reste portée par `indemnite_speciale_smig`, jusqu'à son intégration au SMIG par l'article 3 du décret n° 92-1299 au 1er mai 1992.
+  - Même correction pour le SMAG : **3,546 D** par jour au 1er janvier 1990 (décret n° 90-247, art. 1er) au lieu de 3,661 D, qui comptait l'indemnité spéciale agricole de 115 millimes (décret n° 89-1552) ; suppression des valeurs du 1er août 1989 et du 1er août 1991. Dans `indemnite_speciale_smag`, supprime la valeur du 1er janvier 1990, rattachée au décret n° 90-247, qui ne touche pas l'indemnité.
+  - Tous les usages de ces paramètres visent le SMIG ou le SMAG légal : cotisations du régime des travailleurs à faible revenu et assiette de la retraite complémentaire (`cotisations_sociales`), prestations familiales et contribution aux frais de crèche, seuils de l'AMEN social, indicatrice `smig` et abattement de l'IRPP (`tspr`, `irpp`). Aucun ne doit compter une indemnité exclue des cotisations, des prestations et de la retenue d'impôt.
+  - Conséquence pour la revalorisation des pensions indexées sur le SMIG : la hausse du 1er mai 1992 est de **+10,75 %** (120,016 → 132,912 D), dont les 5 D d'indemnité intégrée, et non de +6,32 %.
+  - Ajoute le SMIG au **1er janvier 2026, 2027 et 2028** (décret n° 2026-67, JORT n° 44 du 30 avril 2026, pp. 838-839) : 554,736 / 582,400 / 611,520 D (48 heures, mensuel), 470,251 / 493,304 / 517,571 D (40 heures), 2,667 / 2,800 / 2,940 D et 2,713 / 2,846 / 2,986 D l'heure.
+  - Ajoute le SMAG journalier manquant : **16,512 D** au 1er octobre 2020 (n° 2020-1070), **17,664 D** au 1er octobre 2022 (n° 2022-768), **18,904 D** au 1er mai 2024 et **20,320 D** au 1er janvier 2025 (n° 2024-420), **21,336 / 22,400 / 23,520 D** aux 1er janvier 2026, 2027 et 2028 (n° 2026-66).
+  - Redate trois valeurs du SMAG qui portaient la date de signature du décret : 12,304 D au **1er mai 2014** (n° 2014-2908, art. 6), 13 D au **1er mai 2015** (n° 2015-1763, art. 6), 13,736 D au **1er août 2016** (n° 2017-669, art. 6). Toutes les dates de ce changement sont des dates d'effet énoncées par le texte.
+  - Corrige l'intitulé du décret SMAG n° 2009-2258, daté du 14 juillet 2009 et non du 2 juin.
+  - Chaque entrée touchée renvoie au fascicule du JORT sur pist.tn, éditions française et arabe, avec numéro, page, article et clause d'effet. Le fascicule n° 45 de 2017 n'est servi qu'en arabe : la référence du SMAG du 1er août 2016 pointe vers l'édition arabe, où le texte a été lu.
+
+<!-- -->
+
 ## 0.80 - [#402](https://github.com/openfisca/openfisca-tunisia/pull/402)
 
 * Amélioration technique.

--- a/openfisca_tunisia/parameters/marche_travail/indemnite_complementaire_provisoire.yaml
+++ b/openfisca_tunisia/parameters/marche_travail/indemnite_complementaire_provisoire.yaml
@@ -12,12 +12,12 @@ metadata:
   reference:
     1981-04-07:
     - title: Décret n° 81-437 du 7 avril 1981
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1981/décret_81_437_fr.pdf
+      href: https://www.pist.tn/jort/1981/1981F/Jo02581.pdf
     - title: امر عدد 437 لسنة 1981
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1981/décret_81_437_ar.pdf
+      href: https://www.pist.tn/jort/1981/1981A/Ja02581.pdf
     1982-02-01:
     - title: Décret n° 82-501 du 16 mars 1982
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1982/décret_82_501_fr.pdf
+      href: https://www.pist.tn/jort/1982/1982F/Jo01982.pdf
     - title: أمر عدد 501 لسنة 1982 يتعلق بالترفيع في الاجر الادنى المضمون لمختلف المهن في الثطاعات غير الفلاحية ةالخاضعى لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1982/décret_82_501_ar.pdf
+      href: https://www.pist.tn/jort/1982/1982A/Ja01982.pdf
 documentation: Le Smic est composé du salaire de base et de cette indemnité complémentaire provisoire et de sa majoration

--- a/openfisca_tunisia/parameters/marche_travail/indemnite_speciale_smag.yaml
+++ b/openfisca_tunisia/parameters/marche_travail/indemnite_speciale_smag.yaml
@@ -2,8 +2,6 @@ description: Indemnité spéciale (IS) journalière pour le SMAG
 values:
   1989-08-01:
     value: 0.115
-  1990-01-01:
-    value: 0.115
   1991-08-01:
     value: 0.215
   1992-05-01:
@@ -14,19 +12,20 @@ metadata:
   unit: currency
   reference:
     1989-08-01:
-      title: Décret n°89-1552 du 06-10-1989
-    1990-01-01:
-    - title: Décret n°90-247 du 05-02-1990
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1990/décret_90_247_fr.pdf
-    - title: امر عدد 247 لسنة 1990 مؤرخ في  5 فيفري 1991 ينعلق يالاجر الادنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1990/décret_90_247_ar.pdf
+    - title: "Décret n° 89-1552 du 6 octobre 1989, portant octroi d'une indemnité spéciale au profit des travailleurs payés au salaire minimum agricole garanti, article premier"
+      href: https://www.pist.tn/jort/1989/1989F/Jo06989.pdf
+      note: "JORT n° 69 du 17 octobre 1989, p. 1632. Article premier : « Le montant journalier de cette indemnité est fixé à 115 millimes. » Article 3 : les retenues d'impôt sur les traitements et salaires, de contribution personnelle d'État, de contribution de solidarité et au profit du FOPROLOS sont suspendues au titre de cette indemnité. Article 4 : l'indemnité n'est pas prise en compte pour la détermination de l'assiette des cotisations et des prestations de sécurité sociale. Article 6 : effet à compter du 1er août 1989. Le décret n° 90-247, qui fixe le SMAG au 1er janvier 1990, ne modifie pas l'indemnité."
+    - title: "أمر عدد 1552 لسنة 1989 مؤرخ في 6 أكتوبر 1989 يتعلق باسناد منحة خاصة لفائدة العملة الخالصين بالأجر الأدنى الفلاحي المضمون"
+      href: https://www.pist.tn/jort/1989/1989A/Ja06989.pdf
     1991-08-01:
-    - title: Décret n°91-1317 du 02-09-1991
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1991/décret_92_1300_fr.pdf
-    - title: امر عدد 1317 لسنة 1991 مؤرخ في 02 سبتمبر 1991
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1991/décret_92_1300_ar.pdf
+    - title: "Décret n° 91-1317 du 2 septembre 1991, portant fixation de l'indemnité spéciale octroyée au profit des travailleurs payés au salaire minimum agricole garanti, article premier"
+      href: https://www.pist.tn/jort/1991/1991F/Jo06391.pdf
+      note: "JORT n° 63 du 17 septembre 1991, p. 1581. Article premier : indemnité fixée à 215 millimes par journée. Article 3 : les retenues d'impôt sur le revenu sont suspendues au titre de cette indemnité. Article 4 : même exclusion de l'assiette des cotisations et des prestations de sécurité sociale. Article 6 : abroge le décret n° 89-1552. Article 7 : effet à compter du 1er août 1991."
+    - title: "أمر عدد 1317 لسنة 1991 مؤرخ في 2 سبتمبر 1991 يتعلق بضبط المنحة الخاصة المسندة لفائدة العملة الخالصين بالأجر الأدنى الفلاحي المضمون"
+      href: https://www.pist.tn/jort/1991/1991A/Ja06391.pdf
     1992-05-01:
-    - title: Décret n°92-1300 du 13-07-1992
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1300_fr.pdf
-    - title: امر عدد 1300 لسنة 1992 مؤرخ  في 13 حويبية 1992 يتعلق يارجر الادنى الغلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1300_ar.pdf
+    - title: "Décret n° 92-1300 du 13 juillet 1992, fixant le salaire minimum agricole garanti, article 3"
+      href: https://www.pist.tn/jort/1992/1992F/Jo04992.pdf
+      note: "JORT n° 49 du 28 juillet 1992, p. 936. Article 3 : les salaires minima fixés aux articles 1 et 2 « comprennent l'indemnité spéciale fixée par le décret sus-visé n° 91-1317 du 2 septembre 1991 ». Article 6 : abroge le décret n° 91-1317. Article 7 : effet à compter du 1er mai 1992. La valeur nulle traduit l'intégration de l'indemnité au SMAG, non sa suppression."
+    - title: "أمر عدد 1300 لسنة 1992 مؤرخ في 13 جويلية 1992 يتعلق بضبط الأجر الأدنى الفلاحي المضمون"
+      href: https://www.pist.tn/jort/1992/1992A/Ja04992.pdf

--- a/openfisca_tunisia/parameters/marche_travail/indemnite_speciale_smig.yaml
+++ b/openfisca_tunisia/parameters/marche_travail/indemnite_speciale_smig.yaml
@@ -10,17 +10,20 @@ metadata:
   unit: currency
   reference:
     1989-08-01:
-    - title: Décret n°89-1551 du 06-10-1989 portant octroi d'une indemnité spéciale au profit des travailleurs payés au salaire minimum interprofessionnel garanti, employés dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1989/décret_89_1551_fr.pdf
-    - title: امر عدد 1551 لسنة 1989 مؤرخ في 6 جوان 1989 يتعلّق بضبط المنحة الخاصة المسندة لفائدة العملة الخالصين بالأجر الأدنى المضمون لمختلف المهن المشتغلين بالقطاعات غير الفلاحية والخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1989/décret_89_1551_ar.pdf
+    - title: "Décret n° 89-1551 du 6 octobre 1989, portant octroi d'une indemnité spéciale au profit des travailleurs payés au salaire minimum interprofessionnel garanti, employés dans les secteurs non agricoles régis par le code du travail, article premier"
+      href: https://www.pist.tn/jort/1989/1989F/Jo06989.pdf
+      note: "JORT n° 69 du 17 octobre 1989, p. 1632. Article premier : indemnité de 3 dinars par mois pour le personnel payé au mois ; 17 millimes l'heure (40 heures) et 14 millimes l'heure (48 heures) pour le personnel payé à l'heure. Article 4 : les retenues d'impôt sur les traitements et salaires, de contribution personnelle d'État, de contribution de solidarité et au profit du FOPROLOS sont suspendues au titre de cette indemnité. Article 5 : « A titre exceptionnel, l'indemnité spéciale n'est pas prise en compte pour la détermination de l'assiette des cotisations et des prestations de sécurité sociale. » Article 7 : effet à compter du 1er août 1989. L'indemnité s'ajoute au SMIG sans le modifier."
+    - title: "أمر عدد 1551 لسنة 1989 مؤرخ في 6 أكتوبر 1989 يتعلق باسناد منحة خاصة لفائدة العملة الخالصين بالأجر الأدنى المضمون لمختلف المهن المشتغلين بالقطاعات غير الفلاحية والخاضعة لمجلة الشغل"
+      href: https://www.pist.tn/jort/1989/1989A/Ja06989.pdf
     1991-08-01:
-    - title: Décret n°91-1316 du 02-09-1991 portant fixation de l'indemnité spéciale octroyée au profit des travailleurs payés au salaire minimum interprofessionnel garanti, employés dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1991/décret_91_1316_fr.pdf
-    - title: امر عدد 1316 لسنة 1991 يتعلّق بضبط المنحة الخاصة المسندة لفائدة العملة الخالصين بالأجر الأدنى المضمون لمختلف المهن المشتغلين بالقطاعات غير الفلاحية والخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1991/décret_91_1316_ar.pdf
+    - title: "Décret n° 91-1316 du 2 septembre 1991, portant fixation de l'indemnité spéciale octroyée au profit des travailleurs payés au salaire minimum interprofessionnel garanti, employés dans les secteurs non agricoles régis par le code du travail, article premier"
+      href: https://www.pist.tn/jort/1991/1991F/Jo06391.pdf
+      note: "JORT n° 63 du 17 septembre 1991, pp. 1580-1581. Article premier : indemnité portée à 5 dinars par mois ; 29 millimes l'heure (40 heures) et 24 millimes l'heure (le fascicule imprime « 45 heures » pour le régime de 48 heures). Article 4 : les retenues d'impôt sur le revenu sont suspendues au titre de cette indemnité. Article 5 : même exclusion de l'assiette des cotisations et des prestations de sécurité sociale. Article 7 : abroge le décret n° 89-1551. Article 8 : effet à compter du 1er août 1991."
+    - title: "أمر عدد 1316 لسنة 1991 مؤرخ في 2 سبتمبر 1991 يتعلق بضبط المنحة الخاصة المسندة لفائدة العملة الخالصين بالأجر الأدنى المضمون لمختلف المهن المشتغلين بالقطاعات غير الفلاحية والخاضعة لمجلة الشغل"
+      href: https://www.pist.tn/jort/1991/1991A/Ja06391.pdf
     1992-05-01:
-    - title: Décret n°92-1299 du 13-07-1992 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1299_fr.pdf
-    - title: امر عدد 1299 لسنة 1992 مؤرخ في 13 جويلية 1992 بتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1299_ar.pdf
+    - title: "Décret n° 92-1299 du 13 juillet 1992, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, articles premier et 3"
+      href: https://www.pist.tn/jort/1992/1992F/Jo04992.pdf
+      note: "JORT n° 49 du 28 juillet 1992, pp. 935-936. Article 3 : le SMIG fixé à l'article premier « comprend l'indemnité spéciale fixée par le décret sus-visé n° 91-1316 du 2 septembre 1991 ». Article 8 : abroge le décret n° 91-1316. Article 9 : effet à compter du 1er mai 1992. La valeur nulle traduit l'intégration de l'indemnité au SMIG, non sa suppression."
+    - title: "أمر عدد 1299 لسنة 1992 مؤرخ في 13 جويلية 1992 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل"
+      href: https://www.pist.tn/jort/1992/1992A/Ja04992.pdf

--- a/openfisca_tunisia/parameters/marche_travail/majoration_smig_40h_mensuel.yaml
+++ b/openfisca_tunisia/parameters/marche_travail/majoration_smig_40h_mensuel.yaml
@@ -7,6 +7,6 @@ metadata:
   reference:
     1982-03-16:
     - title: Décret n° 82-501 du 16 mars 1982 Portant majoration du salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1982/décret_82_501_fr.pdf
+      href: https://www.pist.tn/jort/1982/1982F/Jo01982.pdf
     - title: أمر عدد 501 لسنة 1982 مؤرخ في 16 مارس 1982 يتعلق بالترفيع في الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية والخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1982/décret_82_501_ar.pdf
+      href: https://www.pist.tn/jort/1982/1982A/Ja01982.pdf

--- a/openfisca_tunisia/parameters/marche_travail/majoration_smig_48h_mensuel.yaml
+++ b/openfisca_tunisia/parameters/marche_travail/majoration_smig_48h_mensuel.yaml
@@ -7,6 +7,6 @@ metadata:
   reference:
     1982-03-16:
     - title: Décret n° 82-501 du 16 mars 1982 portant majoration du salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1982/décret_82_501_fr.pdf
+      href: https://www.pist.tn/jort/1982/1982F/Jo01982.pdf
     - title: أمر عدد 501 لسنة 1982 مؤرخ في 16 مارس 1982 يتعلق بالترفيع في الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية والخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1982/décret_82_501_ar.pdf
+      href: https://www.pist.tn/jort/1982/1982A/Ja01982.pdf

--- a/openfisca_tunisia/parameters/marche_travail/salaire_de_base_40h_horaire.yaml
+++ b/openfisca_tunisia/parameters/marche_travail/salaire_de_base_40h_horaire.yaml
@@ -17,31 +17,31 @@ metadata:
   reference:
     2008-07-01:
     - title: Décret n° 2008-2072 du 2 juin 2008, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2008/Décret_2008_2072_fr.pdf
+      href: https://www.pist.tn/jort/2008/2008F/Jo0462008.pdf
     - title: أمر عدد 2072 لسنة 2008 مؤرخ في 2 جوان 2008 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2008/Décret_2008_2072_ar.pdf
+      href: https://www.pist.tn/jort/2008/2008A/Ja0462008.pdf
     2009-08-01:
     - title: Décret n°2009-2257 du 14 Juillet 2009 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2009/Décret_2009_2257_fr.pdf
+      href: https://www.pist.tn/jort/2009/2009F/Jo0622009.pdf
     - title: أمر عدد 2257 لسنة 2009 مؤرخ في 14 جويلية 2009 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2009/Décret_2009_2257_ar.pdf
+      href: https://www.pist.tn/jort/2009/2009A/Ja0622009.pdf
     2010-07-01:
     - title: Décret n°2010-1746 du 17 Juillet 2010 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2010/Décret_2010_1746_ar.pdf
+      href: https://www.pist.tn/jort/2010/2010F/Jo0582010.pdf
     - title: أمر عدد 1746 لسنة 2010 مؤرخ في 17 جويلية 2010 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2010/Décret_2010_1746_ar.pdf
+      href: https://www.pist.tn/jort/2010/2010A/Ja0582010.pdf
     2011-05-01:
     - title: Décret n°2011-679 du 09 Juin 2011 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2011/Décret_2011_679_fr.pdf
+      href: https://www.pist.tn/jort/2011/2011F/Jo0422011.pdf
     - title: أمر عدد 679 لسنة 2011 مؤرخ في 9 جوان 2011 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2011/Décret_2011_679_ar.pdf
+      href: https://www.pist.tn/jort/2011/2011A/Ja0422011.pdf
     2012-07-01:
     - title: Décret n°2012-1981 du 20 Septembre 2012 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2012/Décret_2012_1981_fr.pdf
+      href: https://www.pist.tn/jort/2012/2012F/Jo0772012.pdf
     - title: امر عدد 1981 لسنة 2012 مؤرخ في 20 سبتمبر 2012 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2012/Décret_2012_1981_ar.pdf
+      href: https://www.pist.tn/jort/2012/2012A/Ja0772012.pdf
     2014-05-01:
     - title: Décret n°2014-2907 du 11 Août 2014 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2014/Décret_2014_2907_fr.pdf
+      href: https://www.pist.tn/jort/2014/2014F/Jo0662014.pdf
     - title: امر عدد 2907 لسنة 2014 مؤرخ في 11 أوت 2014 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2014/Décret_2014_2907_ar.pdf
+      href: https://www.pist.tn/jort/2014/2014A/Ja0662014.pdf

--- a/openfisca_tunisia/parameters/marche_travail/salaire_de_base_40h_mensuel.yaml
+++ b/openfisca_tunisia/parameters/marche_travail/salaire_de_base_40h_mensuel.yaml
@@ -17,31 +17,31 @@ metadata:
   reference:
     2008-07-01:
     - title: Décret n°2008-2072 du 02 Juin 2008 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2008/Décret_2008_2072_fr.pdf
+      href: https://www.pist.tn/jort/2008/2008F/Jo0462008.pdf
     - title: أمر عدد 2072 لسنة 2008 مؤرخ في 2 جوان 2008 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2008/Décret_2008_2072_ar.pdf
+      href: https://www.pist.tn/jort/2008/2008A/Ja0462008.pdf
     2009-08-01:
     - title: Décret n°2009-2257 du 14 Juillet 2009 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2009/Décret_2009_2257_fr.pdf
+      href: https://www.pist.tn/jort/2009/2009F/Jo0622009.pdf
     - title: أمر عدد 2257 لسنة 2009 مؤرخ في 14 جويلية 2009 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2009/Décret_2009_2257_ar.pdf
+      href: https://www.pist.tn/jort/2009/2009A/Ja0622009.pdf
     2010-07-01:
     - title: Décret n°2010-1746 du 17 Juillet 2010 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2010/Décret_2010_1746_fr.pdf
+      href: https://www.pist.tn/jort/2010/2010F/Jo0582010.pdf
     - title: أمر عدد 1746 لسنة 2010 مؤرخ في 17 جويلية 2010 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2010/Décret_2010_1746_ar.pdf
+      href: https://www.pist.tn/jort/2010/2010A/Ja0582010.pdf
     2011-05-01:
     - title: Décret n°2011-679 du 09 Juin 2011 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2011/Décret_2011_679_fr.pdf
+      href: https://www.pist.tn/jort/2011/2011F/Jo0422011.pdf
     - title: أمر عدد 679 لسنة 2011 مؤرخ في 9 جوان 2011 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2011/Décret_2011_679_ar.pdf
+      href: https://www.pist.tn/jort/2011/2011A/Ja0422011.pdf
     2012-07-01:
     - title: Décret n°2012-1981 du 20 Septembre 2012 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2012/Décret_2012_1981_fr.pdf
+      href: https://www.pist.tn/jort/2012/2012F/Jo0772012.pdf
     - title: امر عدد 1981 لسنة 2012 مؤرخ في 20 سبتمبر 2012 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2012/Décret_2012_1981_ar.pdf
+      href: https://www.pist.tn/jort/2012/2012A/Ja0772012.pdf
     2014-05-01:
     - title: Décret n°2014-2907 du 11 Août 2014 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2014/Décret_2014_2907_fr.pdf
+      href: https://www.pist.tn/jort/2014/2014F/Jo0662014.pdf
     - title: امر عدد 2907 لسنة 2014 مؤرخ في 11 أوت 2014 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2014/Décret_2014_2907_ar.pdf
+      href: https://www.pist.tn/jort/2014/2014A/Ja0662014.pdf

--- a/openfisca_tunisia/parameters/marche_travail/salaire_de_base_48h_horaire.yaml
+++ b/openfisca_tunisia/parameters/marche_travail/salaire_de_base_48h_horaire.yaml
@@ -17,31 +17,31 @@ metadata:
   reference:
     2008-07-01:
     - title: Décret n°2008-2072 du 02 Juin 2008 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2008/Décret_2008_2072_fr.pdf
+      href: https://www.pist.tn/jort/2008/2008F/Jo0462008.pdf
     - title: امر عدد 2072 لسنة 2008 مؤرخ في 2 جوان 2008 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2008/Décret_2008_2072_ar.pdf
+      href: https://www.pist.tn/jort/2008/2008A/Ja0462008.pdf
     2009-08-01:
     - title: Décret n°2009-2257 du 14 Juillet 2009  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2009/Décret_2009_2257_fr.pdf
+      href: https://www.pist.tn/jort/2009/2009F/Jo0622009.pdf
     - title: أمر عدد 2257 لسنة 2009 مؤرخ في 14 جويلية 2009 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2009/Décret_2009_2257_ar.pdf
+      href: https://www.pist.tn/jort/2009/2009A/Ja0622009.pdf
     2010-07-01:
     - title: Décret n°2010-1746 du 17 Juillet 2010 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2010/Décret_2010_1746_fr.pdf
+      href: https://www.pist.tn/jort/2010/2010F/Jo0582010.pdf
     - title: أمر عدد 1746 لسنة 2010 مؤرخ في 17 جويلية 2010 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2010/Décret_2010_1746_ar.pdf
+      href: https://www.pist.tn/jort/2010/2010A/Ja0582010.pdf
     2011-05-01:
     - title: Décret n°2011-679 du 09 Juin 2011 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2011/Décret_2011_679_fr.pdf
+      href: https://www.pist.tn/jort/2011/2011F/Jo0422011.pdf
     - title: أمر عدد 679 لسنة 2011 مؤرخ في 9 جوان 2011 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2011/Décret_2011_679_ar.pdf
+      href: https://www.pist.tn/jort/2011/2011A/Ja0422011.pdf
     2012-07-01:
     - title: Décret n°2012-1981 du 20 Septembre 2012 , fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2012/Décret_2012_1981_fr.pdf
+      href: https://www.pist.tn/jort/2012/2012F/Jo0772012.pdf
     - title: امر عدد 1981 لسنة 2012 مؤرخ في 20 سبتمبر 2012 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2012/Décret_2012_1981_ar.pdf
+      href: https://www.pist.tn/jort/2012/2012A/Ja0772012.pdf
     2014-05-01:
     - title: Décret n°2014-2907 du 11 Août 2014 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2014/Décret_2014_2907_fr.pdf
+      href: https://www.pist.tn/jort/2014/2014F/Jo0662014.pdf
     - title: امر عدد 2907 لسنة 2014 مؤرخ في 11 أوت 2014 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2014/Décret_2014_2907_ar.pdf
+      href: https://www.pist.tn/jort/2014/2014A/Ja0662014.pdf

--- a/openfisca_tunisia/parameters/marche_travail/salaire_de_base_48h_mensuel.yaml
+++ b/openfisca_tunisia/parameters/marche_travail/salaire_de_base_48h_mensuel.yaml
@@ -17,31 +17,31 @@ metadata:
   reference:
     2008-07-01:
     - title: Décret n°2008-2072 du 02 Juin 2008 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2008/Décret_2008_2072_fr.pdf
+      href: https://www.pist.tn/jort/2008/2008F/Jo0462008.pdf
     - title: أمر عدد 2072 لسنة 2008 مؤرخ في 2 جوان 2008 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية التي ينظمها قانون الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2008/Décret_2008_2072_ar.pdf
+      href: https://www.pist.tn/jort/2008/2008A/Ja0462008.pdf
     2009-08-01:
     - title: Décret n°2009-2257 du 14 Juillet 2009 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2009/Décret_2009_2257_fr.pdf
+      href: https://www.pist.tn/jort/2009/2009F/Jo0622009.pdf
     - title: أمر عدد 2257 لسنة 2009 مؤرخ في 14 جويلية 2009 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية التي ينظمها قانون الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2009/Décret_2009_2257_ar.pdf
+      href: https://www.pist.tn/jort/2009/2009A/Ja0622009.pdf
     2010-07-01:
     - title: Décret n°2010-1746 du 17 Juillet 2010 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2010/Décret_2010_1746_fr.pdf
+      href: https://www.pist.tn/jort/2010/2010F/Jo0582010.pdf
     - title: أمر عدد 1746 لسنة 2010 مؤرخ في 17 جويلية 2010 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية التي ينظمها قانون الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2010/Décret_2010_1746_ar.pdf
+      href: https://www.pist.tn/jort/2010/2010A/Ja0582010.pdf
     2011-05-01:
     - title: Décret n°2011-679 du 09 Juin 2011 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2011/Décret_2011_679_fr.pdf
+      href: https://www.pist.tn/jort/2011/2011F/Jo0422011.pdf
     - title: أمر عدد 679 لسنة 2011 مؤرخ في 9 جوان 2011 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية التي ينظمها قانون الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2011/Décret_2011_679_ar.pdf
+      href: https://www.pist.tn/jort/2011/2011A/Ja0422011.pdf
     2012-07-01:
     - title: Décret n°2012-1981 du 20 Septembre 2012 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2012/Décret_2012_1981_fr.pdf
+      href: https://www.pist.tn/jort/2012/2012F/Jo0772012.pdf
     - title: أمر عدد 1981 لسنة 2012 مؤرخ في 20 سبتمبر 2012 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية التي ينظمها قانون الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2012/Décret_2012_1981_ar.pdf
+      href: https://www.pist.tn/jort/2012/2012A/Ja0772012.pdf
     2014-05-01:
     - title: Décret n° 2014-2907 du 11 août 2014, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2014/Décret_2014_2907_fr.pdf
+      href: https://www.pist.tn/jort/2014/2014F/Jo0662014.pdf
     - title: أمر عدد 2907 لسنة 2014 مؤرخ في 11 أوت 2014 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية التي ينظمها قانون الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2014/Décret_2014_2907_ar.pdf
+      href: https://www.pist.tn/jort/2014/2014A/Ja0662014.pdf

--- a/openfisca_tunisia/parameters/marche_travail/smag_journalier.yaml
+++ b/openfisca_tunisia/parameters/marche_travail/smag_journalier.yaml
@@ -36,12 +36,8 @@ values:
     value: 3.05
   1988-04-01:
     value: 3.2
-  1989-08-01:
-    value: 3.315
   1990-01-01:
-    value: 3.661
-  1991-08-01:
-    value: 3.761
+    value: 3.546
   1992-05-01:
     value: 3.961
   1992-08-01:
@@ -96,16 +92,30 @@ values:
     value: 10.608
   2012-12-01:
     value: 11.608
-  2014-08-11:
+  2014-05-01:
     value: 12.304
-  2015-11-09:
+  2015-05-01:
     value: 13
-  2017-06-05:
+  2016-08-01:
     value: 13.736
   2018-05-01:
     value: 14.56
   2019-05-01:
     value: 15.504
+  2020-10-01:
+    value: 16.512
+  2022-10-01:
+    value: 17.664
+  2024-05-01:
+    value: 18.904
+  2025-01-01:
+    value: 20.32
+  2026-01-01:
+    value: 21.336
+  2027-01-01:
+    value: 22.4
+  2028-01-01:
+    value: 23.52
 metadata:
   unit: currency
   reference:
@@ -199,26 +209,18 @@ metadata:
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/décret_88_890_fr.pdf
     - title: أمر عدد  890   لسنة   1988   مؤرخ في  5 ماي 1988 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/décret_88_980_ar.pdf
-    1989-08-01:
-    - title: Décret n°89-1552 du 06 octobre 1989 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1989/décret_89_1552_fr.pdf
-    - title: أمر عدد   1552  لسنة  1989 مؤرخ في 6 أكتوبر 1989  يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1989/décret_89_1552_ar.pdf
     1990-01-01:
-    - title: Décret n°90-247 du 05 février 1990 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1990/décret_90_247_fr.pdf
-    - title: أمر عدد   247  لسنة  1990 مؤرخ في   5 فيفري 1990 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1990/décret_90_247_ar.pdf
-    1991-08-01:
-    - title: Décret n°91-1317 du 02 septembre 1991 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1991/décret_91_1317-fr.pdf
-    - title: أمر عدد   1317 لسنة  1991 مؤرخ في 2  سبتمبر 1991 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1991/décret_91_1317_ar.pdf
+    - title: "Décret n° 90-247 du 5 février 1990, fixant le salaire minimum agricole garanti, article premier"
+      href: https://www.pist.tn/jort/1990/1990F/Jo01390.pdf
+      note: "JORT n° 13 du 16 février 1990, p. 252. Article premier : le SMAG est « porté à 3,546 dinars par journée de travail effectif ». Article 6 : effet à compter du 1er janvier 1990. Ce montant ne comprend pas l'indemnité spéciale du décret n° 89-1552 (115 millimes par journée), qui subsiste à côté du SMAG et figure dans marche_travail.indemnite_speciale_smag. Jusqu'au 1er janvier 1990 exclu, le SMAG reste celui du décret n° 88-890 : le décret n° 89-1552 ne le modifie pas."
+    - title: "أمر عدد 247 لسنة 1990 مؤرخ في 5 فيفري 1990 يتعلق بضبط الأجر الأدنى الفلاحي المضمون"
+      href: https://www.pist.tn/jort/1990/1990A/Ja01390.pdf
     1992-05-01:
-    - title: Décret n°92-1300 du 13 juillet 1992 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1300_fr.pdf
-    - title: أمر عدد  1300 لسنة  1992 مؤرخ في 13 جويلية 1992  يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1300_ar.pdf
+    - title: "Décret n° 92-1300 du 13 juillet 1992, fixant le salaire minimum agricole garanti, articles premier et 3"
+      href: https://www.pist.tn/jort/1992/1992F/Jo04992.pdf
+      note: "JORT n° 49 du 28 juillet 1992, p. 936. Article premier : le SMAG est fixé à 3,961 dinars par journée de travail effectif. Article 3 : les salaires minima « comprennent l'indemnité spéciale fixée par le décret sus-visé n° 91-1317 du 2 septembre 1991 » (215 millimes par journée), que l'article 6 abroge. Article 7 : effet à compter du 1er mai 1992."
+    - title: "أمر عدد 1300 لسنة 1992 مؤرخ في 13 جويلية 1992 يتعلق بضبط الأجر الأدنى الفلاحي المضمون"
+      href: https://www.pist.tn/jort/1992/1992A/Ja04992.pdf
     1992-08-01:
     - title: Décret n°92-1631 du 07 septembre 1992 fixant le salaire minimum agricole garanti
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1631_fr.pdf
@@ -325,10 +327,11 @@ metadata:
     - title: امر عدد 2073 لسنة 2008 مؤرخ في 2 جوان 2008 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2008/Décret_2008_2073_ar.pdf
     2009-08-01:
-    - title: Décret n°2009-2258 du 02 juin 2009 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2009/Décret_2009_2258_fr.pdf
-    - title: امر عدد 2258 لسنة 2009 مؤرخ في 14 جويلية 2009 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2009/Décret_2009_2258_ar.pdf
+    - title: "Décret n° 2009-2258 du 14 juillet 2009, fixant le salaire minimum agricole garanti, article premier"
+      href: https://www.pist.tn/jort/2009/2009F/Jo0622009.pdf
+      note: "JORT n° 62 du 4 août 2009, pp. 2140-2141. Article premier : le SMAG est fixé à 8,019 dinars par journée de travail effectif. Article 6 : effet à compter du 1er août 2009."
+    - title: "أمر عدد 2258 لسنة 2009 مؤرخ في 14 جويلية 2009 يتعلق بضبط الأجر الأدنى الفلاحي المضمون"
+      href: https://www.pist.tn/jort/2009/2009A/Ja0622009.pdf
     2010-07-01:
     - title: Décret n°2010-1747 du 17 juillet 2010 fixant le salaire minimum agricole garanti.
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2010/Décret_2010_1747_fr.pdf
@@ -346,21 +349,22 @@ metadata:
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2012/Décret_2012_1982_fr.pdf
     - title: امر عدد 1982 لسنة 2012 مؤرخ في 20 سبتمبر 2012 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2012/Décret_2012_1982_ar.pdf
-    2014-08-11:
-    - title: Décret n°2014-2908 du 11 Août 2014  fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2014/Décret_2014_2908_fr.pdf
-    - title: أمر عدد 2908 لسنة 2014 مؤرخ في 11 أوت 2014 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2014/Décret_2014_2908_ar.pdf
-    2015-11-09:
-    - title: Décret n°2015-1763 du 09 Novembre 2015  fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2015/décret-2015-1763_fr.pdf
-    - title: امر عدد 1763 لسنة 2015 مؤرخ في 9 نوفمبر 2015 يتعلق بالاجر الادنى الفلاحى المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2015/décret_2015_1763_ar.pdf
-    2017-06-05:
-    - title: Décret n°2017-669 du 05 Juin 2017 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2017/Décret_2017_669_fr.pdf
-    - title: أمر حكومي عدد 669 لسنة 2017 مؤرخ في 5 جوان 2017 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2017/Décret_2017_669_ar.pdf
+    2014-05-01:
+    - title: "Décret n° 2014-2908 du 11 août 2014, fixant le salaire minimum agricole garanti, article premier"
+      href: https://www.pist.tn/jort/2014/2014F/Jo0662014.pdf
+      note: "JORT n° 66 du 15 août 2014, p. 2064. Article premier : le SMAG est fixé à 12,304 dinars par journée de travail effectif. Article 6 : effet à compter du 1er mai 2014. La date du 11 août 2014 portée auparavant était celle de la signature."
+    - title: "أمر عدد 2908 لسنة 2014 مؤرخ في 11 أوت 2014 يتعلق بضبط الأجر الأدنى الفلاحي المضمون"
+      href: https://www.pist.tn/jort/2014/2014A/Ja0662014.pdf
+    2015-05-01:
+    - title: "Décret gouvernemental n° 2015-1763 du 9 novembre 2015, fixant le salaire minimum agricole garanti, article premier"
+      href: https://www.pist.tn/jort/2015/2015F/Jo0912015.pdf
+      note: "JORT n° 91 du 13 novembre 2015, pp. 2710-2711. Article premier : le SMAG est fixé à 13 dinars par journée de travail effectif. Article 6 : effet à compter du 1er mai 2015. La date du 9 novembre 2015 portée auparavant était celle de la signature."
+    - title: "أمر حكومي عدد 1763 لسنة 2015 مؤرخ في 9 نوفمبر 2015 يتعلق بضبط الأجر الأدنى الفلاحي المضمون"
+      href: https://www.pist.tn/jort/2015/2015A/Ja0912015.pdf
+    2016-08-01:
+    - title: "أمر حكومي عدد 669 لسنة 2017 مؤرخ في 5 جوان 2017 يتعلق بضبط الأجر الأدنى الفلاحي المضمون"
+      href: https://www.pist.tn/jort/2017/2017A/Ja0452017.pdf
+      note: "Décret gouvernemental n° 2017-669 du 5 juin 2017, fixant le salaire minimum agricole garanti. JORT n° 45 du 6 juin 2017, édition arabe, p. 1878. Article premier : le SMAG est fixé à 13,736 dinars par journée de travail effectif. Article 6 : effet à compter du 1er août 2016. La date du 5 juin 2017 portée auparavant était celle de la signature. L'édition française de ce fascicule n'est pas servie par pist.tn : l'adresse 2017F/Jo0452017.pdf renvoie le même fichier que l'édition arabe ; le texte a été lu dans l'édition arabe."
     2018-05-01:
     - title: Décret gouvernemental n°2018-673 du 07 août 2018  fixant le salaire minimum agricole garanti.
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2018/Décret_2018_673_fr.pdf
@@ -371,6 +375,48 @@ metadata:
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2019/Décret_2019_455_fr.pdf
     - title: أمر حكومي عدد 455 لسنة 2019 مؤرخ في 28 ماي 2019 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2019/Décret_2019_455_ar.pdf
+    2020-10-01:
+    - title: "Décret gouvernemental n° 2020-1070 du 30 décembre 2020, fixant le salaire minimum agricole garanti, article premier"
+      href: https://www.pist.tn/jort/2021/2021F/Jo0012021.pdf
+      note: "JORT n° 1 du 5 janvier 2021, p. 25. Article premier : le SMAG est fixé à 16,512 dinars par journée de travail effectif. Article 6 : effet à compter du 1er octobre 2020."
+    - title: "أمر حكومي عدد 1070 لسنة 2020 مؤرخ في 30 ديسمبر 2020 يتعلق بضبط الأجر الأدنى الفلاحي المضمون"
+      href: https://www.pist.tn/jort/2021/2021A/Ja0012021.pdf
+    2022-10-01:
+    - title: "Décret n° 2022-768 du 19 octobre 2022, fixant le salaire minimum agricole garanti, article premier"
+      href: https://www.pist.tn/jort/2022/2022F/Jo1142022.pdf
+      note: "JORT n° 114 du 21 octobre 2022, pp. 2834-2835. Article premier (p. 2834) : le SMAG est fixé à 17,664 dinars par journée de travail effectif. Article 5 (p. 2835) : effet à compter du 1er octobre 2022."
+    - title: "أمر عدد 768 لسنة 2022 مؤرخ في 19 أكتوبر 2022 يتعلق بضبط الأجر الأدنى الفلاحي المضمون"
+      href: https://www.pist.tn/jort/2022/2022A/Ja1142022.pdf
+    2024-05-01:
+    - title: "Décret n° 2024-420 du 9 juillet 2024, fixant le salaire minimum agricole garanti, article premier"
+      href: https://www.pist.tn/jort/2024/2024F/Jo0852024.pdf
+      note: "JORT n° 85 du 9 juillet 2024, pp. 1802-1803 (pagination relevée au pied de page de l'édition française : le décret commence p. 1802, l'article premier et l'article 5 sont p. 1803). Article premier : le SMAG est fixé à 18,904 dinars par journée de travail effectif à compter du 1er mai 2024. Article 5 : le décret prend effet à compter du 1er mai 2024."
+    - title: "أمر عدد 420 لسنة 2024 مؤرخ في 9 جويلية 2024 يتعلق بضبط الأجر الأدنى الفلاحي المضمون"
+      href: https://www.pist.tn/jort/2024/2024A/Ja0852024.pdf
+    2025-01-01:
+    - title: "Décret n° 2024-420 du 9 juillet 2024, fixant le salaire minimum agricole garanti, article premier"
+      href: https://www.pist.tn/jort/2024/2024F/Jo0852024.pdf
+      note: "JORT n° 85 du 9 juillet 2024, pp. 1802-1803 (pagination relevée au pied de page de l'édition française : le décret commence p. 1802, l'article premier et l'article 5 sont p. 1803). Article premier : le SMAG est fixé à 20,320 dinars par journée de travail effectif à compter du 1er janvier 2025. Article 5 : le décret prend effet à compter du 1er mai 2024."
+    - title: "أمر عدد 420 لسنة 2024 مؤرخ في 9 جويلية 2024 يتعلق بضبط الأجر الأدنى الفلاحي المضمون"
+      href: https://www.pist.tn/jort/2024/2024A/Ja0852024.pdf
+    2026-01-01:
+    - title: "Décret n° 2026-66 du 30 avril 2026, fixant le salaire minimum agricole garanti, article premier"
+      href: https://www.pist.tn/jort/2026/2026F/Jo0442026.pdf
+      note: "JORT n° 44 du 30 avril 2026, p. 837. Article premier : le SMAG est fixé à 21,336 dinars par journée de travail effectif à compter du 1er janvier 2026. Article 5 : l'augmentation du SMAG s'applique aux pensions de retraite servies par la Caisse nationale de sécurité sociale."
+    - title: "أمر عدد 66 لسنة 2026 مؤرخ في 30 أفريل 2026 يتعلق بضبط الأجر الأدنى الفلاحي المضمون"
+      href: https://www.pist.tn/jort/2026/2026A/Ja0442026.pdf
+    2027-01-01:
+    - title: "Décret n° 2026-66 du 30 avril 2026, fixant le salaire minimum agricole garanti, article premier"
+      href: https://www.pist.tn/jort/2026/2026F/Jo0442026.pdf
+      note: "JORT n° 44 du 30 avril 2026, p. 837. Article premier : le SMAG est fixé à 22,400 dinars par journée de travail effectif à compter du 1er janvier 2027. Article 5 : l'augmentation du SMAG s'applique aux pensions de retraite servies par la Caisse nationale de sécurité sociale."
+    - title: "أمر عدد 66 لسنة 2026 مؤرخ في 30 أفريل 2026 يتعلق بضبط الأجر الأدنى الفلاحي المضمون"
+      href: https://www.pist.tn/jort/2026/2026A/Ja0442026.pdf
+    2028-01-01:
+    - title: "Décret n° 2026-66 du 30 avril 2026, fixant le salaire minimum agricole garanti, article premier"
+      href: https://www.pist.tn/jort/2026/2026F/Jo0442026.pdf
+      note: "JORT n° 44 du 30 avril 2026, p. 837. Article premier : le SMAG est fixé à 23,520 dinars par journée de travail effectif à compter du 1er janvier 2028. Article 5 : l'augmentation du SMAG s'applique aux pensions de retraite servies par la Caisse nationale de sécurité sociale."
+    - title: "أمر عدد 66 لسنة 2026 مؤرخ في 30 أفريل 2026 يتعلق بضبط الأجر الأدنى الفلاحي المضمون"
+      href: https://www.pist.tn/jort/2026/2026A/Ja0442026.pdf
 documentation: |-
   Salaire minimum agricole garanti par journée de travail effectif pour les travailleurs des deux sexes âgés de 18 ans au moins
   الأجر الأدنى الفلاحي المضمون للعمال من الجنسين البالغين من العمر 18 سنة على الأقل عن كل يوم عمل فعلي

--- a/openfisca_tunisia/parameters/marche_travail/smag_journalier.yaml
+++ b/openfisca_tunisia/parameters/marche_travail/smag_journalier.yaml
@@ -131,84 +131,84 @@ metadata:
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1965/arrêté_31_12_1965_ar.pdf
     1968-05-01:
     - title: Décret n°68-113 du 30 avril 1968 relatif à la rémunération des travailleurs agricoles
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1968/décret_68_113_fr.pdf
+      href: https://www.pist.tn/jort/1968/1968F/Jo01868.pdf
     - title: امر عدد 344  لسنة   1968 مؤرخ في   30 افريل 1968 يتعلق بأجور العملة الفلاحيين
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1968/décret_68_113_ar.pdf
+      href: https://www.pist.tn/jort/1968/1968A/Ja01868.pdf
     1969-11-01:
     - title: Décret n°69-344 du 27 septembre 1969 relatif à la rémunération des travailleurs agricoles
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1969/décret_69_344_fr.pdf
+      href: https://www.pist.tn/jort/1969/1969F/Jo03869.pdf
     - title: امر عدد 344  لسنة   1969 مؤرخ في   27 سبتمبر 1969 يتعلق بأجور العملة الفلاحيين
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1969/décret_69_344_ar.pdf
+      href: https://www.pist.tn/jort/1969/1969A/Ja03869.pdf
     1971-05-01:
     - title: Décret n°71-163 du 03 mai 1971  relatif à la rémunération des travailleurs agricoles
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1971/décret_71_163_fr.pdf
+      href: https://www.pist.tn/jort/1971/1971F/Jo02071.pdf
     - title: امر عدد 163  لسنة   1971  مؤرخ في 3 ماي    1971  بأجور العملة الفلاحيين
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1971/décret_71_163_ar.pdf
+      href: https://www.pist.tn/jort/1971/1971A/Ja02071.pdf
     1974-06-01:
     - title: Décret n°74-571 du 22 mai 1974 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1974/décret_74_571_fr.pdf
+      href: https://www.pist.tn/jort/1974/1974F/Jo03674.pdf
     - title: امر عدد 571  لسنة   1974 مؤرخ في 22 ماي 1974  يتعلق بضبط الأجر الأدنى المضمون في الفلاحة
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1974/décret_74_571_ar.pdf
+      href: https://www.pist.tn/jort/1974/1974A/Ja03674.pdf
     1975-06-01:
     - title: Décret n°75-358 du 03 juin 1975 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1975/décret_75_358_fr.pdf
+      href: https://www.pist.tn/jort/1975/1975F/Jo03875.pdf
     - title: امر عدد  358  لسنة   1975  مؤرخ في 3 جوان 1975  يتعلق بضبط الأجر الأدنى المضمون في الفلاحة
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1975/décret_75_358_ar.pdf
+      href: https://www.pist.tn/jort/1975/1975A/Ja03875.pdf
     1977-05-01:
     - title: Décret n°77-116 du 02 février 1977 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1977/décret_77_116_fr.pdf
+      href: https://www.pist.tn/jort/1977/1977F/Jo00977.pdf
     - title: امر عدد 116  لسنة  1977  مؤرخ في 2 فيفري 1977 يتعلق بضبط الأجر الأدنى المضمون في الفلاحة
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1977/décret_77_116_ar.pdf
+      href: https://www.pist.tn/jort/1977/1977A/Ja00977.pdf
     1978-05-01:
     - title: Décret n°78-442 du 26 avril 1978 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1978/décret_78_442_fr.pdf
+      href: https://www.pist.tn/jort/1978/1978F/Jo03378.pdf
     - title: امر عدد 442  لسنة   1978  مؤرخ في 26 افريل 1978   يتعلق بضبط الأجر الأدنى المضمون في الفلاحة
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1978/décret_78_442_ar.pdf
+      href: https://www.pist.tn/jort/1978/1978A/Ja03378.pdf
     1979-05-01:
     - title: Décret n°79-474 du 21 mai 1979 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1979/décret_79_474_fr.pdf
+      href: https://www.pist.tn/jort/1979/1979F/Jo03479.pdf
     - title: امر عدد 474  لسنة 1979  مؤرخ في  21  ماي  1979   يتعلق بضبط الأجر الأدنى المضمون في الفلاحة
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1979/décret_79_474_ar.pdf
+      href: https://www.pist.tn/jort/1979/1979A/Ja03479.pdf
     1980-02-01:
     - title: Décret n°80-76 du 21 janvier 1980 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1980/décret_80_76_fr.pdf
+      href: https://www.pist.tn/jort/1980/1980F/Jo00580.pdf
     - title: امر عدد 76   لسنة   1980  مؤرخ في   21 جانفي   1980 يتعلق بضبط الأجر الأدنى المضمون في الفلاحة
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1980/décret_80_76_ar.pdf
+      href: https://www.pist.tn/jort/1980/1980A/Ja00580.pdf
     1980-05-01:
     - title: Décret n°80-610 du 19 mai 1980 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1980/décret_80_610_fr.pdf
+      href: https://www.pist.tn/jort/1980/1980F/Jo03180.pdf
     - title: امر عدد  610  لسنة  1980 مؤرخ في 19  ماي 1980  يتعلق بضبط الأجر الأدنى المضمون في الفلاحة
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1980/décret_80_610_ar.pdf
+      href: https://www.pist.tn/jort/1980/1980A/Ja03180.pdf
     1981-04-01:
     - title: Décret n°81-438 du 07 avril 1981 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1981/décret_81_438_fr.pdf
+      href: https://www.pist.tn/jort/1981/1981F/Jo02581.pdf
     - title: امر عدد   438 لسنة  1981  مؤرخ في7 افريل 1981  يتعلق بضبط الأجر الادنى المضمون في الفلاحة
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1981/décret_81_438_ar.pdf
+      href: https://www.pist.tn/jort/1981/1981A/Ja02581.pdf
     1982-02-01:
     - title: Décret n°82-502 du 16 mars 1982  fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1982/décret_82_502_fr.pdf
+      href: https://www.pist.tn/jort/1982/1982F/Jo01982.pdf
     - title: امر عدد  502  لسنة  1982 مؤرخ في 16 مارس 1982 يتعلق بضبط الأجر لأدنى المضمون في الفلاحة
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1982/décret_82_502_ar.pdf
+      href: https://www.pist.tn/jort/1982/1982A/Ja01982.pdf
     1983-01-01:
     - title: Décret n°83-510 du 04 juin 1983 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1983/décret_83_510_fr.pdf
+      href: https://www.pist.tn/jort/1983/1983F/Jo04283.pdf
     - title: امر عدد  510  لسنة  1983 مؤرخ في 4 جوان 1983 يتعلق بضبط الأجر لأدنى المضمون في الفلاحة
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1983/décret_83_510_ar.pdf
+      href: https://www.pist.tn/jort/1983/1983A/Ja04283.pdf
     1986-07-01:
     - title: Décret n°86-690 du 20 juillet 1986 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1986/décret_86_690_fr.pdf
+      href: https://www.pist.tn/jort/1986/1986F/Jo04186.pdf
     - title: امر عدد   690 لسنة  1986 مؤرخ في  19 جوبلية 1986 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1986/décret_86_690_ar.pdf
+      href: https://www.pist.tn/jort/1986/1986A/Ja04186.pdf
     1987-11-01:
     - title: Décret n°87-1278 du 05 novembre 1987 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1987/décret_87_1278_fr.pdf
+      href: https://www.pist.tn/jort/1987/1987F/Jo07887.pdf
     - title: امر عدد  1278  لسنة  1987 مؤرخ في  5 نوفمبر 1987  يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1987/décret_87_1278_ar.pdf
+      href: https://www.pist.tn/jort/1987/1987A/Ja07887.pdf
     1988-04-01:
     - title: Décret n°88-890 du 05 mai 1988  fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/décret_88_890_fr.pdf
+      href: https://www.pist.tn/jort/1988/1988F/Jo03188.pdf
     - title: أمر عدد  890   لسنة   1988   مؤرخ في  5 ماي 1988 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/décret_88_980_ar.pdf
+      href: https://www.pist.tn/jort/1988/1988A/Ja03188.pdf
     1990-01-01:
     - title: "Décret n° 90-247 du 5 février 1990, fixant le salaire minimum agricole garanti, article premier"
       href: https://www.pist.tn/jort/1990/1990F/Jo01390.pdf
@@ -223,109 +223,109 @@ metadata:
       href: https://www.pist.tn/jort/1992/1992A/Ja04992.pdf
     1992-08-01:
     - title: Décret n°92-1631 du 07 septembre 1992 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1631_fr.pdf
+      href: https://www.pist.tn/jort/1992/1992F/Jo06392.pdf
     - title: أمر عدد   1631  لسنة 1992 مؤرخ في  7 سبتمبر 1992  يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1631_ar.pdf
+      href: https://www.pist.tn/jort/1992/1992A/Ja06392.pdf
     1993-05-01:
     - title: Décret n°93-1257 du 07 juin 1993 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/décret_93_1257_fr.pdf
+      href: https://www.pist.tn/jort/1993/1993F/Jo04493.pdf
     - title: أمر عدد    1257 لسنة   1993   مؤرخ في    7 جوان   يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/décret_93_1257_ar.pdf
+      href: https://www.pist.tn/jort/1993/1993A/Ja04493.pdf
     1993-08-01:
     - title: Décret n°93-1840 du 06 septembre 1993 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/décret_93_1840_fr.pdf
+      href: https://www.pist.tn/jort/1993/1993F/Jo06993.pdf
     - title: أمر عدد   1840  لسنة   1993 مؤرخ في 6  سبتمبر 1993 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/décret_93-1840_ar.pdf
+      href: https://www.pist.tn/jort/1993/1993A/Ja06993.pdf
     1994-08-01:
     - title: Décret n°94-1865 du 05 septembre 1994 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1994/décret_94_1865_fr.pdf
+      href: https://www.pist.tn/jort/1994/1994F/Jo07294.pdf
     - title: أمر عدد  1865   لسنة  1994    مؤرخ في  5    سبتمبر 1994  يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1994/décret_94_1865_ar.pdf
+      href: https://www.pist.tn/jort/1994/1994A/Ja07294.pdf
     1995-05-01:
     - title: Décret n°95-901 du 15 mai 1995 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1995/décret_95_901_fr.pdf
+      href: https://www.pist.tn/jort/1995/1995F/Jo04095.pdf
     - title: أمر عدد  901   لسنة   1995 مؤرخ في 15  ماي 1995  يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1995/décret_95_901_ar.pdf
+      href: https://www.pist.tn/jort/1995/1995A/Ja04095.pdf
     1996-05-01:
     - title: Décret n°96-1014 du 27 mai 1996 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1996/décret_96_1014_fr.pdf
+      href: https://www.pist.tn/jort/1996/1996F/Jo04596.pdf
     - title: أمر عدد 1014 لسنة 1996 مؤرخ في  27 ماي 1996 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1996/décret_96_1014_ar.pdf
+      href: https://www.pist.tn/jort/1996/1996A/Ja04596.pdf
     1996-09-09:
     - title: Décret n°96-1548 du 10 septembre 1996 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1996/décret_96_1548_fr.pdf
+      href: https://www.pist.tn/jort/1996/1996F/Jo07496.pdf
     - title: أمر عدد 1548  لسنة 1996 مؤرخ في 10 سبتمبر 1996 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1996/décret_96-1548_ar.pdf
+      href: https://www.pist.tn/jort/1996/1996A/Ja07496.pdf
     1997-07-20:
     - title: Décret n°97-1522 du 04 août 1997 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1997/décret_97_1522_fr.pdf
+      href: https://www.pist.tn/jort/1997/1997F/Jo06397.pdf
     - title: أمر عدد 1522 لسنة 1997 مؤرخ في  4 اوت 1997 بتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1997/décret_97_1522_ar.pdf
+      href: https://www.pist.tn/jort/1997/1997A/Ja06397.pdf
     1997-11-07:
     - title: Décret n°97-2149 du 12 novembre 1997  fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1997/décret_97_2149_fr.pdf
+      href: https://www.pist.tn/jort/1997/1997F/Jo09397.pdf
     - title: أمر عدد 2149 لسنة 1997 مؤرخ في 12 نوفبر 1977 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1997/décret_97_2149_ar.pdf
+      href: https://www.pist.tn/jort/1997/1997A/Ja09397.pdf
     1998-08-20:
     - title: Décret n°98-1675 du 26 août 1998  fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1998/Décret_1998_1675_fr.pdf
+      href: https://www.pist.tn/jort/1998/1998F/Jo07198.pdf
     - title: أمر عدد 1675 لسنة 1998 مؤرخ في 26 أوت 1998 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1998/Décret_1998_1675_ar.pdf
+      href: https://www.pist.tn/jort/1998/1998A/Ja07198.pdf
     1999-05-01:
     - title: Décret n°99-995 du 10 mai 1999  fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1999/Décret_1999_995_fr.pdf
+      href: https://www.pist.tn/jort/1999/1999F/Jo03899.pdf
     - title: أمر عدد 995 لسنة 1999 مؤرخ في 10 ماي 1999 يتعلّق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1999/Décret_1999_995_ar.pdf
+      href: https://www.pist.tn/jort/1999/1999A/Ja03899.pdf
     1999-08-19:
     - title: Décret n°99-1867 du 31 août 1999 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1999/Décret_1999_1867_fr.pdf
+      href: https://www.pist.tn/jort/1999/1999F/Jo07499.pdf
     - title: امر  عدد 1867 لسنة 1999 مؤرخ في 31 أوت 1999 يتعلّق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1999/Décret_1999_1867_ar.pdf
+      href: https://www.pist.tn/jort/1999/1999A/Ja07499.pdf
     2000-05-01:
     - title: Décret n°2000-950 du 11 mai 2000 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2000/Décret_2000_950_fr.pdf
+      href: https://www.pist.tn/jort/2000/2000F/Jo0382000.pdf
     - title: امر عدد  950 لسنة 2000 مؤرخ في 11 ماي 2000 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2000/Décret_2000_950_ar.pdf
+      href: https://www.pist.tn/jort/2000/2000A/Ja03800.pdf
     2001-07-01:
     - title: Décret n°2001-1747 du 01 août 2001 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/Décret_2001_1747_fr.pdf
+      href: https://www.pist.tn/jort/2001/2001F/Jo0632001.pdf
     - title: امر عدد 1747 لسنة 2001 مؤرخ في أول أوت 2001 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/Décret_2001_1747_ar.pdf
+      href: https://www.pist.tn/jort/2001/2001A/Ja0632001.pdf
     2002-07-01:
     - title: Décret n°2002-1791 du 12 août 2002 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2002/Décret_2002_1791_fr.pdf
+      href: https://www.pist.tn/jort/2002/2002F/Jo0672002.pdf
     - title: امر عدد 1791 لسنة 2002 مؤرخ في 12 أوت 2002 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2002/Décret_2002_1791_ar.pdf
+      href: https://www.pist.tn/jort/2002/2002A/Ja0672002.pdf
     2003-07-01:
     - title: Décret n°2003-1692 du 18 août 2003 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2003/Décret_2003_1692_fr.pdf
+      href: https://www.pist.tn/jort/2003/2003F/Jo0672003.pdf
     - title: امر عدد  1692 لسنة 2003 مؤرخ في 18 أوت 2003 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2003/Décret_2003_1692_ar.pdf
+      href: https://www.pist.tn/jort/2003/2003A/Ja0672003.pdf
     2004-07-01:
     - title: Décret n°2004-1804 du 02 août 2004  fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2004/Décret_2004_1804_fr.pdf
+      href: https://www.pist.tn/jort/2004/2004F/Jo0632004.pdf
     - title: امر عدد 1804 لسنة 2004 مؤرخ في 2 أوت 2004 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2004/Décret_2004_1804_ar.pdf
+      href: https://www.pist.tn/jort/2004/2004A/Ja0632004.pdf
     2005-09-01:
     - title: Décret n°2005-2321 du 22 août 2005 fixant le salaire minimum agricole garanti.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2005/Décret_2005_2321_fr.pdf
+      href: https://www.pist.tn/jort/2005/2005F/Jo0682005.pdf
     - title: امر عدد 2321 لسنة 2005 مؤرخ في 22 أوت 2005 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2005/Décret_2005_2321_ar.pdf
+      href: https://www.pist.tn/jort/2005/2005A/Ja0682005.pdf
     2006-07-01:
     - title: Décret n°2006-2099 du 24 juillet 2006 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2006/Décret_2006_2099_fr.pdf
+      href: https://www.pist.tn/jort/2006/2006F/Jo0622006.pdf
     - title: امر عدد 2099 لسنة 2006 مؤرخ في 24 جويلية 2006 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2006/Décret_2006_2099_ar.pdf
+      href: https://www.pist.tn/jort/2006/2006A/Ja0622006.pdf
     2007-07-01:
     - title: Décret n°2007-2080 du 14 août 2007 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/Décret_2007_2080_fr.pdf
+      href: https://www.pist.tn/jort/2007/2007F/Jo0672007.pdf
     - title: أمر عدد 2080 لسنة 2007 مؤرخ في 14 أوت 2007 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/Décret_2007_2080_ar.pdf
+      href: https://www.pist.tn/jort/2007/2007A/Ja0672007.pdf
     2008-07-01:
     - title: Décret n°2008-2073 du 02 juin 2008 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2008/Décret_2008_2073_fr.pdf
+      href: https://www.pist.tn/jort/2008/2008F/Jo0462008.pdf
     - title: امر عدد 2073 لسنة 2008 مؤرخ في 2 جوان 2008 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2008/Décret_2008_2073_ar.pdf
+      href: https://www.pist.tn/jort/2008/2008A/Ja0462008.pdf
     2009-08-01:
     - title: "Décret n° 2009-2258 du 14 juillet 2009, fixant le salaire minimum agricole garanti, article premier"
       href: https://www.pist.tn/jort/2009/2009F/Jo0622009.pdf
@@ -334,21 +334,21 @@ metadata:
       href: https://www.pist.tn/jort/2009/2009A/Ja0622009.pdf
     2010-07-01:
     - title: Décret n°2010-1747 du 17 juillet 2010 fixant le salaire minimum agricole garanti.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2010/Décret_2010_1747_fr.pdf
+      href: https://www.pist.tn/jort/2010/2010F/Jo0582010.pdf
     - title: امر عدد 1747 لسنة 2010 مؤرخ في 17 جويلية 2010 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2010/Décret_2010_1747_ar.pdf
+      href: https://www.pist.tn/jort/2010/2010A/Ja0582010.pdf
     2011-05-01:
     - title: Décret n°2011-681 du 09 juin 2011 fixant le salaire minimum agricole garanti
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2011/Décret_2011_681_fr.pdf
+      href: https://www.pist.tn/jort/2011/2011F/Jo0422011.pdf
     - title: امر عدد 681 لسنة 2011 مؤرخ في 9 جوان 2011 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2011/Décret_2011_681_ar.pdf
+      href: https://www.pist.tn/jort/2011/2011A/Ja0422011.pdf
     2012-07-01:
       title: Décret n°2012-1982 du 20 septembre 2012
     2012-12-01:
     - title: Décret n°2012-1982 du 20 septembre 2012 fixant le salaire minimum agricole garanti.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2012/Décret_2012_1982_fr.pdf
+      href: https://www.pist.tn/jort/2012/2012F/Jo0772012.pdf
     - title: امر عدد 1982 لسنة 2012 مؤرخ في 20 سبتمبر 2012 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2012/Décret_2012_1982_ar.pdf
+      href: https://www.pist.tn/jort/2012/2012A/Ja0772012.pdf
     2014-05-01:
     - title: "Décret n° 2014-2908 du 11 août 2014, fixant le salaire minimum agricole garanti, article premier"
       href: https://www.pist.tn/jort/2014/2014F/Jo0662014.pdf
@@ -367,9 +367,9 @@ metadata:
       note: "Décret gouvernemental n° 2017-669 du 5 juin 2017, fixant le salaire minimum agricole garanti. JORT n° 45 du 6 juin 2017, édition arabe, p. 1878. Article premier : le SMAG est fixé à 13,736 dinars par journée de travail effectif. Article 6 : effet à compter du 1er août 2016. La date du 5 juin 2017 portée auparavant était celle de la signature. L'édition française de ce fascicule n'est pas servie par pist.tn : l'adresse 2017F/Jo0452017.pdf renvoie le même fichier que l'édition arabe ; le texte a été lu dans l'édition arabe."
     2018-05-01:
     - title: Décret gouvernemental n°2018-673 du 07 août 2018  fixant le salaire minimum agricole garanti.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2018/Décret_2018_673_fr.pdf
+      href: https://www.pist.tn/jort/2018/2018F/Jo0642018.pdf
     - title: أمر حكومي عدد 673 لسنة 2018 مؤرخ في 7 أوت 2018 يتعلق بضبط الأجر الأدنى الفلاحي المضمون
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2018/Décret_2018_673_ar.pdf
+      href: https://www.pist.tn/jort/2018/2018A/Ja0642018.pdf
     2019-05-01:
     - title: Décret gouvernemental n° 2019-455 du 28 mai 2019 fixant le salaire minimum agricole garanti
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2019/Décret_2019_455_fr.pdf

--- a/openfisca_tunisia/parameters/marche_travail/smig_40h_horaire.yaml
+++ b/openfisca_tunisia/parameters/marche_travail/smig_40h_horaire.yaml
@@ -34,12 +34,8 @@ values:
     value: 0.532
   1988-04-01:
     value: 0.556
-  1989-08-01:
-    value: 0.573
   1990-01-01:
-    value: 0.621
-  1991-08-01:
-    value: 0.633
+    value: 0.604
   1992-05-01:
     value: 0.671
   1992-08-01:
@@ -110,6 +106,12 @@ values:
     value: 2.409
   2025-01-01:
     value: 2.586
+  2026-01-01:
+    value: 2.713
+  2027-01-01:
+    value: 2.846
+  2028-01-01:
+    value: 2.986
 metadata:
   unit: currency
   reference:
@@ -198,25 +200,18 @@ metadata:
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/décret_88_889_fr.pdf
     - title: امر عدد   889  لسنة  1988  مؤرخ في 5 ماي 1988 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/décret_88_889_ar.pdf
-    1989-08-01:
-    - title: Décret n°89-1551 du 06 octobre 1989  portant octroi d'une Indemnité spéciale au profit des travailleurs payés au salaire minimum agricole garantl.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1989/décret_89_1551_fr.pdf
-    - title: أمر عدد 1551 لسنة 1989 مؤرخ في 6 أكتوبر 1989 يتعلق باسناد منحة خاصة لفائدة العملة الخالصين بالاجر الأدنى المضمون لمختلف المهن ، المشتغلين بالقطاعات غير الفلاحية والخاضعة لمجلة الشغل .
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1989/décret_89_1551_ar.pdf
     1990-01-01:
-    - title: Décret n°90-246 du 05 février 1990 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1990/décret_90_246_fr.pdf
-    - title: أمر عدد 246 لسنة 1990  مؤرخ في 5 فيفري 1990 يتعلّق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1990/décret_90_246_ar.pdf
-    1991-08-01:
-    - title: Décret n°91-1316 du 02 septembre 1991 portant fixation de l'indemnité spéciale octroyée au profit des travailleurs payés au salaire minimum interprofessionnel garanti, employés dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1991/décret_91_1316_fr.pdf
-    - title: أمر عدد  1316 بسنة 1991 يتعلّق بضبط المنحة الخاصة المسندة لفائدة العملة الخالصين بالأجر الأدنى المضمون لمختلف المهن المشتغلين بالقطاعات غير الفلاحية والخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1991/décret_91_1316_ar.pdf
+    - title: "Décret n° 90-246 du 5 février 1990, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
+      href: https://www.pist.tn/jort/1990/1990F/Jo01390.pdf
+      note: "JORT n° 13 du 16 février 1990, p. 252. Article premier : le SMIG est fixé à 120,016 dinars et à 104,706 dinars par mois et à 577 millimes et 604 millimes l'heure, respectivement pour les régimes de 48 heures et de 40 heures. Article 7 : effet à compter du 1er janvier 1990. Ce montant ne comprend pas l'indemnité spéciale du décret n° 89-1551 (3 dinars par mois ; 14 millimes l'heure en 48 heures, 17 millimes en 40 heures), qui subsiste à côté du SMIG et figure dans marche_travail.indemnite_speciale_smig. Jusqu'au 1er janvier 1990 exclu, le SMIG reste celui du décret n° 88-889 : le décret n° 89-1551 ne le modifie pas."
+    - title: "أمر عدد 246 لسنة 1990 مؤرخ في 5 فيفري 1990 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل"
+      href: https://www.pist.tn/jort/1990/1990A/Ja01390.pdf
     1992-05-01:
-    - title: Décret n°92-1299 du 13 juillet 1992 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1299_fr.pdf
-    - href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1299_ar.pdf
+    - title: "Décret n° 92-1299 du 13 juillet 1992, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, articles premier et 3"
+      href: https://www.pist.tn/jort/1992/1992F/Jo04992.pdf
+      note: "JORT n° 49 du 28 juillet 1992, pp. 935-936. Article premier : le SMIG est fixé à 132,912 dinars et à 116,318 dinars par mois et à 639 millimes et 671 millimes l'heure, respectivement pour les régimes de 48 heures et de 40 heures. Article 3 : ce SMIG « comprend l'indemnité spéciale fixée par le décret sus-visé n° 91-1316 du 2 septembre 1991 » (5 dinars par mois), que l'article 8 abroge. Article 9 : effet à compter du 1er mai 1992. La hausse de 120,016 à 132,912 dinars (48 heures) intègre donc ces 5 dinars. Un rectificatif est publié au JORT n° 55 du 21 août 1992, p. 1067 (non lu)."
+    - title: "أمر عدد 1299 لسنة 1992 مؤرخ في 13 جويلية 1992 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل"
+      href: https://www.pist.tn/jort/1992/1992A/Ja04992.pdf
     1992-08-01:
     - title: Décret n°92-1630 du 07 septembre 1992   fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1630_fr.pdf
@@ -387,6 +382,24 @@ metadata:
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/Décret_2024_419_fr.pdf
     - title: امر عدد 419 لسنة 2024 مؤرخ في 9 جويلية 2024 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/Décret_2024_419_ar.pdf
+    2026-01-01:
+    - title: "Décret n° 2026-67 du 30 avril 2026, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
+      href: https://www.pist.tn/jort/2026/2026F/Jo0442026.pdf
+      note: "JORT n° 44 du 30 avril 2026, pp. 838-839. Article premier, point 1 : à compter du 1er janvier 2026, le SMIG est fixé à 554,736 dinars (48 heures) et à 470,251 dinars (40 heures) par mois, et à 2,667 dinars (48 heures) et à 2,713 dinars (40 heures) l'heure ; il comprend l'indemnité complémentaire provisoire. Article 6 : l'augmentation du SMIG s'applique aux pensions de retraite servies par la Caisse nationale de sécurité sociale."
+    - title: "أمر عدد 67 لسنة 2026 مؤرخ في 30 أفريل 2026 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل"
+      href: https://www.pist.tn/jort/2026/2026A/Ja0442026.pdf
+    2027-01-01:
+    - title: "Décret n° 2026-67 du 30 avril 2026, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
+      href: https://www.pist.tn/jort/2026/2026F/Jo0442026.pdf
+      note: "JORT n° 44 du 30 avril 2026, pp. 838-839. Article premier, point 2 : à compter du 1er janvier 2027, le SMIG est fixé à 582,400 dinars (48 heures) et à 493,304 dinars (40 heures) par mois, et à 2,800 dinars (48 heures) et à 2,846 dinars (40 heures) l'heure ; il comprend l'indemnité complémentaire provisoire. Article 6 : l'augmentation du SMIG s'applique aux pensions de retraite servies par la Caisse nationale de sécurité sociale."
+    - title: "أمر عدد 67 لسنة 2026 مؤرخ في 30 أفريل 2026 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل"
+      href: https://www.pist.tn/jort/2026/2026A/Ja0442026.pdf
+    2028-01-01:
+    - title: "Décret n° 2026-67 du 30 avril 2026, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
+      href: https://www.pist.tn/jort/2026/2026F/Jo0442026.pdf
+      note: "JORT n° 44 du 30 avril 2026, pp. 838-839. Article premier, point 3 : à compter du 1er janvier 2028, le SMIG est fixé à 611,520 dinars (48 heures) et à 517,571 dinars (40 heures) par mois, et à 2,940 dinars (48 heures) et à 2,986 dinars (40 heures) l'heure ; il comprend l'indemnité complémentaire provisoire. Article 6 : l'augmentation du SMIG s'applique aux pensions de retraite servies par la Caisse nationale de sécurité sociale."
+    - title: "أمر عدد 67 لسنة 2026 مؤرخ في 30 أفريل 2026 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل"
+      href: https://www.pist.tn/jort/2026/2026A/Ja0442026.pdf
 documentation: |-
   Salaire minimum interprofessionnel garanti (Smig) dans les secteurs non agricoles pour les travailleurs des deux sexes âgés de 18 ans au moins
   الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية للعمال من الجنسين البالغين من العمر 18 سنة على الأقل

--- a/openfisca_tunisia/parameters/marche_travail/smig_40h_horaire.yaml
+++ b/openfisca_tunisia/parameters/marche_travail/smig_40h_horaire.yaml
@@ -117,89 +117,89 @@ metadata:
   reference:
     1961-04-01:
     - title: Décret n°61-145 du 30 mars 1961 portant relèvement général des salaires
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1961/décret_61_145_fr.pdf
+      href: https://www.pist.tn/jort/1961/1961F/Jo01261.pdf
     - title: امر عدد 145 لسنة 1961 مؤرخ في 30 مارس 1961 بتعلق بالترفيع العام في الاجور
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1961/décret_61_145_ar.pdf
+      href: https://www.pist.tn/jort/1961/1961A/Ja01261.pdf
     1966-01-01:
     - title: Décret n°65-561 du 31 décembre 1965 portant relèvement des salaires dans l'industrie, le commerce et les professions libérales
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1965/décret_65_561_fr.pdf
+      href: https://www.pist.tn/jort/1965/1965F/Jo06665.pdf
     - title: امر عدد 561 لسنة 1965 يتعلق بالترفيع في الأجور في قطاع الصناعة والتجارة والمهن الحرة
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1965/décret_65_561_ar.pdf
+      href: https://www.pist.tn/jort/1965/1965A/Ja06665.pdf
       note: "صدر اصلاح خطا بالرائد الرسمي عدد 1 بتاريخ 7 جانفي 1966 حيث تعاد الفقرة ب من الفصل الاول كما يلي: بمبلغ 4 دنانير للشهر الواحد لجميع اصناف المستخدمين الذين يساوي اجرهم القانوني بما فيه المنح الاضافية ستين دينار للشهر الواحد أو اقل"
     1968-05-01:
     - title: Décret n°68-97 du 15 avril 1969 portant suppression des zones de salaires des activités de secteur non agricole
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1968/décret_68_97_fr.pdf
+      href: https://www.pist.tn/jort/1968/1968F/Jo01668.pdf
     - title: امر عدد 97 لسنة 68 مؤرخ في 15 أفريل 1969 يتعلق بحدف مناطق الاجور في نشاطات القطاع غير الفلاحي
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1968/décret_68_97_ar.pdf
+      href: https://www.pist.tn/jort/1968/1968A/Ja01668.pdf
     1971-05-01:
     - title: Décret n°71-164 du 03 mai 1971 instituant une indemnité de cherté de vie dans l'industrie, le Commerce et les professions libérales
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1971/décret_71_164_fr.pdf
+      href: https://www.pist.tn/jort/1971/1971F/Jo02071.pdf
     - title: امر عدد 164 لسنة 1971  يتعلق بإحداث منحة لغلو المعاش في الصناعة والتجارة والمهن الحرة
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1971/décret_71_164_ar.pdf
+      href: https://www.pist.tn/jort/1971/1971A/Ja02071.pdf
     1974-01-01:
     - title: Décret n°74-63 du 31 janvier 1974 fixant le salaire minimum interprofessionnel garanti dans le secteur non agricole régi par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1974/décret_74_63_fr.pdf
+      href: https://www.pist.tn/jort/1974/1974F/Jo01074.pdf
     - title: 1974   أمر عدد63 لسنة   مؤرخ في 31 جانفي 1974  يتعلق بضبط الأجر الأدنى بمختلف المهن المضمون في القطاع غير الفلاحي والخاضع لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1974/décret_74_63_ar.pdf
+      href: https://www.pist.tn/jort/1974/1974A/Ja01074.pdf
     1975-06-01:
     - title: Décret n°75-357 du 03 juin 1975 fixant le salaire minimum interprofessionnel garanti dans le secteur non agricole régi par le Code du Travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1975/décret_75_357_fr.pdf
+      href: https://www.pist.tn/jort/1975/1975F/Jo03875.pdf
     - title: امر عدد 357 لسنة 1975 مؤرخ في 03 جوان 1975 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاع الغير الفلاحي والخاضع لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1975/décret_75_357_ar.pdf
+      href: https://www.pist.tn/jort/1975/1975A/Ja03875.pdf
     1977-02-01:
     - title: Décret n°77-115 du 02 février  fixant le salaire minimum interprofessionnel garanti dans le secteur non agricole régi par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1977/décret_77_115_fr.pdf
+      href: https://www.pist.tn/jort/1977/1977F/Jo00977.pdf
     - title: امر عدد 115 لسنة 1977 مؤرخ في 02 فيفري 1977 يتعلق بضبط الاجر الادنى المضمون لمختلف المهن في القطاع غير الفلاحي و الخاضع لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1977/décret_77_115_ar.pdf
+      href: https://www.pist.tn/jort/1977/1977A/Ja00977.pdf
     1978-05-01:
     - title: Décret n°78-441 du 26 avril 1978 fixant le salaire minimum interprofessionnel garanti dans le secteur non agricole régi par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1978/décret_78_441_fr.pdf
+      href: https://www.pist.tn/jort/1978/1978F/Jo03378.pdf
     - title: امر عدد 441 لسنة 1978 مؤرخ في26 افريل 1978 يتعلق بضبط الاجر الادنى المضمون لمختلف المهن في القطاع غير الفلاحي و الخاضع لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1978/décret_78_441_ar.pdf
+      href: https://www.pist.tn/jort/1978/1978A/Ja03378.pdf
     1979-05-01:
     - title: Décret n°79-473 du 21 mai 1979 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1979/décret_79_473_fr.pdf
+      href: https://www.pist.tn/jort/1979/1979F/Jo03479.pdf
     - title: امر عدد   473 لسنة    1979 مؤرخ في    21 ماي 1979   يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1979/décret_79_473_ar.pdf
+      href: https://www.pist.tn/jort/1979/1979A/Ja03479.pdf
     1980-02-01:
     - title: Décret n°80-75 du 21 janvier 1980 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1980/décret_80_75_fr.pdf
+      href: https://www.pist.tn/jort/1980/1980F/Jo00580.pdf
     - title: امر عدد   75  لسنة    1980 مؤرخ في    21 جانفي 1980   يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1980/décret_80_75_ar.pdf
+      href: https://www.pist.tn/jort/1980/1980A/Ja00580.pdf
     1980-05-01:
     - title: Décret n°80-609 du 19 mai 1980 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1980/décret_80_609_fr.pdf
+      href: https://www.pist.tn/jort/1980/1980F/Jo03180.pdf
     - title: امر عدد  609   لسنة   1980 مؤرخ في    19 ماي 1980    يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1980/décret_80_609_ar.pdf
+      href: https://www.pist.tn/jort/1980/1980A/Ja03180.pdf
     1981-04-01:
     - title: Décret n°81-437 du 07 avril 1981 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1981/décret_81_437_fr.pdf
+      href: https://www.pist.tn/jort/1981/1981F/Jo02581.pdf
     - title: امر عدد  437  لسنة  1981   مؤرخ في   7 افريل 1981    يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1981/décret_81_437_ar.pdf
+      href: https://www.pist.tn/jort/1981/1981A/Ja02581.pdf
     1982-02-01:
     - title: Décret n°82-501 du 16 mars 1982 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1982/décret_82_501_fr.pdf
+      href: https://www.pist.tn/jort/1982/1982F/Jo01982.pdf
     - title: امر عدد    501 لسنة  1982  مؤرخ في    16 مارس 1982   يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1982/décret_82_501_ar.pdf
+      href: https://www.pist.tn/jort/1982/1982A/Ja01982.pdf
     1983-01-01:
     - title: Décret n°83-509 du 04 juin 1983 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1983/décret_83_509_fr.pdf
+      href: https://www.pist.tn/jort/1983/1983F/Jo04283.pdf
     - title: امر عدد   509  لسنة   1983 مؤرخ في   4 جوان 1983  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1983/décret_83_509_ar.pdf
+      href: https://www.pist.tn/jort/1983/1983A/Ja04283.pdf
     1986-07-01:
     - title: Décret n°86-689 du 20 juillet 1986 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1986/décret_86_690_fr.pdf
+      href: https://www.pist.tn/jort/1986/1986F/Jo04186.pdf
     - href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1986/décret_86_690_ar.pdf
     1987-11-01:
     - title: Décret n°87-1277 du 05 novembre 1987 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1987/décret_87_1277_fr.pdf
+      href: https://www.pist.tn/jort/1987/1987F/Jo07887.pdf
     - title: امر عدد  1277   لسنة  1987  مؤرخ في    5 توفمبر 1987   يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1987/décret_87_1277_ar.pdf
+      href: https://www.pist.tn/jort/1987/1987A/Ja07887.pdf
     1988-04-01:
     - title: Décret n°88-889 du 05 mai 1988 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/décret_88_889_fr.pdf
+      href: https://www.pist.tn/jort/1988/1988F/Jo03188.pdf
     - title: امر عدد   889  لسنة  1988  مؤرخ في 5 ماي 1988 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/décret_88_889_ar.pdf
+      href: https://www.pist.tn/jort/1988/1988A/Ja03188.pdf
     1990-01-01:
     - title: "Décret n° 90-246 du 5 février 1990, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
       href: https://www.pist.tn/jort/1990/1990F/Jo01390.pdf
@@ -214,149 +214,149 @@ metadata:
       href: https://www.pist.tn/jort/1992/1992A/Ja04992.pdf
     1992-08-01:
     - title: Décret n°92-1630 du 07 septembre 1992   fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1630_fr.pdf
+      href: https://www.pist.tn/jort/1992/1992F/Jo06392.pdf
     - title: امر عدد 1630    لسنة  1992  مؤرخ في  7 سبتمبر 1992 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1630_ar.pdf
+      href: https://www.pist.tn/jort/1992/1992A/Ja06392.pdf
     1993-05-01:
     - title: Décret n°93-1256 du 07 juin 1993  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/décret_93_1256_fr.pdf
+      href: https://www.pist.tn/jort/1993/1993F/Jo04493.pdf
     - title: أمر عدد   1256  لسنة  1993  مؤرخ في 7 جوان 1993  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/décret_93_1256_ar.pdf
+      href: https://www.pist.tn/jort/1993/1993A/Ja04493.pdf
     1993-08-01:
     - title: Décret n°93-1838 du 06 septembre 1993 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/décret_93_1838_fr.pdf
+      href: https://www.pist.tn/jort/1993/1993F/Jo06993.pdf
     - title: أمر عدد  1838   لسنة  1993  مؤرخ في  6 سبتمبر 1993 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/décret_93_1838_ar.pdf
+      href: https://www.pist.tn/jort/1993/1993A/Ja06993.pdf
     1994-08-01:
     - title: Décret n°94-1804 du 29 août 1994 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1994/décret_94_1804_fr.pdf
+      href: https://www.pist.tn/jort/1994/1994F/Jo07194.pdf
     - title: أمر عدد   1804  لسنة   1995   مؤرخ في 29 اوت  1995  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1994/décret_94_1804_fr.pdf
+      href: https://www.pist.tn/jort/1994/1994A/Ja07194.pdf
     1995-05-01:
     - title: Décret n°95-900 du 15 mai 1995 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1995/décret_95_900_fr.pdf
+      href: https://www.pist.tn/jort/1995/1995F/Jo04095.pdf
     - title: أمر عدد  900   لسنة   1995   مؤرخ في 15 ماي 1995  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1995/décret_95_900_ar.pdf
+      href: https://www.pist.tn/jort/1995/1995A/Ja04095.pdf
     1996-05-01:
     - title: Décret n°96-1013 du 27 mai 1996 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1996/décret_96_1013_fr.pdf
+      href: https://www.pist.tn/jort/1996/1996F/Jo04596.pdf
     - title: أمر عدد   1013  لسنة  1996 مؤرخ في 27 ماي يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1996/décret_96_1013_ar.pdf
+      href: https://www.pist.tn/jort/1996/1996A/Ja04596.pdf
     1996-09-09:
     - title: Décret n°96-1547 du 10 septembre 1996 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1996/décret_96_1547_fr.pdf
+      href: https://www.pist.tn/jort/1996/1996F/Jo07496.pdf
     - title: أمر عدد   1547  لسنة  1996    مؤرخ في  10 سبتمبر 1996 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1996/décret_96_1547_ar.pdf
+      href: https://www.pist.tn/jort/1996/1996A/Ja07496.pdf
     1997-07-20:
     - title: Décret n°97-1521 du 04 août  1997 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1997/décret_97_1521_fr.pdf
+      href: https://www.pist.tn/jort/1997/1997F/Jo06397.pdf
     - title: أمر عدد   1521  لسنة  1997  مؤرخ في  4  اوت 1997 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1997/décret_97_1521_ar.pdf
+      href: https://www.pist.tn/jort/1997/1997A/Ja06397.pdf
     1997-11-07:
     - title: Décret n°97-2148 du 12 novembre 1997 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1997/décret_97_2148_fr.pdf
+      href: https://www.pist.tn/jort/1997/1997F/Jo09397.pdf
     - title: أمر عدد   2148 لسنة 1997 مؤرخ في 12 نوفبر 1977 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1997/décret_97_2148_ar.pdf
+      href: https://www.pist.tn/jort/1997/1997A/Ja09397.pdf
     1998-08-20:
     - title: Décret n°98-1674 du 26 août 1998 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1998/Décret_1998_1674_fr.pdf
+      href: https://www.pist.tn/jort/1998/1998F/Jo07198.pdf
     - title: أمر عدد 1674 لسنة 1998 مؤرخ في 26 أوت 1998 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1998/Décret_1998_1674_ar.pdf
+      href: https://www.pist.tn/jort/1998/1998A/Ja07198.pdf
     1999-05-01:
     - title: Décret n°99-994 du 10 mai 1999 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1999/Décret_1999_994_fr.pdf
+      href: https://www.pist.tn/jort/1999/1999F/Jo03899.pdf
     - title: أمر عدد 994 لسنة 1999 مؤرخ في 8 ماي 1999 يتعلّق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1999/Décret_1999_994_ar.pdf
+      href: https://www.pist.tn/jort/1999/1999A/Ja03899.pdf
     1999-08-19:
     - title: Décret n°99-1866 du 31 août 1999 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1999/Décret_1999_1866_fr.pdf
+      href: https://www.pist.tn/jort/1999/1999F/Jo07499.pdf
     - title: أمر عدد 1866 لسنة 1999 مؤرخ في 30 أوت 1999 يتعلّق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1999/Décret_1999_1866_ar.pdf
+      href: https://www.pist.tn/jort/1999/1999A/Ja07499.pdf
     2000-05-01:
     - title: Décret n°2000-949 du 11 mai 2000 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2000/Décret_2000_949_fr.pdf
+      href: https://www.pist.tn/jort/2000/2000F/Jo0382000.pdf
     - title: أمر عدد 949 لسنة 2000 مؤرخ في 11 ماي 2000 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2000/Décret_2000_949_ar.pdf
+      href: https://www.pist.tn/jort/2000/2000A/Ja03800.pdf
     2001-07-01:
     - title: Décret n°2001-1746 du 01 août 2001 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/Décret_2001_1746_fr.pdf
+      href: https://www.pist.tn/jort/2001/2001F/Jo0632001.pdf
     - title: أمر عدد 1746 لسنة 2001 مؤرخ في أول أوت 2001 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/Décret_2001_1746_ar.pdf
+      href: https://www.pist.tn/jort/2001/2001A/Ja0632001.pdf
     2002-07-01:
     - title: Décret n°2002-1790 du 12 août 2002 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2002/Décret_2002_1790_fr.pdf
+      href: https://www.pist.tn/jort/2002/2002F/Jo0672002.pdf
     - title: أمر عدد 1790 لسنة 2002 مؤرخ في 12 أوت 2002 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2002/Décret_2002_1790_ar.pdf
+      href: https://www.pist.tn/jort/2002/2002A/Ja0672002.pdf
     2003-07-01:
     - title: Décret n°2003-1691 du 18 août 2003 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2003/Décret_2003_1691_fr.pdf
+      href: https://www.pist.tn/jort/2003/2003F/Jo0672003.pdf
     - title: أمر عدد 1691 لسنة 2003 مؤرخ في 18 أوت 2003 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2003/Décret_2003_1691_ar.pdf
+      href: https://www.pist.tn/jort/2003/2003A/Ja0672003.pdf
     2004-07-01:
     - title: Décret n°2004-1803 du 02 août 2004 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2004/Décret_2004_1803_fr.pdf
+      href: https://www.pist.tn/jort/2004/2004F/Jo0632004.pdf
     - title: أمر عدد 1803 لسنة 2004 مؤرخ في 2 أوت 2004 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2004/Décret_2004_1803_ar.pdf
+      href: https://www.pist.tn/jort/2004/2004A/Ja0632004.pdf
     2005-09-01:
     - title: Décret n°2005-2320 du 22 août 2005 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2005/Décret_2005_2320_fr.pdf
+      href: https://www.pist.tn/jort/2005/2005F/Jo0682005.pdf
     - title: أمر عدد 2320 لسنة 2005 مؤرخ في 22 أوت 2005 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2005/Décret_2005_2320_ar.pdf
+      href: https://www.pist.tn/jort/2005/2005A/Ja0682005.pdf
     2006-07-01:
     - title: Décret n°2006-2098 du 24 juillet 2006 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2006/Décret_2006_2098_fr.pdf
+      href: https://www.pist.tn/jort/2006/2006F/Jo0622006.pdf
     - title: امر عدد 2098 لسنة 2006 مؤرخ في 24 جويلية 2006 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2006/Décret_2006_2098_ar.pdf
+      href: https://www.pist.tn/jort/2006/2006A/Ja0622006.pdf
     2007-07-01:
     - title: Décret n° 2007-2079 du 14 août 2007, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/Décret_2007_2079_fr.pdf?
+      href: https://www.pist.tn/jort/2007/2007F/Jo0672007.pdf
     - title: أمر عدد 2079 لسنة 2007 مؤرخ في 14 أوت 2007 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/Décret_2007_2079_ar.pdf
+      href: https://www.pist.tn/jort/2007/2007A/Ja0672007.pdf
     2008-07-01:
     - title: Décret n°2008-2072 du 02 juin 2008  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2008/Décret_2008_2072_fr.pdf
+      href: https://www.pist.tn/jort/2008/2008F/Jo0462008.pdf
     - title: أمر عدد 2072 لسنة 2008 مؤرخ في 2 جوان 2008 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2008/Décret_2008_2072_ar.pdf
+      href: https://www.pist.tn/jort/2008/2008A/Ja0462008.pdf
     2009-08-01:
     - title: Décret n°2009-2257 du 14 juillet 2009 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2009/Décret_2009_2257_fr.pdf
+      href: https://www.pist.tn/jort/2009/2009F/Jo0622009.pdf
     - title: أمر عدد 2257 لسنة 2009 مؤرخ في 14 جويلية 2009 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2009/Décret_2009_2257_ar.pdf
+      href: https://www.pist.tn/jort/2009/2009A/Ja0622009.pdf
     2010-07-01:
     - title: Décret n°2010-1746 du 17 juillet 2010 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2010/Décret_2010_1746_fr.pdf
+      href: https://www.pist.tn/jort/2010/2010F/Jo0582010.pdf
     - title: أمر عدد 1746 لسنة 2010 مؤرخ في 17 جويلية 2010 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2010/Décret_2010_1746_ar.pdf
+      href: https://www.pist.tn/jort/2010/2010A/Ja0582010.pdf
     2011-05-01:
     - title: Décret n°2011-679 du 09 juin 2011 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2011/Décret_2011_679_fr.pdf
+      href: https://www.pist.tn/jort/2011/2011F/Jo0422011.pdf
     - title: أمر عدد 679 لسنة 2011 مؤرخ في 9 جوان 2011 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2011/Décret_2011_679_ar.pdf
+      href: https://www.pist.tn/jort/2011/2011A/Ja0422011.pdf
     2012-07-01:
     - title: Décret n°2012-1981 du 20 septembre 2012 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2012/Décret_2012_1981_fr.pdf
+      href: https://www.pist.tn/jort/2012/2012F/Jo0772012.pdf
     - title: امر عدد 1981 لسنة 2012 مؤرخ في 20 سبتمبر 2012 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2012/Décret_2012_1981_ar.pdf
+      href: https://www.pist.tn/jort/2012/2012A/Ja0772012.pdf
     2014-05-01:
     - title: Décret n°2014-2907 du 11 août 2014 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2014/Décret_2014_2907_fr.pdf
+      href: https://www.pist.tn/jort/2014/2014F/Jo0662014.pdf
     - title: امر عدد 2907 لسنة 2014 مؤرخ في 11 أوت 2014 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2014/Décret_2014_2907_ar.pdf
+      href: https://www.pist.tn/jort/2014/2014A/Ja0662014.pdf
     2015-05-01:
     - title: Décret n°2015-1762 du 09 novembre 2015 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2015/décret_2015_1762_fr.pdf
+      href: https://www.pist.tn/jort/2015/2015F/Jo0912015.pdf
     - title: امر حكومي عدد 1762 لسنة 2015 مؤرخ في 9 نوفمبر 2015 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2015/décret_2015_1762_ar.pdf
+      href: https://www.pist.tn/jort/2015/2015A/Ja0912015.pdf
     2016-08-01:
     - title: Décret n°2017-668 du 05 juin 2017 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2017/Décret_2017_668_fr.pdf
+      href: https://www.pist.tn/jort/2017/2017F/Jo0452017.pdf
     - title: امر حكومي عدد 668 لسنة 2017 مؤرخ في 5 جوان 2017 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2017/Décret_2017_668_ar.pdf
+      href: https://www.pist.tn/jort/2017/2017A/Ja0452017.pdf
     2018-05-01:
     - title: Décret gouvernemental n°2018-672 du 07 août 2018 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code de travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2018/Décret_2018_672_fr.pdf
+      href: https://www.pist.tn/jort/2018/2018F/Jo0642018.pdf
     - title: امر حكومي عدد 672 لسنة 2018 مؤرخ في 7 أوت 2018 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2018/Décret_2018_672_ar.pdf
+      href: https://www.pist.tn/jort/2018/2018A/Ja0642018.pdf
     2019-05-01:
     - title: Décret gouvernemental n°2019-454 du 28 mai 2019 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2019/Décret_2019_454_fr.pdf
@@ -364,24 +364,24 @@ metadata:
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2019/Décret_2019_454_ar.pdf
     2020-10-01:
     - title: Décret gouvernemental n° 2020-1069 du 30 décembre 2020  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2020/Décret_2020_1069_ar.pdf
+      href: https://www.pist.tn/jort/2021/2021F/Jo0012021.pdf
     - title: امر حكومي عدد 1069 لسنة 2020 مؤرخ في 30 ديسمبر 2020 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2020/Décret_2020_1069_fr.pdf
+      href: https://www.pist.tn/jort/2021/2021A/Ja0012021.pdf
     2022-10-01:
     - title: Décret gouvernemental n°2022-769 du 19 octobre 2022 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2022/Décret_2022_769_fr.pdf
+      href: https://www.pist.tn/jort/2022/2022F/Jo1142022.pdf
     - title: امر عدد 769 لسنة 2022 مؤرخ في 19 أكتوبر 2022 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2022/Décret_2022_769_ar.pdf
+      href: https://www.pist.tn/jort/2022/2022A/Ja1142022.pdf
     2024-05-01:
     - title: Décret n°2024-419 du 09 juillet 2024 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/Décret_2024_419_fr.pdf
+      href: https://www.pist.tn/jort/2024/2024F/Jo0852024.pdf
     - title: امر عدد 419 لسنة 2024 مؤرخ في 9 جويلية 2024 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/Décret_2024_419_ar.pdf
+      href: https://www.pist.tn/jort/2024/2024A/Ja0852024.pdf
     2025-01-01:
     - title: Décret n°2024-419 du 09 juillet 2024  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/Décret_2024_419_fr.pdf
+      href: https://www.pist.tn/jort/2024/2024F/Jo0852024.pdf
     - title: امر عدد 419 لسنة 2024 مؤرخ في 9 جويلية 2024 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/Décret_2024_419_ar.pdf
+      href: https://www.pist.tn/jort/2024/2024A/Ja0852024.pdf
     2026-01-01:
     - title: "Décret n° 2026-67 du 30 avril 2026, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
       href: https://www.pist.tn/jort/2026/2026F/Jo0442026.pdf

--- a/openfisca_tunisia/parameters/marche_travail/smig_40h_mensuel.yaml
+++ b/openfisca_tunisia/parameters/marche_travail/smig_40h_mensuel.yaml
@@ -34,12 +34,8 @@ values:
     value: 92.226
   1988-04-01:
     value: 96.386
-  1989-08-01:
-    value: 99.386
   1990-01-01:
-    value: 107.706
-  1991-08-01:
-    value: 109.706
+    value: 104.706
   1992-05-01:
     value: 116.318
   1992-08-01:
@@ -110,6 +106,12 @@ values:
     value: 417.558
   2025-01-01:
     value: 448.238
+  2026-01-01:
+    value: 470.251
+  2027-01-01:
+    value: 493.304
+  2028-01-01:
+    value: 517.571
 metadata:
   unit: currency
   reference:
@@ -198,26 +200,18 @@ metadata:
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/décret_88_889_fr.pdf
     - title: امر عدد   889  لسنة  1988  مؤرخ في 5 ماي 1988 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/décret_88_889_ar.pdf
-    1989-08-01:
-    - title: Décret n°89-1551 du 06 octobre 1989 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1989/décret_89_1551_fr.pdf
-    - title: أمر عدد 1551 لسنة 1989 مؤرخ في 6 أكتوبر 1989 يتعلق باسناد منحة خاصة لفائدة العملة الخالصين بالاجر الأدنى المضمون لمختلف المهن ، المشتغلين بالقطاعات غير الفلاحية والخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1989/décret_89_1551_ar.pdf
     1990-01-01:
-    - title: Décret n°90-246 du 05 février 1990 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1990/décret_90_246_fr.pdf
-    - title: أمر عدد 246 لسنة 1990  مؤرخ في 5 فيفري 1990 يتعلّق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1990/décret_90_246_ar.pdf
-    1991-08-01:
-    - title: Décret n°91-1316 du 02 septembre 1991 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1991/décret_91_1316_fr.pdf
-    - title: امر عدد   1316  لسنة    مؤرخ في        يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1991/décret_91_1316_ar.pdf
+    - title: "Décret n° 90-246 du 5 février 1990, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
+      href: https://www.pist.tn/jort/1990/1990F/Jo01390.pdf
+      note: "JORT n° 13 du 16 février 1990, p. 252. Article premier : le SMIG est fixé à 120,016 dinars et à 104,706 dinars par mois et à 577 millimes et 604 millimes l'heure, respectivement pour les régimes de 48 heures et de 40 heures. Article 7 : effet à compter du 1er janvier 1990. Ce montant ne comprend pas l'indemnité spéciale du décret n° 89-1551 (3 dinars par mois ; 14 millimes l'heure en 48 heures, 17 millimes en 40 heures), qui subsiste à côté du SMIG et figure dans marche_travail.indemnite_speciale_smig. Jusqu'au 1er janvier 1990 exclu, le SMIG reste celui du décret n° 88-889 : le décret n° 89-1551 ne le modifie pas."
+    - title: "أمر عدد 246 لسنة 1990 مؤرخ في 5 فيفري 1990 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل"
+      href: https://www.pist.tn/jort/1990/1990A/Ja01390.pdf
     1992-05-01:
-    - title: Décret n°92-1299 du 13 juillet 1992 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1299_fr.pdf
-    - title: امر عدد 1299    لسنة  1992  مؤرخ في  13 جويلية 1992 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1299_ar.pdf?ref_type=heads
+    - title: "Décret n° 92-1299 du 13 juillet 1992, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, articles premier et 3"
+      href: https://www.pist.tn/jort/1992/1992F/Jo04992.pdf
+      note: "JORT n° 49 du 28 juillet 1992, pp. 935-936. Article premier : le SMIG est fixé à 132,912 dinars et à 116,318 dinars par mois et à 639 millimes et 671 millimes l'heure, respectivement pour les régimes de 48 heures et de 40 heures. Article 3 : ce SMIG « comprend l'indemnité spéciale fixée par le décret sus-visé n° 91-1316 du 2 septembre 1991 » (5 dinars par mois), que l'article 8 abroge. Article 9 : effet à compter du 1er mai 1992. La hausse de 120,016 à 132,912 dinars (48 heures) intègre donc ces 5 dinars. Un rectificatif est publié au JORT n° 55 du 21 août 1992, p. 1067 (non lu)."
+    - title: "أمر عدد 1299 لسنة 1992 مؤرخ في 13 جويلية 1992 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل"
+      href: https://www.pist.tn/jort/1992/1992A/Ja04992.pdf
     1992-08-01:
     - title: Décret n°92-1630 du 07 septembre 1992 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1300_fr.pdf
@@ -388,6 +382,24 @@ metadata:
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/décret_2024_419_fr.pdf
     - title: امر عدد 419 لسنة 2024 مؤرخ في 9 جويلية 2024 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/décret_2024_419_ar.pdf
+    2026-01-01:
+    - title: "Décret n° 2026-67 du 30 avril 2026, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
+      href: https://www.pist.tn/jort/2026/2026F/Jo0442026.pdf
+      note: "JORT n° 44 du 30 avril 2026, pp. 838-839. Article premier, point 1 : à compter du 1er janvier 2026, le SMIG est fixé à 554,736 dinars (48 heures) et à 470,251 dinars (40 heures) par mois, et à 2,667 dinars (48 heures) et à 2,713 dinars (40 heures) l'heure ; il comprend l'indemnité complémentaire provisoire. Article 6 : l'augmentation du SMIG s'applique aux pensions de retraite servies par la Caisse nationale de sécurité sociale."
+    - title: "أمر عدد 67 لسنة 2026 مؤرخ في 30 أفريل 2026 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل"
+      href: https://www.pist.tn/jort/2026/2026A/Ja0442026.pdf
+    2027-01-01:
+    - title: "Décret n° 2026-67 du 30 avril 2026, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
+      href: https://www.pist.tn/jort/2026/2026F/Jo0442026.pdf
+      note: "JORT n° 44 du 30 avril 2026, pp. 838-839. Article premier, point 2 : à compter du 1er janvier 2027, le SMIG est fixé à 582,400 dinars (48 heures) et à 493,304 dinars (40 heures) par mois, et à 2,800 dinars (48 heures) et à 2,846 dinars (40 heures) l'heure ; il comprend l'indemnité complémentaire provisoire. Article 6 : l'augmentation du SMIG s'applique aux pensions de retraite servies par la Caisse nationale de sécurité sociale."
+    - title: "أمر عدد 67 لسنة 2026 مؤرخ في 30 أفريل 2026 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل"
+      href: https://www.pist.tn/jort/2026/2026A/Ja0442026.pdf
+    2028-01-01:
+    - title: "Décret n° 2026-67 du 30 avril 2026, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
+      href: https://www.pist.tn/jort/2026/2026F/Jo0442026.pdf
+      note: "JORT n° 44 du 30 avril 2026, pp. 838-839. Article premier, point 3 : à compter du 1er janvier 2028, le SMIG est fixé à 611,520 dinars (48 heures) et à 517,571 dinars (40 heures) par mois, et à 2,940 dinars (48 heures) et à 2,986 dinars (40 heures) l'heure ; il comprend l'indemnité complémentaire provisoire. Article 6 : l'augmentation du SMIG s'applique aux pensions de retraite servies par la Caisse nationale de sécurité sociale."
+    - title: "أمر عدد 67 لسنة 2026 مؤرخ في 30 أفريل 2026 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل"
+      href: https://www.pist.tn/jort/2026/2026A/Ja0442026.pdf
   official_journal_date:
     2022-10-01: "2022-10-21"
 documentation: |-

--- a/openfisca_tunisia/parameters/marche_travail/smig_40h_mensuel.yaml
+++ b/openfisca_tunisia/parameters/marche_travail/smig_40h_mensuel.yaml
@@ -117,89 +117,89 @@ metadata:
   reference:
     1961-04-01:
     - title: Décret n°61-145 du 30 mars 1961 portant relèvement général des salaires
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1961/décret_61_145_fr.pdf
+      href: https://www.pist.tn/jort/1961/1961F/Jo01261.pdf
     - title: امر عدد   145 بسنة  1961 مؤرخ في 30 مارس 1961 يتعلق بالترفيع العام للاجور
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1961/dêxret_61_145_ar.pdf
+      href: https://www.pist.tn/jort/1961/1961A/Ja01261.pdf
     1966-01-01:
     - title: Décret n°65-561 du 31 décembre 1965
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1965/décret_65_561_fr.pdf
+      href: https://www.pist.tn/jort/1965/1965F/Jo06665.pdf
     - title: امر عدد 561  لسنة 1965 مؤرخ في 31 ديسمبر   يتعلق بالترفيع  في الاجور في قطاع الصناعة والتجارة  و المهن الحرة
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1965/décret_65_561_ar.pdf
+      href: https://www.pist.tn/jort/1965/1965A/Ja06665.pdf
     1968-05-01:
     - title: Décret n°68-97 du 15 avril 1969 portant suppression des zones de salaires dans les activités  du secteur non agricole
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1968/décret_68_97_fr.pdf
+      href: https://www.pist.tn/jort/1968/1968F/Jo01668.pdf
     - title: امر عدد   97 لسنة   1968  مؤرخ في     يتعلق بجدف الأجور في نشاطات  القطاع غير الفلاحي
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1968/décret_68_97_ar.pdf
+      href: https://www.pist.tn/jort/1968/1968A/Ja01668.pdf
     1971-05-01:
     - title: Décret n°71-164 du 03 mai 1971 instituant une indemnité de cherté de vie dans l'industrie , le commerce et les professions libérales
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1971/décret_71_164_fr.pdf
+      href: https://www.pist.tn/jort/1971/1971F/Jo02071.pdf
     - title: امر عدد  164  لسنة   1971  مؤرخ في   3 ماي 1971  يتعلق باحداث منحة لغلو  المعاش  في القطاعات في الصناعة  و التجارة  والمهن الحرة
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1971/décret_71_164_ar.pdf
+      href: https://www.pist.tn/jort/1971/1971A/Ja02071.pdf
     1974-01-01:
     - title: Décret n°74-63 du 31 janvier 1974 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1974/décret_74_63_fr.pdf
+      href: https://www.pist.tn/jort/1974/1974F/Jo01074.pdf
     - title: امر عدد 63   لسنة   1974  مؤرخ في   31 جانفي 1974   يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1974/décret_74_63_ar.pdf
+      href: https://www.pist.tn/jort/1974/1974A/Ja01074.pdf
     1975-06-01:
     - title: Décret n°75-357 du 03 Juin 1975 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1975/décret_75_357_fr.pdf
+      href: https://www.pist.tn/jort/1975/1975F/Jo03875.pdf
     - title: امر عدد  357  لسنة  1975   مؤرخ في     3 جوان 1975 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1975/décret_75_357_ar.pdf
+      href: https://www.pist.tn/jort/1975/1975A/Ja03875.pdf
     1977-02-01:
     - title: Décret n°77-115 du 02 février 1977 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1977/décret_77_115_fr.pdf
+      href: https://www.pist.tn/jort/1977/1977F/Jo00977.pdf
     - title: امر عدد  115  لسنة 1977  مؤرخ في  2 فيفري  1977 يتعلق  بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1977/décret_77_115_ar.pdf
+      href: https://www.pist.tn/jort/1977/1977A/Ja00977.pdf
     1978-05-01:
     - title: Décret n°78-441 du 26 avril 1978 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1978/décret_78_441_fr.pdf
+      href: https://www.pist.tn/jort/1978/1978F/Jo03378.pdf
     - title: امر عدد  441  لسنة 1978    مؤرخ في    26 افريل 1978  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1978/décret_78_441_ar.pdf
+      href: https://www.pist.tn/jort/1978/1978A/Ja03378.pdf
     1979-05-01:
     - title: Décret n°79-473 du 21 mai 1979 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1979/décret_79_473_fr.pdf
+      href: https://www.pist.tn/jort/1979/1979F/Jo03479.pdf
     - title: امر عدد   473 لسنة    1979 مؤرخ في    21 ماي 1979   يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1979/décret_79_473_ar.pdf
+      href: https://www.pist.tn/jort/1979/1979A/Ja03479.pdf
     1980-02-01:
     - title: Décret n°80-75 du 21 janvier 1980 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1980/décret_80_75_fr.pdf
+      href: https://www.pist.tn/jort/1980/1980F/Jo00580.pdf
     - title: امر عدد   75  لسنة    1980 مؤرخ في    21 جانفي 1980   يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1980/décret_80_75_ar.pdf
+      href: https://www.pist.tn/jort/1980/1980A/Ja00580.pdf
     1980-05-01:
     - title: Décret n°80-609 du 19 Mai 1980  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1980/décret_80_609_fr.pdf
+      href: https://www.pist.tn/jort/1980/1980F/Jo03180.pdf
     - title: امر عدد  609   لسنة   1980 مؤرخ في    19 ماي 1980    يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1980/décret_80_609_ar.pdf
+      href: https://www.pist.tn/jort/1980/1980A/Ja03180.pdf
     1981-04-01:
     - title: Décret n°81-437 du 07 avril 1981 instituant une indemnité complémentaires provisoire dans les secteurs non agricoles régis par le Code de travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1981/décret_81_437_fr.pdf
+      href: https://www.pist.tn/jort/1981/1981F/Jo02581.pdf
     - title: امر عدد  437  لسنة  1981   مؤرخ في   7 افريل 1981    يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1981/décret_81_437_ar.pdf
+      href: https://www.pist.tn/jort/1981/1981A/Ja02581.pdf
     1982-02-01:
     - title: Décret n°82-501 du 16 mars 1982 portant majoration du salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1982/décret_82_501_fr.pdf
+      href: https://www.pist.tn/jort/1982/1982F/Jo01982.pdf
     - title: امر عدد    501 لسنة  1982  مؤرخ في    16 مارس 1982   يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1982/décret_82_501_ar.pdf
+      href: https://www.pist.tn/jort/1982/1982A/Ja01982.pdf
     1983-01-01:
     - title: Décret n°83-509 du 04 juin 1983 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1983/décret_83_509_fr.pdf
+      href: https://www.pist.tn/jort/1983/1983F/Jo04283.pdf
     - title: امر عدد   509  لسنة   1983 مؤرخ في   4 جوان 1983  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1983/décret_83_509_ar.pdf
+      href: https://www.pist.tn/jort/1983/1983A/Ja04283.pdf
     1986-07-01:
     - title: Décret n°86-689 du 20 juillet 1986 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1986/décret_86_689_fr.pdf
+      href: https://www.pist.tn/jort/1986/1986F/Jo04186.pdf
     - title: امر عدد   689 لسنة 1986 مؤرخ في    19 جويلية 1986 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1986/décret_86_689_ar.pdf
+      href: https://www.pist.tn/jort/1986/1986A/Ja04186.pdf
     1987-11-01:
     - title: Décret n°87-1277 du 05 novembre 1987 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1987/décret_87_1277_fr.pdf
+      href: https://www.pist.tn/jort/1987/1987F/Jo07887.pdf
     - title: امر عدد  1277   لسنة  1987  مؤرخ في    5 توفمبر 1987   يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1987/décret_87_1277_ar.pdf
+      href: https://www.pist.tn/jort/1987/1987A/Ja07887.pdf
     1988-04-01:
     - title: Décret n°88-889 du 05 mai 1988 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/décret_88_889_fr.pdf
+      href: https://www.pist.tn/jort/1988/1988F/Jo03188.pdf
     - title: امر عدد   889  لسنة  1988  مؤرخ في 5 ماي 1988 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/décret_88_889_ar.pdf
+      href: https://www.pist.tn/jort/1988/1988A/Ja03188.pdf
     1990-01-01:
     - title: "Décret n° 90-246 du 5 février 1990, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
       href: https://www.pist.tn/jort/1990/1990F/Jo01390.pdf
@@ -214,149 +214,149 @@ metadata:
       href: https://www.pist.tn/jort/1992/1992A/Ja04992.pdf
     1992-08-01:
     - title: Décret n°92-1630 du 07 septembre 1992 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1300_fr.pdf
+      href: https://www.pist.tn/jort/1992/1992F/Jo06392.pdf
     - title: امر عدد 1630    لسنة  1992  مؤرخ في  7 سبتمبر 1992 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1300_ar.pdf
+      href: https://www.pist.tn/jort/1992/1992A/Ja06392.pdf
     1993-05-01:
     - title: Décret n°93-1256 du 07 juin 1993 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/décret_93_1256_fr.pdf
+      href: https://www.pist.tn/jort/1993/1993F/Jo04493.pdf
     - title: أمر عدد   1256  لسنة  1993  مؤرخ في 7 جوان 1993  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/décret_93_1256_ar.pdf
+      href: https://www.pist.tn/jort/1993/1993A/Ja04493.pdf
     1993-08-01:
     - title: Décret n°93-1838 du 06 septembre 1993 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/décret_93_1838_fr.pdf
+      href: https://www.pist.tn/jort/1993/1993F/Jo06993.pdf
     - title: أمر عدد  1838   لسنة  1993  مؤرخ في  6 سبتمبر 1993 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/décret_93_1838_ar.pdf
+      href: https://www.pist.tn/jort/1993/1993A/Ja06993.pdf
     1994-08-01:
     - title: Décret n°94-1804 du 29 août 1994 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1994/décret_94_1804_fr.pdf
+      href: https://www.pist.tn/jort/1994/1994F/Jo07194.pdf
     - title: أمر عدد   1804  لسنة   1995   مؤرخ في 29 اوت  1995  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1994/décret_94_1804_ar.pdf
+      href: https://www.pist.tn/jort/1994/1994A/Ja07194.pdf
     1995-05-01:
     - title: Décret n°95-900 du 15 mai 1995 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1995/décret_95_900_fr.pdf
+      href: https://www.pist.tn/jort/1995/1995F/Jo04095.pdf
     - title: أمر عدد  900   لسنة   1995   مؤرخ في 15 ماي 1995  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1995/décret_95_900_ar.pdf
+      href: https://www.pist.tn/jort/1995/1995A/Ja04095.pdf
     1996-05-01:
     - title: Décret n°96-1013 du 27 mai 1996 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1996/décret_96_1013_fr.pdf
+      href: https://www.pist.tn/jort/1996/1996F/Jo04596.pdf
     - title: أمر عدد   1013  لسنة  1996 مؤرخ في 27 ماي يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1996/décret_96_1013_ar.pdf
+      href: https://www.pist.tn/jort/1996/1996A/Ja04596.pdf
     1996-09-09:
     - title: Décret n°96-1547 du 10 septembre 1996 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1996/décret_96_1547_fr.pdf
+      href: https://www.pist.tn/jort/1996/1996F/Jo07496.pdf
     - title: أمر عدد   1547  لسنة  1996    مؤرخ في  10 سبتمبر 1996 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1996/décret_96_1547_ar.pdf
+      href: https://www.pist.tn/jort/1996/1996A/Ja07496.pdf
     1997-07-20:
     - title: Décret n°97-1521 du 04 août 1997 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1997/décret_97_1521_fr.pdf
+      href: https://www.pist.tn/jort/1997/1997F/Jo06397.pdf
     - title: أمر عدد   1521  لسنة  1997  مؤرخ في  4  اوت 1997 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1997/décret_97_1521_ar.pdf
+      href: https://www.pist.tn/jort/1997/1997A/Ja06397.pdf
     1997-11-07:
     - title: Décret n°97-2148 du 12 novembre 1997 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1997/décret_97_2148_fr.pdf
+      href: https://www.pist.tn/jort/1997/1997F/Jo09397.pdf
     - title: أمر عدد   2148 لسنة 1997 مؤرخ في 12 نوفبر 1977 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1997/décret_97_2148_ar.pdf
+      href: https://www.pist.tn/jort/1997/1997A/Ja09397.pdf
     1998-08-20:
     - title: Décret n°98-1674 du 26 août 1998 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1998/décret_1998_1674_fr.pdf
+      href: https://www.pist.tn/jort/1998/1998F/Jo07198.pdf
     - title: أمر عدد 1674 لسنة 1998 مؤرخ في 26 أوت 1998 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1998/décret_1998_1674_ar.pdf
+      href: https://www.pist.tn/jort/1998/1998A/Ja07198.pdf
     1999-05-01:
     - title: Décret n°99-994 du 10 mai 1999 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1999/décret_1999_994_fr.pdf
+      href: https://www.pist.tn/jort/1999/1999F/Jo03899.pdf
     - title: أمر عدد 994 لسنة 1999 مؤرخ في 8 ماي 1999 يتعلّق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1999/décret_1999_994_ar.pdf
+      href: https://www.pist.tn/jort/1999/1999A/Ja03899.pdf
     1999-08-19:
     - title: Décret n°99-1866 du 31 août 1999 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1999/décret_1999_1866_fr.pdf
+      href: https://www.pist.tn/jort/1999/1999F/Jo07499.pdf
     - title: أمر عدد 1866 لسنة 1999 مؤرخ في 30 أوت 1999 يتعلّق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1999/décret_1999_1866_ar.pdf
+      href: https://www.pist.tn/jort/1999/1999A/Ja07499.pdf
     2000-05-01:
     - title: Décret n°2000-949 du 11 mai 2000 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2000/décret_2000_949_fr.pdf
+      href: https://www.pist.tn/jort/2000/2000F/Jo0382000.pdf
     - title: أمر عدد 949 لسنة 2000 مؤرخ في 11 ماي 2000 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2000/décret_2000_949_ar.pdf
+      href: https://www.pist.tn/jort/2000/2000A/Ja03800.pdf
     2001-07-01:
     - title: Décret n°2001-1746 du 01 août 2001 fixant le salaire minimum interprofessionnel garanti dans les secteurs non  agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/décret_2001_1746_fr.pdf
+      href: https://www.pist.tn/jort/2001/2001F/Jo0632001.pdf
     - title: أمر عدد 1746 لسنة 2001 مؤرخ في أول أوت 2001 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/décret_2001_1746_ar.pdf
+      href: https://www.pist.tn/jort/2001/2001A/Ja0632001.pdf
     2002-07-01:
     - title: Décret n°2002-1790 du 12 août 2002 fixant le salaire minimum interprofessionnel garanti dans les secteurs non  agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2002/décret_2002_1790_fr.pdf
+      href: https://www.pist.tn/jort/2002/2002F/Jo0672002.pdf
     - title: أمر عدد 1790 لسنة 2002 مؤرخ في 12 أوت 2002 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2002/décret_2002_1790_ar.pdf
+      href: https://www.pist.tn/jort/2002/2002A/Ja0672002.pdf
     2003-07-01:
     - title: Décret n°2003-1691 du 18 août 2003 fixant le salaire minimum interprofessionnel garanti dans les secteurs non  agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2003/décret_2003_1691_fr.pdf
+      href: https://www.pist.tn/jort/2003/2003F/Jo0672003.pdf
     - title: أمر عدد 1691 لسنة 2003 مؤرخ في 18 أوت 2003 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2003/décret_2003_1691_ar.pdf
+      href: https://www.pist.tn/jort/2003/2003A/Ja0672003.pdf
     2004-07-01:
     - title: Décret n°2004-1803 du 02 août 2004 fixant le salaire minimum interprofessionnel garanti dans les secteurs non  agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2004/décret_2004_1803_fr.pdf
+      href: https://www.pist.tn/jort/2004/2004F/Jo0632004.pdf
     - title: أمر عدد 1803 لسنة 2004 مؤرخ في 2 أوت 2004 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2004/décret_2004_1803_ar.pdf
+      href: https://www.pist.tn/jort/2004/2004A/Ja0632004.pdf
     2005-09-01:
     - title: Décret n°2005-2320 du 22 août 2005 , fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2005/décret_2005_2320_fr.pdf
+      href: https://www.pist.tn/jort/2005/2005F/Jo0682005.pdf
     - title: أمر  عدد 2320 لسنة 2005 مؤرخ في 22 أوت 2005 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2005/décret_2005_2320_ar.pdf
+      href: https://www.pist.tn/jort/2005/2005A/Ja0682005.pdf
     2006-07-01:
     - title: Décret n°2006-2098 du 24 juillet 2006 , fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2006/décret_2006_2098_fr.pdf
+      href: https://www.pist.tn/jort/2006/2006F/Jo0622006.pdf
     - title: أمر عدد 2098 لسنة 2006 مؤرخ في 24 جويلية 2006 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2006/décret_2006_2098_ar.pdf
+      href: https://www.pist.tn/jort/2006/2006A/Ja0622006.pdf
     2007-07-01:
     - title: Décret n°2007-2079 du 14 août 2007 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/décret_2007_2079_fr.pdf
+      href: https://www.pist.tn/jort/2007/2007F/Jo0672007.pdf
     - title: أمر عدد 2079 لسنة 2007 مؤرخ في 14 أوت 2007 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/décret_2007_2079_ar.pdf
+      href: https://www.pist.tn/jort/2007/2007A/Ja0672007.pdf
     2008-07-01:
     - title: Décret n°2008-2072 du 02 juin 2008 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2008/décret_2008_2072_fr.pdf
+      href: https://www.pist.tn/jort/2008/2008F/Jo0462008.pdf
     - title: أمر عدد 2072 لسنة 2008 مؤرخ في 2 جوان 2008 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2008/décret_2008_2072_ar.pdf
+      href: https://www.pist.tn/jort/2008/2008A/Ja0462008.pdf
     2009-08-01:
     - title: Décret n°2009-2257 du 14 juillet 2009 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2009/décret_2009_2257_fr.pdf
+      href: https://www.pist.tn/jort/2009/2009F/Jo0622009.pdf
     - title: أمر عدد 2257 لسنة 2009 مؤرخ في 14 جويلية 2009 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2009/décret_2009_2257_ar.pdf
+      href: https://www.pist.tn/jort/2009/2009A/Ja0622009.pdf
     2010-07-01:
     - title: Décret n°2010-1746 du 17 juillet 2010 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2010/décret_2010_1746_fr.pdf
+      href: https://www.pist.tn/jort/2010/2010F/Jo0582010.pdf
     - title: أمر عدد 1746 لسنة 2010 مؤرخ في 17 جويلية 2010 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2010/décret_2010_1746_ar.pdf
+      href: https://www.pist.tn/jort/2010/2010A/Ja0582010.pdf
     2011-05-01:
     - title: Décret n°2011-679 du 09 juin 2011 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2011/décret_2011_679_fr.pdf
+      href: https://www.pist.tn/jort/2011/2011F/Jo0422011.pdf
     - title: أمر عدد 679 لسنة 2011 مؤرخ في 9 جوان 2011 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2011/décret_2011_679_ar.pdf
+      href: https://www.pist.tn/jort/2011/2011A/Ja0422011.pdf
     2012-07-01:
     - title: Décret n°2012-1981 du 20 septembre 2012 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2012/décret_2012_1981_fr.pdf?ref_type=heads
+      href: https://www.pist.tn/jort/2012/2012F/Jo0772012.pdf
     - title: امر عدد 1981 لسنة 2012 مؤرخ في 20 سبتمبر 2012 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2012/décret_2012_1981_ar.pdf
+      href: https://www.pist.tn/jort/2012/2012A/Ja0772012.pdf
     2014-05-01:
     - title: Décret n°2014-2907 du 11 août 2014 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2014/décret_2014_2907_fr.pdf
+      href: https://www.pist.tn/jort/2014/2014F/Jo0662014.pdf
     - title: امر عدد 2907 لسنة 2014 مؤرخ في 11 أوت 2014 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2014/décret_2014_2907_ar.pdf
+      href: https://www.pist.tn/jort/2014/2014A/Ja0662014.pdf
     2015-05-01:
     - title: Décret n°2015-1762 du 09 novembre 2015 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2015/décret_2015_1762_fr.pdf?ref_type=heads
+      href: https://www.pist.tn/jort/2015/2015F/Jo0912015.pdf
     - title: امر حكومي عدد 1762 لسنة 2015 مؤرخ في 9 نوفمبر 2015 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2015/décret_2015_1762_ar.pdf
+      href: https://www.pist.tn/jort/2015/2015A/Ja0912015.pdf
     2016-08-01:
     - title: Décret n°2017-668 du 05 juin 2017  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2017/décret_2017_668_fr.pdf
+      href: https://www.pist.tn/jort/2017/2017F/Jo0452017.pdf
     - title: امر حكومي عدد 668 لسنة 2017 مؤرخ في 5 جوان 2017 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2017/décret_2017_668_ar.pdf
+      href: https://www.pist.tn/jort/2017/2017A/Ja0452017.pdf
     2018-05-01:
     - title: Décret gouvernemental n°2018-672 du 07 août 2018 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2018/décret_2018_672_fr.pdf
+      href: https://www.pist.tn/jort/2018/2018F/Jo0642018.pdf
     - title: امر حكومي عدد 672 لسنة 2018 مؤرخ في 7 أوت 2018 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2018/décret_2018_672_ar.pdf
+      href: https://www.pist.tn/jort/2018/2018A/Ja0642018.pdf
     2019-05-01:
     - title: Décret gouvernemental n°2019-454 du 28 mai 2019 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2019/décret_2019_454_fr.pdf
@@ -364,24 +364,24 @@ metadata:
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2019/décret_2019_454_ar.pdf
     2020-10-01:
     - title: Décret gouvernemental n° 2020-1069 du 30 décembre 2020 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2020/décret_2020_1069_fr.pdf
+      href: https://www.pist.tn/jort/2021/2021F/Jo0012021.pdf
     - title: امر حكومي عدد 1069 لسنة 2020 مؤرخ في 30 ديسمبر 2020 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2020/décret_2020_1069_ar.pdf
+      href: https://www.pist.tn/jort/2021/2021A/Ja0012021.pdf
     2022-10-01:
     - title: Décret gouvernemental n°2022-769 du 19 octobre 2022 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2022/décret_2022_769_fr.pdf
+      href: https://www.pist.tn/jort/2022/2022F/Jo1142022.pdf
     - title: امر عدد 769 لسنة 2022 مؤرخ في 19 أكتوبر 2022 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2022/décret_2022_769_ar.pdf
+      href: https://www.pist.tn/jort/2022/2022A/Ja1142022.pdf
     2024-05-01:
     - title: Décret n°2024-419 du 09 juillet 2024 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/décret_2024_419_fr.pdf
+      href: https://www.pist.tn/jort/2024/2024F/Jo0852024.pdf
     - title: امر عدد 419 لسنة 2024 مؤرخ في 9 جويلية 2024 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/décret_2024_419_ar.pdf
+      href: https://www.pist.tn/jort/2024/2024A/Ja0852024.pdf
     2025-01-01:
     - title: Décret n°2024-419 du 09 juillet 2024 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/décret_2024_419_fr.pdf
+      href: https://www.pist.tn/jort/2024/2024F/Jo0852024.pdf
     - title: امر عدد 419 لسنة 2024 مؤرخ في 9 جويلية 2024 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/décret_2024_419_ar.pdf
+      href: https://www.pist.tn/jort/2024/2024A/Ja0852024.pdf
     2026-01-01:
     - title: "Décret n° 2026-67 du 30 avril 2026, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
       href: https://www.pist.tn/jort/2026/2026F/Jo0442026.pdf

--- a/openfisca_tunisia/parameters/marche_travail/smig_48h_horaire.yaml
+++ b/openfisca_tunisia/parameters/marche_travail/smig_48h_horaire.yaml
@@ -117,89 +117,89 @@ metadata:
   reference:
     1961-04-01:
     - title: Décret n°61-145 du 30 mars 1961 portant  relèvement général des salaires
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1961/décret_61_145_fr.pdf
+      href: https://www.pist.tn/jort/1961/1961F/Jo01261.pdf
     - title: امر عدد  145 لسنة    1961 مؤرخ  في  30 مارس 1961  يتعلق بالترفيع العام الاجور
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1961/déxret_61_145_ar.pd
+      href: https://www.pist.tn/jort/1961/1961A/Ja01261.pdf
     1966-01-01:
     - title: Décret n°65-561 du 31 décembre 1965 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code de travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1965/décret_65_561_fr.pdf
+      href: https://www.pist.tn/jort/1965/1965F/Jo06665.pdf
     - title: امر عدد  561 لسنة   1965  مؤرخ  في 31 ديسمبر 1965    يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1965/décret_65_561_ar.pdf
+      href: https://www.pist.tn/jort/1965/1965A/Ja06665.pdf
     1968-05-01:
     - title: Décret n°68-97 du 15 avril 1969  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code de travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1968/décret_68_97_fr.pdf
+      href: https://www.pist.tn/jort/1968/1968F/Jo01668.pdf
     - title: امر عدد 97   لسنة   1968  مؤرخ  في 15 افريل 1968  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1968/décret_68_97_ar.pdf
+      href: https://www.pist.tn/jort/1968/1968A/Ja01668.pdf
     1971-05-01:
     - title: Décret n°71-164 du 03 mai 1971 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code de travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1971/décret_71_164_fr.pdf
+      href: https://www.pist.tn/jort/1971/1971F/Jo02071.pdf
     - title: امر عدد 164 لسنة   1971  مؤرخ  في 3 ماي 1971  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1971/décret_71_164_ar.pdf
+      href: https://www.pist.tn/jort/1971/1971A/Ja02071.pdf
     1974-01-01:
     - title: Décret n°74-63 du 31 janvier 1974  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code de travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1974/décret_74_63_fr.pdf
+      href: https://www.pist.tn/jort/1974/1974F/Jo01074.pdf
     - title: امر عدد 63  لسنة  1974   مؤرخ  في   31 جانفي 1974   يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1974/décret_74_63_ar.pdf
+      href: https://www.pist.tn/jort/1974/1974A/Ja01074.pdf
     1975-06-01:
     - title: Décret n°75-357 du 03 juin 1975  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code de travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1975/décret_75_357_fr.pdf
+      href: https://www.pist.tn/jort/1975/1975F/Jo03875.pdf
     - title: امر عدد  357 لسنة    1975 مؤرخ  في   3 جوان 1975  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1975/décret_75_357_ar.pdf
+      href: https://www.pist.tn/jort/1975/1975A/Ja03875.pdf
     1977-02-01:
     - title: Décret n°77-115 du 02 février 1977 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code de travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1977/décret_77_115_fr.pdf
+      href: https://www.pist.tn/jort/1977/1977F/Jo00977.pdf
     - title: امر عدد 115  لسنة    1977 مؤرخ  في  2 فيفري 1977  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1977/décret_77_115_ar.pdf
+      href: https://www.pist.tn/jort/1977/1977A/Ja00977.pdf
     1978-05-01:
     - title: Décret n°78-441 du 26 avril 1978  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code de travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1978/décret_78_441_fr.pdf
+      href: https://www.pist.tn/jort/1978/1978F/Jo03378.pdf
     - title: امر عدد   441  لسنة    1978 مؤرخ في  26 أفريل 1978   يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1978/décret_78_441_ar.pdf
+      href: https://www.pist.tn/jort/1978/1978A/Ja03378.pdf
     1979-05-01:
     - title: Décret n°79-473 du 21 mai 1979  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code de travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1979/décret_79_473_fr.pdf
+      href: https://www.pist.tn/jort/1979/1979F/Jo03479.pdf
     - title: امر عدد   473 لسنة    1979 مؤرخ في    21 ماي 1979   يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1979/décret_79_473_ar.pdf
+      href: https://www.pist.tn/jort/1979/1979A/Ja03479.pdf
     1980-02-01:
     - title: Décret n°80-75 du 21 janvier 1980  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code de travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1980/décret_80_75_fr.pdf?ref_type=heads
+      href: https://www.pist.tn/jort/1980/1980F/Jo00580.pdf
     - title: امر عدد   75  لسنة    1980 مؤرخ في    21 جانفي 1980   يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1980/décret_80_75_ar.pdf
+      href: https://www.pist.tn/jort/1980/1980A/Ja00580.pdf
     1980-05-01:
     - title: Décret n°80-609 du 19 mai 1980 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code de travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1980/décret_80_609_fr.pdf
+      href: https://www.pist.tn/jort/1980/1980F/Jo03180.pdf
     - title: امر عدد  609   لسنة   1980 مؤرخ في    19 ماي 1980    يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1980/décret_80_609_ar.pdf
+      href: https://www.pist.tn/jort/1980/1980A/Ja03180.pdf
     1981-04-01:
     - title: Décret n°81-437 du 07 avril 1981 instituant une indemnité complémentaire provisoire  dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1981/décret_81_437_fr.pdf
+      href: https://www.pist.tn/jort/1981/1981F/Jo02581.pdf
     - title: امر عدد  437  لسنة  1981   مؤرخ في   7 افريل 1981    يتعلق بإحداث منحة اضافية مؤقتة  في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1981/décret_81_437_ar.pdf
+      href: https://www.pist.tn/jort/1981/1981A/Ja02581.pdf
     1982-02-01:
     - title: Décret n°82-501 du 16 mars 1982 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1982/décret_82_501_fr.pdf
+      href: https://www.pist.tn/jort/1982/1982F/Jo01982.pdf
     - title: امر عدد    501 لسنة  1982  مؤرخ في    16 مارس 1982   يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1982/décret_82_501_ar.pdf
+      href: https://www.pist.tn/jort/1982/1982A/Ja01982.pdf
     1983-01-01:
     - title: Décret n°83-509 du 04 juin 1983 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1983/décret_83_509_fr.pdf
+      href: https://www.pist.tn/jort/1983/1983F/Jo04283.pdf
     - title: امر عدد   509  لسنة   1983 مؤرخ في   4 جوان 1983  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1983/décret_83_509_ar.pdf?ref_type=heads
+      href: https://www.pist.tn/jort/1983/1983A/Ja04283.pdf
     1986-07-01:
     - title: Décret n°86-689 du 20 juillet 1986 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1986/décret_86_689_fr.pdf
+      href: https://www.pist.tn/jort/1986/1986F/Jo04186.pdf
     - title: امر عدد  689 لسنة 1986  مؤرخ في 20 جويلية 1986 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1986/décret_86_689_ar.pdf
+      href: https://www.pist.tn/jort/1986/1986A/Ja04186.pdf
     1987-11-01:
     - title: Décret n°87-1277 du 05 novembre 1987 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1987/décret_87_1277_fr.pdf
+      href: https://www.pist.tn/jort/1987/1987F/Jo07887.pdf
     - title: امر عدد  1277   لسنة  1987  مؤرخ في    5 توفمبر 1987   يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1987/décret_87_1277_ar.pdf
+      href: https://www.pist.tn/jort/1987/1987A/Ja07887.pdf
     1988-04-01:
     - title: Décret n°88-889 du 05 mai 1988 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/décret_88_889_fr.pdf
+      href: https://www.pist.tn/jort/1988/1988F/Jo03188.pdf
     - title: امر عدد   889  لسنة  1988  مؤرخ في 5 ماي 1988 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/décret_88_889_ar.pdf
+      href: https://www.pist.tn/jort/1988/1988A/Ja03188.pdf
     1990-01-01:
     - title: "Décret n° 90-246 du 5 février 1990, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
       href: https://www.pist.tn/jort/1990/1990F/Jo01390.pdf
@@ -214,149 +214,149 @@ metadata:
       href: https://www.pist.tn/jort/1992/1992A/Ja04992.pdf
     1992-08-01:
     - title: Décret n°92-1630 du 07 septembre 1992 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1630_fr.pdf
+      href: https://www.pist.tn/jort/1992/1992F/Jo06392.pdf
     - title: امر عدد 1630    لسنة  1992  مؤرخ في  7 سبتمبر 1992 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1630_ar.pdf
+      href: https://www.pist.tn/jort/1992/1992A/Ja06392.pdf
     1993-05-01:
     - title: Décret n°93-1256 du 07 juin 1993 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/décret_93_1256_fr.pdf
+      href: https://www.pist.tn/jort/1993/1993F/Jo04493.pdf
     - title: أمر عدد   1256  لسنة  1993  مؤرخ في 7 جوان 1993  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/décret_93_1256_ar.pdf
+      href: https://www.pist.tn/jort/1993/1993A/Ja04493.pdf
     1993-08-01:
     - title: Décret n°93-1838 du 06 septembre 1993 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/décret_93_1838_fr.pdf
+      href: https://www.pist.tn/jort/1993/1993F/Jo06993.pdf
     - title: أمر عدد  1838   لسنة  1993  مؤرخ في  6 سبتمبر 1993 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/décret_93_1838_ar.pdf
+      href: https://www.pist.tn/jort/1993/1993A/Ja06993.pdf
     1994-08-01:
     - title: Décret n°94-1804 du 29 août 1994 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1994/décret_94_1804_fr.pdf
+      href: https://www.pist.tn/jort/1994/1994F/Jo07194.pdf
     - title: أمر عدد   1804  لسنة   1995   مؤرخ في 29 اوت  1995  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1994/décret_94_1804_ar.pdf
+      href: https://www.pist.tn/jort/1994/1994A/Ja07194.pdf
     1995-05-01:
     - title: Décret n°95-900 du 15 mai 1995 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1995/décret_95_900_fr.pdf
+      href: https://www.pist.tn/jort/1995/1995F/Jo04095.pdf
     - title: أمر عدد  900   لسنة   1995   مؤرخ في 15 ماي 1995  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1995/décret_95_900_ar.pdf
+      href: https://www.pist.tn/jort/1995/1995A/Ja04095.pdf
     1996-05-01:
     - title: Décret n°96-1013 du 27 mai 1996 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1996/décret_96_1013_fr.pdf
+      href: https://www.pist.tn/jort/1996/1996F/Jo04596.pdf
     - title: أمر عدد   1013  لسنة  1996 مؤرخ في 27 ماي يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1996/décret_96_1013_ar.pdf
+      href: https://www.pist.tn/jort/1996/1996A/Ja04596.pdf
     1996-09-09:
     - title: Décret n°96-1547 du 10 septembre 1996  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1996/décret_96_1547_fr.pdf
+      href: https://www.pist.tn/jort/1996/1996F/Jo07496.pdf
     - title: أمر عدد   1547  لسنة  1996    مؤرخ في  10 سبتمبر 1996 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1996/décret_96_1547_ar.pdf
+      href: https://www.pist.tn/jort/1996/1996A/Ja07496.pdf
     1997-07-20:
     - title: Décret n°97-1521 du 04 août 1997  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1997/décret_97_1521_fr.pdf
+      href: https://www.pist.tn/jort/1997/1997F/Jo06397.pdf
     - title: أمر عدد   1521  لسنة  1997  مؤرخ في  4  اوت 1997 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1997/décret_97_1521_ar.pdf
+      href: https://www.pist.tn/jort/1997/1997A/Ja06397.pdf
     1997-11-07:
     - title: Décret n°97-2148 du 12 novembre 1997 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1997/décret_97_2148_fr.pdf
+      href: https://www.pist.tn/jort/1997/1997F/Jo09397.pdf
     - title: أمر عدد   2148 لسنة 1997 مؤرخ في 12 نوفبر 1977 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1997/décret_97_2148_ar.pdf
+      href: https://www.pist.tn/jort/1997/1997A/Ja09397.pdf
     1998-08-20:
     - title: Décret n°98-1674 du 26 août 1998  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1998/décret_1998_1674_fr.pdf
+      href: https://www.pist.tn/jort/1998/1998F/Jo07198.pdf
     - title: أمر عدد 1674 لسنة 1998 مؤرخ في 26 أوت 1998 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1998/décret_1998_1674_ar.pdf
+      href: https://www.pist.tn/jort/1998/1998A/Ja07198.pdf
     1999-05-01:
     - title: Décret n°99-994 du 10 mai 1999  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1999/décret_1999_994_fr.pdf
+      href: https://www.pist.tn/jort/1999/1999F/Jo03899.pdf
     - title: أمر عدد 994 لسنة 1999 مؤرخ في 8 ماي 1999 يتعلّق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1999/décret_1999_994_ar.pdf
+      href: https://www.pist.tn/jort/1999/1999A/Ja03899.pdf
     1999-08-19:
     - title: Décret n°99-1866 du 31 août 1999  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1999/décret_1999_1866_fr.pdf
+      href: https://www.pist.tn/jort/1999/1999F/Jo07499.pdf
     - title: أمر عدد 1866 لسنة 1999 مؤرخ في 30 أوت 1999 يتعلّق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1999/décret_1999_1866_ar.pdf
+      href: https://www.pist.tn/jort/1999/1999A/Ja07499.pdf
     2000-05-01:
     - title: Décret n°2000-949 du 11 mai 2000  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2000/décret_2000_949_fr.pdf
+      href: https://www.pist.tn/jort/2000/2000F/Jo0382000.pdf
     - title: أمر عدد 949 لسنة 2000 مؤرخ في 11 ماي 2000 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2000/décret_2000_949_ar.pdf
+      href: https://www.pist.tn/jort/2000/2000A/Ja03800.pdf
     2001-07-01:
     - title: Décret n°2001-1746 du 01 août 2001  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/décret_2001_1746_fr.pdf
+      href: https://www.pist.tn/jort/2001/2001F/Jo0632001.pdf
     - title: أمر عدد 1746 لسنة 2001 مؤرخ في أول أوت 2001 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/décret_2001_1746_ar.pdf
+      href: https://www.pist.tn/jort/2001/2001A/Ja0632001.pdf
     2002-07-01:
     - title: Décret n°2002-1790 du 12 août 2002 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2002/décret_2002_1790_fr.pdf
+      href: https://www.pist.tn/jort/2002/2002F/Jo0672002.pdf
     - title: أمر عدد 1790 لسنة 2002 مؤرخ في 12 أوت 2002 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2002/décret_2002_1790_ar.pdf
+      href: https://www.pist.tn/jort/2002/2002A/Ja0672002.pdf
     2003-07-01:
     - title: Décret n°2003-1691 du 18 août 2003 , fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2003/décret_2003_1691_fr.pdf
+      href: https://www.pist.tn/jort/2003/2003F/Jo0672003.pdf
     - title: أمر عدد 1691 لسنة 2003 مؤرخ في 18 أوت 2003 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2003/décret_2003_1691_ar.pdf
+      href: https://www.pist.tn/jort/2003/2003A/Ja0672003.pdf
     2004-07-01:
     - title: Décret n°2004-1803 du 02 août 2004  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2004/décret_2004_1803_fr.pdf
+      href: https://www.pist.tn/jort/2004/2004F/Jo0632004.pdf
     - title: أمر عدد 1803 لسنة 2004 مؤرخ في 2 أوت 2004 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2004/décret_2004_1803_ar.pdf
+      href: https://www.pist.tn/jort/2004/2004A/Ja0632004.pdf
     2005-09-01:
     - title: Décret n°2005-2320 du 22 août 2005 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2005/décret_2005_2320_fr.pdf
+      href: https://www.pist.tn/jort/2005/2005F/Jo0682005.pdf
     - title: أمر  عدد 2320 لسنة 2005 مؤرخ في 22 أوت 2005 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2005/décret_2005_2320_ar.pdf
+      href: https://www.pist.tn/jort/2005/2005A/Ja0682005.pdf
     2006-07-01:
     - title: Décret n°2006-2098 du 24 juillet 2006 , fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2006/décret_2006_2098_fr.pdf
+      href: https://www.pist.tn/jort/2006/2006F/Jo0622006.pdf
     - title: أمر عدد 2098 لسنة 2006 مؤرخ في 24 جويلية 2006 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2006/décret_2006_2098_ar.pdf
+      href: https://www.pist.tn/jort/2006/2006A/Ja0622006.pdf
     2007-07-01:
     - title: Décret n°2007-2079 du 14 août 2007 , fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/décret_2007_2079_fr.pdf
+      href: https://www.pist.tn/jort/2007/2007F/Jo0672007.pdf
     - title: أمر عدد 2079 لسنة 2007 مؤرخ في 14 أوت 2007 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/décret_2007_2079_ar.pdf
+      href: https://www.pist.tn/jort/2007/2007A/Ja0672007.pdf
     2008-07-01:
     - title: Décret n°2008-2072 du 02 juin 2008 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2008/décret_2008_2072_fr.pdf
+      href: https://www.pist.tn/jort/2008/2008F/Jo0462008.pdf
     - title: أمر عدد 2072 لسنة 2008 مؤرخ في 2 جوان 2008 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2008/décret_2008_2072_ar.pdf
+      href: https://www.pist.tn/jort/2008/2008A/Ja0462008.pdf
     2009-08-01:
     - title: Décret n°2009-2257 du 14 juillet 2009  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2009/décret_2009_2257_fr.pdf
+      href: https://www.pist.tn/jort/2009/2009F/Jo0622009.pdf
     - title: أمر عدد 2257 لسنة 2009 مؤرخ في 14 جويلية 2009 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2009/décret_2009_2257_ar.pdf
+      href: https://www.pist.tn/jort/2009/2009A/Ja0622009.pdf
     2010-07-01:
     - title: Décret n°2010-1746 du 17 juillet 2010 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2010/décret_2010_1746_fr.pdf
+      href: https://www.pist.tn/jort/2010/2010F/Jo0582010.pdf
     - title: أمر عدد 1746 لسنة 2010 مؤرخ في 17 جويلية 2010 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2010/décret_2010_1746_ar.pdf
+      href: https://www.pist.tn/jort/2010/2010A/Ja0582010.pdf
     2011-05-01:
     - title: Décret n°2011-679 du 09 juin 2011 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2011/décret_2011_679_fr.pdf
+      href: https://www.pist.tn/jort/2011/2011F/Jo0422011.pdf
     - title: أمر عدد 679 لسنة 2011 مؤرخ في 9 جوان 2011 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2011/décret_2011_679_ar.pdf
+      href: https://www.pist.tn/jort/2011/2011A/Ja0422011.pdf
     2012-07-01:
     - title: Décret n°2012-1981 du 20 septembre 2012 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2012/décret_2012_1981_fr.pdf
+      href: https://www.pist.tn/jort/2012/2012F/Jo0772012.pdf
     - title: امر عدد 1981 لسنة 2012 مؤرخ في 20 سبتمبر 2012 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2012/décret_2012_1981_ar.pdf
+      href: https://www.pist.tn/jort/2012/2012A/Ja0772012.pdf
     2014-05-01:
     - title: Décret n°2014-2907 du 11 août 2014 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2014/décret_2014_2907_fr.pdf
+      href: https://www.pist.tn/jort/2014/2014F/Jo0662014.pdf
     - title: امر عدد 2907 لسنة 2014 مؤرخ في 11 أوت 2014 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2014/décret_2014_2907_ar.pdf
+      href: https://www.pist.tn/jort/2014/2014A/Ja0662014.pdf
     2015-05-01:
     - title: Décret n°2015-1762 du 09 novembre 2015 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2015/décret_2015_1762_fr.pdf
+      href: https://www.pist.tn/jort/2015/2015F/Jo0912015.pdf
     - title: امر حكومي عدد 1762 لسنة 2015 مؤرخ في 9 نوفمبر 2015 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2015/décret_2015_1762_ar.pdf
+      href: https://www.pist.tn/jort/2015/2015A/Ja0912015.pdf
     2016-08-01:
     - title: Décret n°2017-668 du 05 juin 2017 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2017/décret_2017_668_fr.pdf
+      href: https://www.pist.tn/jort/2017/2017F/Jo0452017.pdf
     - title: امر حكومي عدد 668 لسنة 2017 مؤرخ في 5 جوان 2017 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2017/décret_2017_668_ar.pdf
+      href: https://www.pist.tn/jort/2017/2017A/Ja0452017.pdf
     2018-05-01:
     - title: Décret gouvernemental n°2018-672 du 07 août 2018 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2018/décret_2018_672_fr.pdf
+      href: https://www.pist.tn/jort/2018/2018F/Jo0642018.pdf
     - title: امر حكومي عدد 672 لسنة 2018 مؤرخ في 7 أوت 2018 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2018/décret_2018_672_ar.pdf
+      href: https://www.pist.tn/jort/2018/2018A/Ja0642018.pdf
     2019-05-01:
     - title: Décret gouvernemental n°2019-454 du 28 mai 2019
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2019/décret_2019_454_fr.pdf?ref_type=heads
@@ -364,24 +364,24 @@ metadata:
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2019/décret_2019_454_ar.pdf
     2020-10-01:
     - title: Décret gouvernemental n° 2020-1069 du 30 décembre 2020 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2020/décret_2020_1069_fr.pdf
+      href: https://www.pist.tn/jort/2021/2021F/Jo0012021.pdf
     - title: امر حكومي عدد 1069 لسنة 2020 مؤرخ في 30 ديسمبر 2020 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2020/décret_2020_1069_ar.pdf
+      href: https://www.pist.tn/jort/2021/2021A/Ja0012021.pdf
     2022-10-01:
     - title: Décret gouvernemental n°2022-769 du 19 octobre 2022 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2022/décret_2022_769_fr.pdf?ref_type=heads
+      href: https://www.pist.tn/jort/2022/2022F/Jo1142022.pdf
     - title: امر عدد 769 لسنة 2022 مؤرخ في 19 أكتوبر 2022 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2022/décret_2022_769_ar.pdf
+      href: https://www.pist.tn/jort/2022/2022A/Ja1142022.pdf
     2024-05-01:
     - title: Décret n°2024-419 du 09 juillet 2024  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/décret_2024_419_fr.pdf
+      href: https://www.pist.tn/jort/2024/2024F/Jo0852024.pdf
     - title: امر عدد 419 لسنة 2024 مؤرخ في 9 جويلية 2024 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/décret_2024_419_ar.pdf
+      href: https://www.pist.tn/jort/2024/2024A/Ja0852024.pdf
     2025-01-01:
     - title: Décret n°2024-419 du 09 juillet 2024 , fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/décret_2024_419_fr.pdf
+      href: https://www.pist.tn/jort/2024/2024F/Jo0852024.pdf
     - title: امر عدد 419 لسنة 2024 مؤرخ في 9 جويلية 2024 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/décret_2024_419_ar.pdf
+      href: https://www.pist.tn/jort/2024/2024A/Ja0852024.pdf
     2026-01-01:
     - title: "Décret n° 2026-67 du 30 avril 2026, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
       href: https://www.pist.tn/jort/2026/2026F/Jo0442026.pdf

--- a/openfisca_tunisia/parameters/marche_travail/smig_48h_horaire.yaml
+++ b/openfisca_tunisia/parameters/marche_travail/smig_48h_horaire.yaml
@@ -34,12 +34,8 @@ values:
     value: 0.505
   1988-04-01:
     value: 0.529
-  1989-08-01:
-    value: 0.543
   1990-01-01:
-    value: 0.591
-  1991-08-01:
-    value: 0.601
+    value: 0.577
   1992-05-01:
     value: 0.639
   1992-08-01:
@@ -110,6 +106,12 @@ values:
     value: 2.363
   2025-01-01:
     value: 2.54
+  2026-01-01:
+    value: 2.667
+  2027-01-01:
+    value: 2.8
+  2028-01-01:
+    value: 2.94
 metadata:
   unit: currency
   reference:
@@ -198,26 +200,18 @@ metadata:
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/décret_88_889_fr.pdf
     - title: امر عدد   889  لسنة  1988  مؤرخ في 5 ماي 1988 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/décret_88_889_ar.pdf
-    1989-08-01:
-    - title: Décret n°89-1551 du 06 octobre 1989 portant octroi d'une indemnité spéciale au profit des travailleurs payés au salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1989/décret_89_1551_fr.pdf
-    - title: لمجلة الشغل أمر عدد 1551 لسنة 1989 مؤرخ في 6 أكتوبر 1989 يتعلق باسناد منحة خاصة لفائدة العملة الخالصين بالاجر الأدنى المضمون لمختلف المهن ، المشتغلين بالقطاعات غير الفلاحية والخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1989/décret_89_1551_ar.pdf
     1990-01-01:
-    - title: Décret n°90-246 du 05 février 1990 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1990/décret_90_246_fr.pdf
-    - title: أمر عدد 246 لسنة 1990  مؤرخ في 5 فيفري 1990 يتعلّق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1990/décret_90_246_ar.pdf
-    1991-08-01:
-    - title: Décret n°91-1316 du 02 septembre 1991 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1991/décret_91_1316_fr.pdf
-    - title: امر عدد   1316  لسنة  1991  مؤرخ في 2 سبتمبر     1991  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1991/décret_91_1316_ar.pdf
+    - title: "Décret n° 90-246 du 5 février 1990, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
+      href: https://www.pist.tn/jort/1990/1990F/Jo01390.pdf
+      note: "JORT n° 13 du 16 février 1990, p. 252. Article premier : le SMIG est fixé à 120,016 dinars et à 104,706 dinars par mois et à 577 millimes et 604 millimes l'heure, respectivement pour les régimes de 48 heures et de 40 heures. Article 7 : effet à compter du 1er janvier 1990. Ce montant ne comprend pas l'indemnité spéciale du décret n° 89-1551 (3 dinars par mois ; 14 millimes l'heure en 48 heures, 17 millimes en 40 heures), qui subsiste à côté du SMIG et figure dans marche_travail.indemnite_speciale_smig. Jusqu'au 1er janvier 1990 exclu, le SMIG reste celui du décret n° 88-889 : le décret n° 89-1551 ne le modifie pas."
+    - title: "أمر عدد 246 لسنة 1990 مؤرخ في 5 فيفري 1990 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل"
+      href: https://www.pist.tn/jort/1990/1990A/Ja01390.pdf
     1992-05-01:
-    - title: Décret n°92-1299 du 13 juillet 1992 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1299_fr.pdf
-    - title: امر عدد 1299    لسنة  1992  مؤرخ في  13 جويلية 1992 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1299_ar.pdf
+    - title: "Décret n° 92-1299 du 13 juillet 1992, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, articles premier et 3"
+      href: https://www.pist.tn/jort/1992/1992F/Jo04992.pdf
+      note: "JORT n° 49 du 28 juillet 1992, pp. 935-936. Article premier : le SMIG est fixé à 132,912 dinars et à 116,318 dinars par mois et à 639 millimes et 671 millimes l'heure, respectivement pour les régimes de 48 heures et de 40 heures. Article 3 : ce SMIG « comprend l'indemnité spéciale fixée par le décret sus-visé n° 91-1316 du 2 septembre 1991 » (5 dinars par mois), que l'article 8 abroge. Article 9 : effet à compter du 1er mai 1992. La hausse de 120,016 à 132,912 dinars (48 heures) intègre donc ces 5 dinars. Un rectificatif est publié au JORT n° 55 du 21 août 1992, p. 1067 (non lu)."
+    - title: "أمر عدد 1299 لسنة 1992 مؤرخ في 13 جويلية 1992 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل"
+      href: https://www.pist.tn/jort/1992/1992A/Ja04992.pdf
     1992-08-01:
     - title: Décret n°92-1630 du 07 septembre 1992 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1630_fr.pdf
@@ -388,6 +382,24 @@ metadata:
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/décret_2024_419_fr.pdf
     - title: امر عدد 419 لسنة 2024 مؤرخ في 9 جويلية 2024 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/décret_2024_419_ar.pdf
+    2026-01-01:
+    - title: "Décret n° 2026-67 du 30 avril 2026, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
+      href: https://www.pist.tn/jort/2026/2026F/Jo0442026.pdf
+      note: "JORT n° 44 du 30 avril 2026, pp. 838-839. Article premier, point 1 : à compter du 1er janvier 2026, le SMIG est fixé à 554,736 dinars (48 heures) et à 470,251 dinars (40 heures) par mois, et à 2,667 dinars (48 heures) et à 2,713 dinars (40 heures) l'heure ; il comprend l'indemnité complémentaire provisoire. Article 6 : l'augmentation du SMIG s'applique aux pensions de retraite servies par la Caisse nationale de sécurité sociale."
+    - title: "أمر عدد 67 لسنة 2026 مؤرخ في 30 أفريل 2026 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل"
+      href: https://www.pist.tn/jort/2026/2026A/Ja0442026.pdf
+    2027-01-01:
+    - title: "Décret n° 2026-67 du 30 avril 2026, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
+      href: https://www.pist.tn/jort/2026/2026F/Jo0442026.pdf
+      note: "JORT n° 44 du 30 avril 2026, pp. 838-839. Article premier, point 2 : à compter du 1er janvier 2027, le SMIG est fixé à 582,400 dinars (48 heures) et à 493,304 dinars (40 heures) par mois, et à 2,800 dinars (48 heures) et à 2,846 dinars (40 heures) l'heure ; il comprend l'indemnité complémentaire provisoire. Article 6 : l'augmentation du SMIG s'applique aux pensions de retraite servies par la Caisse nationale de sécurité sociale."
+    - title: "أمر عدد 67 لسنة 2026 مؤرخ في 30 أفريل 2026 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل"
+      href: https://www.pist.tn/jort/2026/2026A/Ja0442026.pdf
+    2028-01-01:
+    - title: "Décret n° 2026-67 du 30 avril 2026, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
+      href: https://www.pist.tn/jort/2026/2026F/Jo0442026.pdf
+      note: "JORT n° 44 du 30 avril 2026, pp. 838-839. Article premier, point 3 : à compter du 1er janvier 2028, le SMIG est fixé à 611,520 dinars (48 heures) et à 517,571 dinars (40 heures) par mois, et à 2,940 dinars (48 heures) et à 2,986 dinars (40 heures) l'heure ; il comprend l'indemnité complémentaire provisoire. Article 6 : l'augmentation du SMIG s'applique aux pensions de retraite servies par la Caisse nationale de sécurité sociale."
+    - title: "أمر عدد 67 لسنة 2026 مؤرخ في 30 أفريل 2026 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل"
+      href: https://www.pist.tn/jort/2026/2026A/Ja0442026.pdf
 documentation: |-
   Salaire minimum interprofessionnel garanti (Smig) dans les secteurs non agricoles pour les travailleurs des deux sexes âgés de 18 ans au moins
   الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية للعمال من الجنسين البالغين من العمر 18 سنة على الأقل

--- a/openfisca_tunisia/parameters/marche_travail/smig_48h_mensuel.yaml
+++ b/openfisca_tunisia/parameters/marche_travail/smig_48h_mensuel.yaml
@@ -117,89 +117,89 @@ metadata:
   reference:
     1961-04-01:
     - title: Décret n°61-145 du 30 mars 1961 relative à la majoration générale des salaires
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1961/décret_61_145_fr.pdf
+      href: https://www.pist.tn/jort/1961/1961F/Jo01261.pdf
     - title: امر عدد  145 لسنة    1961 مؤرخ  في  30 مارس 1961  يتعلق بالترفيع العام الاجور
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1961/déxret_61_145_ar.pdf
+      href: https://www.pist.tn/jort/1961/1961A/Ja01261.pdf
     1966-01-01:
     - title: Décret n°65-561 du 31 décembre 1965  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1965/décret_65_561_fr.pdf
+      href: https://www.pist.tn/jort/1965/1965F/Jo06665.pdf
     - title: امر عدد  561 لسنة   1965  مؤرخ  في 31 ديسمبر 1965    يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1965/décret_65_561_ar.pdf
+      href: https://www.pist.tn/jort/1965/1965A/Ja06665.pdf
     1968-05-01:
     - title: Décret n°68-97 du 15 avril 1969  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1968/décret_68_97_fr.pdf
+      href: https://www.pist.tn/jort/1968/1968F/Jo01668.pdf
     - title: امر عدد 97   لسنة   1968  مؤرخ  في 15 افريل 1968  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1968/décret_68_97_ar.pdf
+      href: https://www.pist.tn/jort/1968/1968A/Ja01668.pdf
     1971-05-01:
     - title: Décret n°71-164 du 03 mai 1971 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1971/décret_71_164_fr.pdf
+      href: https://www.pist.tn/jort/1971/1971F/Jo02071.pdf
     - title: امر عدد 164 لسنة   1971  مؤرخ  في 3 ماي 1971  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1971/décret_71_164_ar.pdf
+      href: https://www.pist.tn/jort/1971/1971A/Ja02071.pdf
     1974-01-01:
     - title: Décret n°74-63 du 31 janvier 1974 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1974/décret_74_63_fr.pdf
+      href: https://www.pist.tn/jort/1974/1974F/Jo01074.pdf
     - title: امر عدد 63  لسنة  1974   مؤرخ  في   31 جانفي 1974   يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1974/décret_74_63_ar.pdf
+      href: https://www.pist.tn/jort/1974/1974A/Ja01074.pdf
     1975-06-01:
     - title: Décret n°75-357 du 03 Juin 1975 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1975/décret_75_357_fr.pdf
+      href: https://www.pist.tn/jort/1975/1975F/Jo03875.pdf
     - title: امر عدد  357 لسنة    1975 مؤرخ  في   3 جوان 1975  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1975/décret_75_357_ar.pdf
+      href: https://www.pist.tn/jort/1975/1975A/Ja03875.pdf
     1977-02-01:
     - title: Décret n°77-115 du 02 février 1977 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1977/décret_77_115_fr.pdf
+      href: https://www.pist.tn/jort/1977/1977F/Jo00977.pdf
     - title: امر عدد 115  لسنة    1977 مؤرخ  في  2 فيفري 1977  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1977/décret_77_115_ar.pdf
+      href: https://www.pist.tn/jort/1977/1977A/Ja00977.pdf
     1978-05-01:
     - title: Décret n°78-441 du 26 avril 1978 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1978/décret_78_441_fr.pdf
+      href: https://www.pist.tn/jort/1978/1978F/Jo03378.pdf
     - title: امر عدد   441  لسنة    1978 مؤرخ 26 أفريل 1978   يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1978/décret_78_441_ar.pdf
+      href: https://www.pist.tn/jort/1978/1978A/Ja03378.pdf
     1979-05-01:
     - title: Décret n°79-473 du 21 mai 1979 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1979/décret_79_473_fr.pdf
+      href: https://www.pist.tn/jort/1979/1979F/Jo03479.pdf
     - title: امر عدد   473 لسنة    1979 مؤرخ في    21 ماي 1979   يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1979/décret_79_473_ar.pdf
+      href: https://www.pist.tn/jort/1979/1979A/Ja03479.pdf
     1980-02-01:
     - title: Décret n°80-75 du 21 janvier 1980 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1980/décret_80_75_fr.pdf
+      href: https://www.pist.tn/jort/1980/1980F/Jo00580.pdf
     - title: امر عدد   75  لسنة    1980 مؤرخ في    21 جانفي 1980   يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1980/décret_80_75_ar.pdf
+      href: https://www.pist.tn/jort/1980/1980A/Ja00580.pdf
     1980-05-01:
     - title: Décret n°80-609 du 19 Mai 1980 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1980/décret_80_609_fr.pdf
+      href: https://www.pist.tn/jort/1980/1980F/Jo03180.pdf
     - title: امر عدد  609   لسنة   1980 مؤرخ في    19 ماي 1980    يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1980/décret_80_609_ar.pdf
+      href: https://www.pist.tn/jort/1980/1980A/Ja03180.pdf
     1981-04-01:
     - title: Décret n°81-437 du 07 avril 1981 instituant une indemnité complémentaire provisoire  dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1981/décret_81_437_fr.pdf
+      href: https://www.pist.tn/jort/1981/1981F/Jo02581.pdf
     - title: امر عدد  437  لسنة  1981   مؤرخ في   7 افريل 1981    يتعلق بإحداث منحة اضافية مؤقتة  في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1981/décret_81_437_ar.pdf
+      href: https://www.pist.tn/jort/1981/1981A/Ja02581.pdf
     1982-02-01:
     - title: Décret n°82-501 du 16 mars 1982 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1982/décret_82_501_fr.pdf?ref_type=heads
+      href: https://www.pist.tn/jort/1982/1982F/Jo01982.pdf
     - title: امر عدد    501 لسنة  1982  مؤرخ في    16 مارس 1982   يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1982/décret_82_501_ar.pdf
+      href: https://www.pist.tn/jort/1982/1982A/Ja01982.pdf
     1983-01-01:
     - title: Décret n°83-509 du 04 juin 1983 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1983/décret_83_509_fr.pdf
+      href: https://www.pist.tn/jort/1983/1983F/Jo04283.pdf
     - title: امر عدد   509  لسنة   1983 مؤرخ في   4 جوان 1983  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1983/décret_83_509_ar.pdf
+      href: https://www.pist.tn/jort/1983/1983A/Ja04283.pdf
     1986-07-01:
     - title: Décret n°86-689 du 20 juillet 1986 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1986/décret_86_689_fr.pdf
+      href: https://www.pist.tn/jort/1986/1986F/Jo04186.pdf
     - title: امر عدد  689 لسنة 1986  مؤرخ في 20 جويلية 1986 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1986/décret_86_689_ar.pdf
+      href: https://www.pist.tn/jort/1986/1986A/Ja04186.pdf
     1987-11-01:
     - title: Décret n°87-1277 du 05 novembre 1987 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1987/décret_87_1277_fr.pdf
+      href: https://www.pist.tn/jort/1987/1987F/Jo07887.pdf
     - title: امر عدد  1277   لسنة  1987  مؤرخ في    5 توفمبر 1987   يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1987/décret_87_1277_ar.pdf
+      href: https://www.pist.tn/jort/1987/1987A/Ja07887.pdf
     1988-04-01:
     - title: Décret n°88-889 du 05 mai 1988 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/décret_88_889_fr.pdf
+      href: https://www.pist.tn/jort/1988/1988F/Jo03188.pdf
     - title: امر عدد   889  لسنة  1988  مؤرخ في 5 ماي 1988 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/décret_88_889_ar.pdf
+      href: https://www.pist.tn/jort/1988/1988A/Ja03188.pdf
     1990-01-01:
     - title: "Décret n° 90-246 du 5 février 1990, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
       href: https://www.pist.tn/jort/1990/1990F/Jo01390.pdf
@@ -214,149 +214,149 @@ metadata:
       href: https://www.pist.tn/jort/1992/1992A/Ja04992.pdf
     1992-08-01:
     - title: Décret n°92-1630 du 07 septembre 1992  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1630_fr.pdf
+      href: https://www.pist.tn/jort/1992/1992F/Jo06392.pdf
     - title: امر عدد 1630    لسنة  1992  مؤرخ في  7 سبتمبر 1992 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1630_ar.pdf
+      href: https://www.pist.tn/jort/1992/1992A/Ja06392.pdf
     1993-05-01:
     - title: Décret n°93-1256 du 07 juin 1993  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/décret_93_1256_fr.pdf
+      href: https://www.pist.tn/jort/1993/1993F/Jo04493.pdf
     - title: أمر عدد   1256  لسنة  1993  مؤرخ في 7 جوان 1993  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/décret_93_1256_ar.pdf
+      href: https://www.pist.tn/jort/1993/1993A/Ja04493.pdf
     1993-08-01:
     - title: Décret n°93-1838 du 06 septembre 1993  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/décret_93_1838_fr.pdf
+      href: https://www.pist.tn/jort/1993/1993F/Jo06993.pdf
     - title: أمر عدد  1838   لسنة  1993  مؤرخ في  6 سبتمبر 1993 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/décret_93_1838_ar.pdf
+      href: https://www.pist.tn/jort/1993/1993A/Ja06993.pdf
     1994-08-01:
     - title: Décret n°94-1804 du 29 août 1994 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1994/décret_94_1804_fr.pdf
+      href: https://www.pist.tn/jort/1994/1994F/Jo07194.pdf
     - title: أمر عدد   1804  لسنة   1995   مؤرخ في 29 اوت  1995  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1994/décret_94_1804_ar.pdf
+      href: https://www.pist.tn/jort/1994/1994A/Ja07194.pdf
     1995-05-01:
     - title: Décret n°95-900 du 15 mai 1995  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1995/décret_95_900_fr.pdf
+      href: https://www.pist.tn/jort/1995/1995F/Jo04095.pdf
     - title: أمر عدد  900   لسنة   1995   مؤرخ في 15 ماي 1995  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1995/décret_95_900_ar.pdf
+      href: https://www.pist.tn/jort/1995/1995A/Ja04095.pdf
     1996-05-01:
     - title: Décret n°96-1013 du 27 mai 1996 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1996/décret_96_1013_fr.pdf
+      href: https://www.pist.tn/jort/1996/1996F/Jo04596.pdf
     - title: أمر عدد   1013  لسنة  1996 مؤرخ في 27 ماي يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1996/décret_96_1013_ar.pdf
+      href: https://www.pist.tn/jort/1996/1996A/Ja04596.pdf
     1996-09-09:
     - title: Décret n°96-1547 du 10 septembre 1996 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1996/décret_96_1547_fr.pdf
+      href: https://www.pist.tn/jort/1996/1996F/Jo07496.pdf
     - title: أمر عدد   1547  لسنة  1996    مؤرخ في  10 سبتمبر 1996 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1996/décret_96_1547_ar.pdf
+      href: https://www.pist.tn/jort/1996/1996A/Ja07496.pdf
     1997-07-20:
     - title: Décret n°97-1521 du 04 août 1997 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1997/décret_97_1521_fr.pdf
+      href: https://www.pist.tn/jort/1997/1997F/Jo06397.pdf
     - title: أمر عدد   1521  لسنة  1997  مؤرخ في  4  اوت 1997 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1997/décret_97_1521_ar.pdf
+      href: https://www.pist.tn/jort/1997/1997A/Ja06397.pdf
     1997-11-07:
     - title: Décret n°97-2148 du 12 novembre 1997 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1997/décret_97_2148_fr.pdf
+      href: https://www.pist.tn/jort/1997/1997F/Jo09397.pdf
     - title: أمر عدد   2148 لسنة 1997 مؤرخ في 12 نوفبر 1977 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1997/décret_97_2148_ar.pdf
+      href: https://www.pist.tn/jort/1997/1997A/Ja09397.pdf
     1998-08-20:
     - title: Décret n°98-1674 du 26 août 1998 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1998/Décret_1998_1674_fr.pdf
+      href: https://www.pist.tn/jort/1998/1998F/Jo07198.pdf
     - title: أمر عدد 1674 لسنة 1998 مؤرخ في 26 أوت 1998 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1998/Décret_1998_1674_ar.pdf
+      href: https://www.pist.tn/jort/1998/1998A/Ja07198.pdf
     1999-05-01:
     - title: Décret n°99-994 du 10 mai 1999  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1999/Décret_1999_994_fr.pdf
+      href: https://www.pist.tn/jort/1999/1999F/Jo03899.pdf
     - title: أمر عدد 994 لسنة 1999 مؤرخ في 8 ماي 1999 يتعلّق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1999/Décret_1999_994_ar.pdf
+      href: https://www.pist.tn/jort/1999/1999A/Ja03899.pdf
     1999-08-19:
     - title: Décret n°99-1866 du 31 août 1999  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1999/Décret_1999_1866_fr.pdf
+      href: https://www.pist.tn/jort/1999/1999F/Jo07499.pdf
     - title: أمر عدد 1866 لسنة 1999 مؤرخ في 30 أوت 1999 يتعلّق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1999/Décret_1999_1866_ar.pdf
+      href: https://www.pist.tn/jort/1999/1999A/Ja07499.pdf
     2000-05-01:
     - title: Décret n°2000-949 du 11 mai 2000 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2000/Décret_2000_949_fr.pdf
+      href: https://www.pist.tn/jort/2000/2000F/Jo0382000.pdf
     - title: أمر عدد 949 لسنة 2000 مؤرخ في 11 ماي 2000 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2000/Décret_2000_949_ar.pdf
+      href: https://www.pist.tn/jort/2000/2000A/Ja03800.pdf
     2001-07-01:
     - title: Décret n°2001-1746 du 01 août 2001 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/Décret_2001_1746_fr.pdf
+      href: https://www.pist.tn/jort/2001/2001F/Jo0632001.pdf
     - title: أمر عدد 1746 لسنة 2001 مؤرخ في أول أوت 2001 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/Décret_2001_1746_ar.pdf
+      href: https://www.pist.tn/jort/2001/2001A/Ja0632001.pdf
     2002-07-01:
     - title: Décret n°2002-1790 du 12 août 2002 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2002/Décret_2002_1790_fr.pdf
+      href: https://www.pist.tn/jort/2002/2002F/Jo0672002.pdf
     - title: أمر عدد 1790 لسنة 2002 مؤرخ في 12 أوت 2002 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2002/Décret_2002_1790_ar.pdf
+      href: https://www.pist.tn/jort/2002/2002A/Ja0672002.pdf
     2003-07-01:
     - title: Décret n°2003-1691 du 18 août 2003 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2003/Décret_2003_1691_fr.pdf
+      href: https://www.pist.tn/jort/2003/2003F/Jo0672003.pdf
     - title: أمر عدد 1691 لسنة 2003 مؤرخ في 18 أوت 2003 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2003/Décret_2003_1691_ar.pdf
+      href: https://www.pist.tn/jort/2003/2003A/Ja0672003.pdf
     2004-07-01:
     - title: Décret n°2004-1803 du 02 août 2004 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2004/Décret_2004_1803_fr.pdf
+      href: https://www.pist.tn/jort/2004/2004F/Jo0632004.pdf
     - title: أمر عدد 1803 لسنة 2004 مؤرخ في 2 أوت 2004 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2004/Décret_2004_1803_ar.pdf
+      href: https://www.pist.tn/jort/2004/2004A/Ja0632004.pdf
     2005-09-01:
     - title: Décret n°2005-2320 du 22 août 2005 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2005/Décret_2005_2320_fr.pdf
+      href: https://www.pist.tn/jort/2005/2005F/Jo0682005.pdf
     - title: أمر عدد 2320 لسنة 2005 مؤرخ في 22 أوت 2005 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2005/Décret_2005_2320_ar.pdf
+      href: https://www.pist.tn/jort/2005/2005A/Ja0682005.pdf
     2006-07-01:
     - title: Décret n°2006-2098 du 24 juillet 2006 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2006/Décret_2006_2098_fr.pdf
+      href: https://www.pist.tn/jort/2006/2006F/Jo0622006.pdf
     - title: أمر عدد 2098 لسنة 2006 مؤرخ في 24 جويلية 2006 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2006/Décret_2006_2098_ar.pdf
+      href: https://www.pist.tn/jort/2006/2006A/Ja0622006.pdf
     2007-07-01:
     - title: Décret n°2007-2079 du 14 août 2007  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/Décret_2007_2079_fr.pdf
+      href: https://www.pist.tn/jort/2007/2007F/Jo0672007.pdf
     - title: أمر عدد 2079 لسنة 2007 مؤرخ في 14 أوت 2007 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/Décret_2007_2079_ar.pdf
+      href: https://www.pist.tn/jort/2007/2007A/Ja0672007.pdf
     2008-07-01:
     - title: Décret n°2008-2072 du 02 juin 2008 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2008/Décret_2008_2072_fr.pdf
+      href: https://www.pist.tn/jort/2008/2008F/Jo0462008.pdf
     - title: أمر عدد 2072 لسنة 2008 مؤرخ في 2 جوان 2008 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2008/Décret_2008_2072_ar.pdf
+      href: https://www.pist.tn/jort/2008/2008A/Ja0462008.pdf
     2009-08-01:
     - title: Décret n°2009-2257 du 14 juillet 2009  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2009/Décret_2009_2257_fr.pdf
+      href: https://www.pist.tn/jort/2009/2009F/Jo0622009.pdf
     - title: أمر عدد 2257 لسنة 2009 مؤرخ في 14 جويلية 2009 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2009/Décret_2009_2257_ar.pdf
+      href: https://www.pist.tn/jort/2009/2009A/Ja0622009.pdf
     2010-07-01:
     - title: Décret n°2010-1746 du 17 juillet 2010  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2010/Décret_2010_1746_fr.pdf
+      href: https://www.pist.tn/jort/2010/2010F/Jo0582010.pdf
     - title: أمر عدد 1746 لسنة 2010 مؤرخ في 17 جويلية 2010 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2010/Décret_2010_1746_ar.pdf
+      href: https://www.pist.tn/jort/2010/2010A/Ja0582010.pdf
     2011-05-01:
     - title: Décret n°2011-679 du 09 juin 2011 fixant le  salaire minimum interprofessionnel garanti  dans les secteurs non agricoles régis par le  code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2011/Décret_2011_679_fr.pdf
+      href: https://www.pist.tn/jort/2011/2011F/Jo0422011.pdf
     - title: أمر عدد 679 لسنة 2011 مؤرخ في 9 جوان 2011 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2011/Décret_2011_679_ar.pdf
+      href: https://www.pist.tn/jort/2011/2011A/Ja0422011.pdf
     2012-07-01:
     - title: Décret n°2012-1981 du 20 septembre 2012 fixant le  salaire minimum interprofessionnel garanti  dans les secteurs non agricoles régis par le  code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2012/Décret_2012_1981_fr.pdf
+      href: https://www.pist.tn/jort/2012/2012F/Jo0772012.pdf
     - title: امر عدد  437  لسنة  1981   مؤرخ في   7 افريل 1981    يتعلق بإحداث منحة اضافية مؤقتة  في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2012/Décret_2012_1981_ar.pdf
+      href: https://www.pist.tn/jort/2012/2012A/Ja0772012.pdf
     2014-05-01:
     - title: Décret n°2014-2907 du 11 août 2014, fixant le  salaire minimum interprofessionnel garanti  dans les secteurs non agricoles régis par le  code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2014/Décret_2014_2907_fr.pdf
+      href: https://www.pist.tn/jort/2014/2014F/Jo0662014.pdf
     - title: أمر عدد 2907 لسنة 2014 مؤرخ في 11 أوت 2014 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2014/Décret_2014_2907_ar.pdf
+      href: https://www.pist.tn/jort/2014/2014A/Ja0662014.pdf
     2015-05-01:
     - title: Décret n°2015-1762 du 09 novembre 2015 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2015/décret_2015_1762_fr.pdf
+      href: https://www.pist.tn/jort/2015/2015F/Jo0912015.pdf
     - title: امر حكومي عدد 1762 لسنة 2015 مؤرخ في 9 نوفمبر 2015 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2015/décret_2015_1762_ar.pdf
+      href: https://www.pist.tn/jort/2015/2015A/Ja0912015.pdf
     2016-08-01:
     - title: Décret n°2017-668 du 05 juin 2017 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2017/Décret_2017_668_fr.pdf
+      href: https://www.pist.tn/jort/2017/2017F/Jo0452017.pdf
     - title: امر حكومي عدد 668 لسنة 2017 مؤرخ في 5 جوان 2017 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2017/Décret_2017_668_ar.pdf
+      href: https://www.pist.tn/jort/2017/2017A/Ja0452017.pdf
     2018-05-01:
     - title: Décret gouvernemental n°2018-672 du 07 août 2018
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2018/Décret_2018_672_fr.pdf
+      href: https://www.pist.tn/jort/2018/2018F/Jo0642018.pdf
     - title: امر حكومي عدد 672 لسنة 2018 مؤرخ في 7 أوت 2018 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2018/Décret_2018_672_ar.pdf
+      href: https://www.pist.tn/jort/2018/2018A/Ja0642018.pdf
     2019-05-01:
     - title: Décret gouvernemental n°2019-454 du 28 mai 2019 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2020/Décret_2020_1069_fr.pdf
@@ -364,24 +364,24 @@ metadata:
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2020/Décret_2020_1069_fr.pdf
     2020-10-01:
     - title: Décret gouvernemental n° 2020-1069 du 30 décembre 2020 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2020/Décret_2020_1069_fr.pdf
+      href: https://www.pist.tn/jort/2021/2021F/Jo0012021.pdf
     - title: امر حكومي عدد 1069 لسنة 2020 مؤرخ في 30 ديسمبر 2020 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2020/Décret_2020_1069_ar.pdf
+      href: https://www.pist.tn/jort/2021/2021A/Ja0012021.pdf
     2022-10-01:
     - title: Décret gouvernemental n°2022-769 du 19 octobre 2022 , fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2022/Décret_2022_769_fr.pdf
+      href: https://www.pist.tn/jort/2022/2022F/Jo1142022.pdf
     - title: امر حكومي عدد 1069 لسنة 2020 مؤرخ في 30 ديسمبر 2020 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2022/Décret_2022_769_ar.pdf
+      href: https://www.pist.tn/jort/2022/2022A/Ja1142022.pdf
     2024-05-01:
     - title: Décret n°2024-419 du 09 juillet 2024 , fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/Décret_2024_419_fr.pdf
+      href: https://www.pist.tn/jort/2024/2024F/Jo0852024.pdf
     - title: امر عدد 419 لسنة 2024 مؤرخ في 9 جويلية 2024 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/Décret_2024_419_ar.pdf
+      href: https://www.pist.tn/jort/2024/2024A/Ja0852024.pdf
     2025-01-01:
     - title: Décret n°2024-419 du 09 juillet 2024  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/Décret_2024_419_fr.pdf
+      href: https://www.pist.tn/jort/2024/2024F/Jo0852024.pdf
     - title: امر عدد 419 لسنة 2024 مؤرخ في 9 جويلية 2024 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/Décret_2024_419_ar.pdf
+      href: https://www.pist.tn/jort/2024/2024A/Ja0852024.pdf
     2026-01-01:
     - title: "Décret n° 2026-67 du 30 avril 2026, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
       href: https://www.pist.tn/jort/2026/2026F/Jo0442026.pdf

--- a/openfisca_tunisia/parameters/marche_travail/smig_48h_mensuel.yaml
+++ b/openfisca_tunisia/parameters/marche_travail/smig_48h_mensuel.yaml
@@ -34,12 +34,8 @@ values:
     value: 105.04
   1988-04-01:
     value: 110.032
-  1989-08-01:
-    value: 113.032
   1990-01-01:
-    value: 123.016
-  1991-08-01:
-    value: 125.016
+    value: 120.016
   1992-05-01:
     value: 132.912
   1992-08-01:
@@ -110,6 +106,12 @@ values:
     value: 491.504
   2025-01-01:
     value: 528.32
+  2026-01-01:
+    value: 554.736
+  2027-01-01:
+    value: 582.4
+  2028-01-01:
+    value: 611.52
 metadata:
   unit: currency
   reference:
@@ -198,26 +200,18 @@ metadata:
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/décret_88_889_fr.pdf
     - title: امر عدد   889  لسنة  1988  مؤرخ في 5 ماي 1988 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/décret_88_889_ar.pdf
-    1989-08-01:
-    - title: Décret n°89-1551 du 06 octobre 1989 portant octroi d'une indemnité spéciale au profit des travailleurs payés au salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1989/décret_89_1551_fr.pdf
-    - title: أمر عدد 1551 لسنة 1989 مؤرخ في 6 أكتوبر 1989 يتعلق باسناد منحة خاصة لفائدة العملة الخالصين بالاجر الأدنى المضمون لمختلف المهن ، المشتغلين بالقطاعات غير الفلاحية والخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1989/décret_89_1551_ar.pdf
     1990-01-01:
-    - title: Décret n°90-246 du 05 février 1990 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1990/décret_90_246_fr.pdf
-    - title: أمر عدد 246 لسنة 1990  مؤرخ في 5 فيفري 1990 يتعلّق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1990/décret_90_246_ar.pdf
-    1991-08-01:
-    - title: Décret n°91-1316 du 02 septembre 1991  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1991/décret_91_1316_fr.pdf
-    - title: امر عدد   1316  لسنة  1991  مؤرخ في 2 سبتمبر     1991  يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1991/décret_91_1316_ar.pdf
+    - title: "Décret n° 90-246 du 5 février 1990, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
+      href: https://www.pist.tn/jort/1990/1990F/Jo01390.pdf
+      note: "JORT n° 13 du 16 février 1990, p. 252. Article premier : le SMIG est fixé à 120,016 dinars et à 104,706 dinars par mois et à 577 millimes et 604 millimes l'heure, respectivement pour les régimes de 48 heures et de 40 heures. Article 7 : effet à compter du 1er janvier 1990. Ce montant ne comprend pas l'indemnité spéciale du décret n° 89-1551 (3 dinars par mois ; 14 millimes l'heure en 48 heures, 17 millimes en 40 heures), qui subsiste à côté du SMIG et figure dans marche_travail.indemnite_speciale_smig. Jusqu'au 1er janvier 1990 exclu, le SMIG reste celui du décret n° 88-889 : le décret n° 89-1551 ne le modifie pas."
+    - title: "أمر عدد 246 لسنة 1990 مؤرخ في 5 فيفري 1990 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل"
+      href: https://www.pist.tn/jort/1990/1990A/Ja01390.pdf
     1992-05-01:
-    - title: Décret n°92-1299 du 13 juillet 1992 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1299_fr.pdf
-    - title: امر عدد 1299    لسنة  1992  مؤرخ في  13 جويلية 1992 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1299_ar.pdf
+    - title: "Décret n° 92-1299 du 13 juillet 1992, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, articles premier et 3"
+      href: https://www.pist.tn/jort/1992/1992F/Jo04992.pdf
+      note: "JORT n° 49 du 28 juillet 1992, pp. 935-936. Article premier : le SMIG est fixé à 132,912 dinars et à 116,318 dinars par mois et à 639 millimes et 671 millimes l'heure, respectivement pour les régimes de 48 heures et de 40 heures. Article 3 : ce SMIG « comprend l'indemnité spéciale fixée par le décret sus-visé n° 91-1316 du 2 septembre 1991 » (5 dinars par mois), que l'article 8 abroge. Article 9 : effet à compter du 1er mai 1992. La hausse de 120,016 à 132,912 dinars (48 heures) intègre donc ces 5 dinars. Un rectificatif est publié au JORT n° 55 du 21 août 1992, p. 1067 (non lu)."
+    - title: "أمر عدد 1299 لسنة 1992 مؤرخ في 13 جويلية 1992 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل"
+      href: https://www.pist.tn/jort/1992/1992A/Ja04992.pdf
     1992-08-01:
     - title: Décret n°92-1630 du 07 septembre 1992  fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1992/décret_92_1630_fr.pdf
@@ -388,6 +382,24 @@ metadata:
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/Décret_2024_419_fr.pdf
     - title: امر عدد 419 لسنة 2024 مؤرخ في 9 جويلية 2024 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2024/Décret_2024_419_ar.pdf
+    2026-01-01:
+    - title: "Décret n° 2026-67 du 30 avril 2026, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
+      href: https://www.pist.tn/jort/2026/2026F/Jo0442026.pdf
+      note: "JORT n° 44 du 30 avril 2026, pp. 838-839. Article premier, point 1 : à compter du 1er janvier 2026, le SMIG est fixé à 554,736 dinars (48 heures) et à 470,251 dinars (40 heures) par mois, et à 2,667 dinars (48 heures) et à 2,713 dinars (40 heures) l'heure ; il comprend l'indemnité complémentaire provisoire. Article 6 : l'augmentation du SMIG s'applique aux pensions de retraite servies par la Caisse nationale de sécurité sociale."
+    - title: "أمر عدد 67 لسنة 2026 مؤرخ في 30 أفريل 2026 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل"
+      href: https://www.pist.tn/jort/2026/2026A/Ja0442026.pdf
+    2027-01-01:
+    - title: "Décret n° 2026-67 du 30 avril 2026, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
+      href: https://www.pist.tn/jort/2026/2026F/Jo0442026.pdf
+      note: "JORT n° 44 du 30 avril 2026, pp. 838-839. Article premier, point 2 : à compter du 1er janvier 2027, le SMIG est fixé à 582,400 dinars (48 heures) et à 493,304 dinars (40 heures) par mois, et à 2,800 dinars (48 heures) et à 2,846 dinars (40 heures) l'heure ; il comprend l'indemnité complémentaire provisoire. Article 6 : l'augmentation du SMIG s'applique aux pensions de retraite servies par la Caisse nationale de sécurité sociale."
+    - title: "أمر عدد 67 لسنة 2026 مؤرخ في 30 أفريل 2026 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل"
+      href: https://www.pist.tn/jort/2026/2026A/Ja0442026.pdf
+    2028-01-01:
+    - title: "Décret n° 2026-67 du 30 avril 2026, fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail, article premier"
+      href: https://www.pist.tn/jort/2026/2026F/Jo0442026.pdf
+      note: "JORT n° 44 du 30 avril 2026, pp. 838-839. Article premier, point 3 : à compter du 1er janvier 2028, le SMIG est fixé à 611,520 dinars (48 heures) et à 517,571 dinars (40 heures) par mois, et à 2,940 dinars (48 heures) et à 2,986 dinars (40 heures) l'heure ; il comprend l'indemnité complémentaire provisoire. Article 6 : l'augmentation du SMIG s'applique aux pensions de retraite servies par la Caisse nationale de sécurité sociale."
+    - title: "أمر عدد 67 لسنة 2026 مؤرخ في 30 أفريل 2026 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل"
+      href: https://www.pist.tn/jort/2026/2026A/Ja0442026.pdf
   official_journal_date:
     2022-10-01: "2022-10-21"
 documentation: |-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-Tunisia"
-version = "0.80"
+version = "0.81"
 description = "OpenFisca Rules as Code model for Tunisia."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "tunisia"]

--- a/uv.lock
+++ b/uv.lock
@@ -1524,7 +1524,7 @@ web-api = [
 
 [[package]]
 name = "openfisca-tunisia"
-version = "0.80"
+version = "0.81"
 source = { editable = "." }
 dependencies = [
     { name = "openfisca-core", extra = ["web-api"] },


### PR DESCRIPTION
## Constat

Contrôle de `parameters/marche_travail/` contre les fascicules du JORT (issue #403). Les 36 dates d'effet du SMIG lues entre 1981 et 2025 concordent. Les écarts portent sur trois points.

1. **Indemnités spéciales comptées comme salaire minimum (1989-1991).** Aux 1er août 1989, 1er janvier 1990 et 1er août 1991, les quatre séries du SMIG portaient le SMIG augmenté de l'indemnité spéciale : 123,016 D au lieu de 120,016 D en 1990 (48 heures, mensuel). Même chose pour le SMAG : 3,661 D au lieu de 3,546 D.
2. **Valeurs manquantes.** Le SMIG s'arrêtait au 1er janvier 2025 et le SMAG au 1er mai 2019.
3. **Dates et intitulés.** Trois valeurs du SMAG portaient la date de signature du décret (2014-08-11, 2015-11-09, 2017-06-05). L'intitulé du décret SMAG n° 2009-2258 était faux, et les références pointaient vers un dépôt GitLab personnel.

## Décision sur les indemnités spéciales

**Les paramètres `smig_*` et `smag_journalier` portent le SMIG et le SMAG légaux. L'indemnité reste dans `indemnite_speciale_smig` et `indemnite_speciale_smag`**, qui existaient déjà pour cela.

Ce choix repose sur le texte des décrets, lus au fascicule.

- L'indemnité n'est pas le SMIG. Le décret n° 89-1551 l'institue « au profit des travailleurs payés au salaire minimum interprofessionnel garanti » (art. 1er). Le décret n° 90-246 fixe ensuite le SMIG à 120,016 D sans la mentionner (JORT n° 13 du 16 février 1990, p. 252). Il faut attendre le décret n° 92-1299 pour que le SMIG « comprend[ne] l'indemnité spéciale » (art. 3), au 1er mai 1992.
- **Sécurité sociale.** « A titre exceptionnel, l'indemnité spéciale n'est pas prise en compte pour la détermination de l'assiette des cotisations et des prestations de sécurité sociale » : décret n° 89-1551, art. 5 ; n° 91-1316, art. 5 ; n° 89-1552, art. 4 ; n° 91-1317, art. 4.
- **Impôt.** Les retenues d'impôt sur les traitements et salaires, de CPE, de contribution de solidarité et au FOPROLOS « sont suspendus au titre de cette indemnité » (89-1551, art. 4 ; 89-1552, art. 3). Pour l'impôt sur le revenu, voir 91-1316, art. 4, et 91-1317, art. 3.

### Usages recensés

| Usage | Paramètre | Ce que vise le texte |
|---|---|---|
| `cotisations_sociales` : barème du régime des travailleurs à faible revenu (seuils en SMIG) | `smig_48h_mensuel` | cotisation de sécurité sociale, donc SMIG légal (et régime postérieur à 1992) |
| `retraite_complementaire_employeur` / `_salarie` : assiette au-delà de 6 SMIG | `smig_48h_mensuel` | cotisation, donc SMIG légal |
| `prestations_familiales` : enfant apprenti à moins de 75 % du SMIG ; crèche, 2,5 SMIG | `smig_48h_mensuel` | prestation de sécurité sociale, donc SMIG légal |
| `amen_social` : seuils de revenu (depuis 2020) | `smig_48h_mensuel` | SMIG légal, hors période |
| `tspr.smig` et `irpp.calcule_base_imposable` : indicatrice SMIG | `smig_40h_mensuel` | impôt, donc SMIG légal (retenue suspendue sur l'indemnité) |
| hors paquet, `openfisca-tunisia-pension` : pension minimale CNRPS et RSNA ; RSA | `smig_40h_mensuel`, `marche_travail.smag` | prestation, donc SMIG ou SMAG légal |

Aucun usage ne vise la rémunération minimale effectivement servie. Les deux notions restent donc séparées, sans nouveau paramètre.

## Valeurs changées ou ajoutées

Toutes les dates ci-dessous sont des **dates d'effet énoncées par le texte**. Aucune n'a eu besoin de la règle supplétive (jour franc ou cinq jours après la publication).

| Paramètre | Date | Avant | Après | Source |
|---|---|---|---|---|
| `smig_48h_mensuel` / `40h_mensuel` / `48h_horaire` / `40h_horaire` | 1989-08-01 | 113,032 / 99,386 / 0,543 / 0,573 | *supprimée* (le SMIG de 1988 reste en vigueur) | 89-1551 : indemnité, pas le SMIG |
| idem | 1990-01-01 | 123,016 / 107,706 / 0,591 / 0,621 | **120,016 / 104,706 / 0,577 / 0,604** | 90-246, art. 1er et 7, JORT n° 13/1990, p. 252 |
| idem | 1991-08-01 | 125,016 / 109,706 / 0,601 / 0,633 | *supprimée* (SMIG inchangé) | 91-1316 : indemnité portée à 5 D |
| idem | 2026-01-01 | — | 554,736 / 470,251 / 2,667 / 2,713 | 2026-67, art. 1er, JORT n° 44/2026, pp. 838-839 |
| idem | 2027-01-01 | — | 582,400 / 493,304 / 2,800 / 2,846 | idem |
| idem | 2028-01-01 | — | 611,520 / 517,571 / 2,940 / 2,986 | idem |
| `smag_journalier` | 1989-08-01 | 3,315 | *supprimée* | 89-1552 : indemnité de 115 millimes |
| idem | 1990-01-01 | 3,661 | **3,546** | 90-247, art. 1er et 6, JORT n° 13/1990, p. 252 |
| idem | 1991-08-01 | 3,761 | *supprimée* | 91-1317 : indemnité de 215 millimes |
| idem | 2014-08-11 → **2014-05-01** | 12,304 | 12,304 | 2014-2908, art. 6, JORT n° 66/2014, p. 2064 |
| idem | 2015-11-09 → **2015-05-01** | 13 | 13 | 2015-1763, art. 6, JORT n° 91/2015, pp. 2710-2711 |
| idem | 2017-06-05 → **2016-08-01** | 13,736 | 13,736 | 2017-669, art. 6, JORT n° 45/2017, éd. arabe p. 1878 |
| idem | 2020-10-01 | — | 16,512 | 2020-1070, art. 6, JORT n° 1/2021, p. 25 |
| idem | 2022-10-01 | — | 17,664 | 2022-768, art. 5, JORT n° 114/2022, pp. 2834-2835 |
| idem | 2024-05-01 | — | 18,904 | 2024-420, art. 1er et 5, JORT n° 85/2024, pp. 1802-1803 |
| idem | 2025-01-01 | — | 20,320 | idem |
| idem | 2026-01-01 / 2027-01-01 / 2028-01-01 | — | 21,336 / 22,400 / 23,520 | 2026-66, art. 1er, JORT n° 44/2026, p. 837 |
| `indemnite_speciale_smag` | 1990-01-01 | 0,115 (rattachée au décret 90-247) | *supprimée* : 90-247 ne touche pas l'indemnité, fixée à 115 millimes depuis le 1er août 1989 | 89-1552 |

Autres points :

- **Conséquence sur la revalorisation des pensions.** Au 1er mai 1992, le SMIG 48 heures passe de 120,016 à 132,912 D : **+10,75 %**, dont les 5 D d'indemnité intégrée. La base affichait +6,32 %.
- **Intitulés.** « Fixant le SMIG » était un intitulé faux pour les décrets n° 89-1551 et 91-1316. Il disparaît avec les entrées de 1989 et 1991 des séries du SMIG : ces décrets sont désormais référencés dans `indemnite_speciale_smig` sous leur intitulé exact. L'intitulé du décret SMAG n° 2009-2258 est corrigé : il date du 14 juillet 2009, non du 2 juin.
- **Valeurs nulles au 1er mai 1992.** Dans les deux fichiers d'indemnité, la note précise que la valeur nulle traduit l'intégration de l'indemnité au SMIG ou au SMAG (92-1299, art. 3 ; 92-1300, art. 3), et non sa suppression.
- **Pagination du décret n° 2024-420.** La notice de `jort_cache.db` donne pp. 1801-1802. Le pied de page de l'édition française donne **pp. 1802-1803** : le décret commence p. 1802, l'article premier et l'article 5 sont p. 1803. La note le dit.

## Références

- **Commit 1.** Chaque entrée touchée renvoie au fascicule pist.tn, en éditions française et arabe, avec une `note` : n° de JORT, page, article, clause d'effet. Le fascicule n° 45 de 2017 n'est servi qu'en arabe (`2017F/Jo0452017.pdf` et `2017A/Ja0452017.pdf` sont le même fichier) : la référence du SMAG au 1er août 2016 pointe vers l'édition arabe, où le texte a été lu.
- **Commit 2**, mécanique : 537 liens GitLab de `marche_travail/` remplacés, seuls les `href` changent.
  - Le numéro du décret est lu dans l'intitulé français, et non dans le lien GitLab, faux par endroits.
  - Les URL viennent de `jort_cache.db` (`pdf_fr`, `pdf_ar`), sous condition d'une notice unique hors rectificatif.
  - Les 104 URL distinctes répondent `200 application/pdf`.
  - Le décret n° 2022-769, sans notice propre, prend l'URL du fascicule n° 114 de 2022, lu à la p. 2835.

## Tests

- **`make test`** (YAML et Python, environnement `uv sync --extra dev`) : **163 réussis** avant (sur `origin/master`) et **163 réussis** après, soit 81 tests YAML et 82 tests Python. Un premier `make test` lancé sans l'extra `dev` s'arrêtait sur `tests/reforms/de_net_a_imposable/basic.yaml` (78 réussis, 1 échec) : `scipy` était absent, d'où `fsolve = None`. Ce défaut d'environnement est sans lien avec ce changement.
- **Tests YAML fichier par fichier**, comme la CI les répartit : 81 réussis avant et après.

Aucun test ne couvre 1989-1991 ni les dates ajoutées : aucun résultat ne change.

`.github/is-version-number-acceptable.sh` passe localement (0.81).

## Ce qui reste

- **Aucune formule ne lit `indemnite_speciale_smig` ni `indemnite_speciale_smag`.** Du 1er août 1989 au 30 avril 1992, le modèle renvoie désormais le SMIG et le SMAG légaux, et aucun calcul n'y ajoute les 3 D puis 5 D (115 puis 215 millimes par jour) de l'indemnité. C'est le bon résultat pour les usages recensés : cotisations, prestations et IRPP excluent l'indemnité. Mais sur ces mois, une rémunération minimale brute simulée est inférieure à ce qui était effectivement servi, et aucun paramètre lu ne permet de la reconstituer. Les formules sont hors du périmètre de cette PR.
- **Liens GitLab non remplacés dans `marche_travail/`** (15) :
  - les arrêtés SMAG de 1963 et 1965 : pas d'URL dans `jort_cache.db` ;
  - le décret SMAG n° 2019-455 : pas d'URL dans `jort_cache.db` ;
  - le décret SMIG n° 2019-454 : `jort_cache.db` n'a pas d'URL française. Les références du précis ne donnent que l'édition arabe (`2019A/Ja0432019.pdf`), et ces liens sont laissés en l'état. Dans `smig_48h_mensuel.yaml`, au 2019-05-01, les deux entrées (française et arabe) pointent en outre vers le PDF du **décret n° 2020-1069**, donc vers un autre texte ;
  - un lien vers le décret SMAG n° 86-690 au 1986-07-01 du SMIG 40 h horaire, là encore un autre texte.
- **Hors `marche_travail/`**, 87 liens GitLab restent : régimes spéciaux du secteur public, contribution sociale de solidarité, CNRPS maladie et décès.
- **Défauts de références repérés, non corrigés** faute de lecture :
  - intitulés arabes erronés du SMIG en 2012 et 2022 ;
  - le SMIG 2016-08-01 (décret n° 2017-668) renvoie désormais à `2017F/Jo0452017.pdf`, qui sert l'édition arabe.
- **Non lu au fascicule** : le SMAG entre 1991 et 2008 (notices seules), le second palier du 1er décembre 2012 (11,608 D), et le rectificatif du décret n° 92-1299 (JORT n° 55/1992, p. 1067).
- **Indemnités horaires.** `indemnite_speciale_smig` ne porte que le montant mensuel. Les montants horaires (14 et 17 millimes en 1989, 24 et 29 en 1991) sont dans les notes, pas en paramètres.
- **Précis socio-fiscal.** Les tableaux engendrés depuis ce modèle (série du SMIG, taux de 1992) changeront après fusion. Rien n'est régénéré depuis cette branche.

Refs #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SNmAfUpcmPrZt2pKZKy8Z
