### PR TITLE
Références et documentation : les fascicules du JORT à la place des liens GitLab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+### 0.82.1 - [#413](https://github.com/openfisca/openfisca-tunisia/pull/413)
+
+* Amélioration technique.
+* Périodes concernées : aucune. Aucune valeur n'est modifiée.
+* Zones impactées : `parameters/prelevements_sociaux/cotisations_sociales`, `parameters/prelevements_sociaux/contribution_sociale_solidarite`, `parameters/marche_travail`.
+* Détails :
+  - Corrige le **titre arabe de la loi n° 88-16**, qui datait de 1983 un texte de 1988. Le titre est repris sur le fascicule arabe du JORT n° 20 du 22 mars 1988, p. 427. Les deux fichiers du régime de retraite des gouverneurs, qui portaient deux libellés différents, portent désormais celui du fascicule.
+  - Écrit dans la documentation des paramètres que les parts **prestations familiales 3,10 %**, **indemnités de maladie et de maternité 0,85 %** et **décès 0,65 %** du régime général sont obtenues **par solde** du taux global de 18 % — 18,00 − 7,25 − 4,75 − 1,00 − 0,40 = 4,60 — et qu'aucun texte lu ne les établit. Aucune source n'est inventée : la documentation dit que la source manque.
+  - Fait de même pour les deux points voisins : le **déplacement de 0,0278 point** entre pensions et prestations familiales, qui écarte le partage employeur/salarié de la clé 13/5 de l'article 41 (nouveau) sans qu'un texte le prescrive, et le **partage des 1,20 % d'assurances sociales du régime agricole**, dont seule la part de maladie de 0,91 % est attestée, tardivement, par l'article 7 du décret n° 2007-1406.
+  - Remplace **88 liens** vers un dépôt GitLab personnel par les fascicules du JORT sur pist.tn, en éditions française et arabe. Chaque cible vient de `jort_cache.db`, le numéro du texte étant pris dans l'intitulé et jamais dans le lien GitLab, faux par endroits ; chaque URL a été vérifiée.
+  - Corrige dans `marche_travail` les **titres arabes du SMIG 2012 et du SMIG 2022**, qui étaient ceux du décret n° 81-437 et du décret n° 2020-1069, et le lien du **SMIG 40 h horaire de 1986**, qui renvoyait au décret n° 86-690 quand la valeur porte le décret n° 86-689.
+  - Résout les **arrêtés SMAG de 1963 et de 1965**, que l'issue croyait hors du corpus utilisable : ils sont dans `jort_cache.db`. Répare enfin une entrée de `pensionne_cnrps/deces` qui portait une URL en guise d'intitulé, sans `href`.
+  - **Quatorze liens subsistent**, faute d'adresse fiable : les décrets gouvernementaux n° 2019-454 et n° 2019-455, absents du cache, la note commune n° 1/2023 et la circulaire du Premier ministre n° 12 de 1993, qui ne sont pas des textes du JORT. Le décret-loi n° 2022-79 n'ayant pas d'édition française — le fascicule n° 141 de 2022 répond 404 en français et 200 en arabe — ses trois références pointent vers l'édition arabe.
+
+<!-- -->
+
 ## 0.82 - [#420](https://github.com/openfisca/openfisca-tunisia/pull/420)
 
 * Amélioration technique.

--- a/openfisca_tunisia/parameters/marche_travail/smag_journalier.yaml
+++ b/openfisca_tunisia/parameters/marche_travail/smag_journalier.yaml
@@ -121,14 +121,14 @@ metadata:
   reference:
     1964-01-01:
     - title: Arrêté des Secrétaires d'Etat à l'Agriculture et à la Santé Publique et aux Affaires Sociales du 24 décembre 1963 modifiant l'arrêté du 30 avril 1956  relatif à la rémunération des travailleurs agricoles.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1963/arrêté_24_12_63_fr.pdf
+      href: https://www.pist.tn/jort/1963/1963F/Jo05963.pdf
     - title: قرار من  كاتبي الدولة للفلاحة والصحة العمومية   مؤرخ في  24 ديسمبر 1963 يتعلق بتنقيح القرار المؤرخ في  30 افريل 1956  المتعلق بخلاص اجور  العملة الفلاحيين
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1963/arrêté_24_12_63_ar.pdf
+      href: https://www.pist.tn/jort/1963/1963A/Ja05963.pdf
     1966-01-01:
     - title: Arrêté des secrétaires d'Etat au plan et à  l'économie nationale et à la jeunesse aux sports et aux affaires sociales du 31 décembre 1965 portant relèvement du salaire minimum journalier des travailleurs agricoles
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1965/arrêté_31_12_1965_fr.pdf
+      href: https://www.pist.tn/jort/1965/1965F/Jo06665.pdf
     - title: قرار من كاتبي الدولة للتخطيط والاقتصاد الوطني وللشباب والرياضة والشؤون الاجتماعية مؤرخ في 31 دبسمبر 1965  بالترفيع في الأجر اليومي الأدنى للعملة الفلاحيين
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1965/arrêté_31_12_1965_ar.pdf
+      href: https://www.pist.tn/jort/1965/1965A/Ja06665.pdf
     1968-05-01:
     - title: Décret n°68-113 du 30 avril 1968 relatif à la rémunération des travailleurs agricoles
       href: https://www.pist.tn/jort/1968/1968F/Jo01868.pdf

--- a/openfisca_tunisia/parameters/marche_travail/smig_40h_horaire.yaml
+++ b/openfisca_tunisia/parameters/marche_travail/smig_40h_horaire.yaml
@@ -189,7 +189,8 @@ metadata:
     1986-07-01:
     - title: Décret n°86-689 du 20 juillet 1986 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
       href: https://www.pist.tn/jort/1986/1986F/Jo04186.pdf
-    - href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1986/décret_86_690_ar.pdf
+    - title: "Décret n° 86-689 du 20 juillet 1986 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail — édition arabe du fascicule (JORT n° 41, p. 819)"
+      href: https://www.pist.tn/jort/1986/1986A/Ja04186.pdf
     1987-11-01:
     - title: Décret n°87-1277 du 05 novembre 1987 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
       href: https://www.pist.tn/jort/1987/1987F/Jo07887.pdf

--- a/openfisca_tunisia/parameters/marche_travail/smig_48h_mensuel.yaml
+++ b/openfisca_tunisia/parameters/marche_travail/smig_48h_mensuel.yaml
@@ -335,7 +335,7 @@ metadata:
     2012-07-01:
     - title: Décret n°2012-1981 du 20 septembre 2012 fixant le  salaire minimum interprofessionnel garanti  dans les secteurs non agricoles régis par le  code du travail.
       href: https://www.pist.tn/jort/2012/2012F/Jo0772012.pdf
-    - title: امر عدد  437  لسنة  1981   مؤرخ في   7 افريل 1981    يتعلق بإحداث منحة اضافية مؤقتة  في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
+    - title: امر عدد 1981 لسنة 2012 مؤرخ في 20 سبتمبر 2012 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
       href: https://www.pist.tn/jort/2012/2012A/Ja0772012.pdf
     2014-05-01:
     - title: Décret n°2014-2907 du 11 août 2014, fixant le  salaire minimum interprofessionnel garanti  dans les secteurs non agricoles régis par le  code du travail.
@@ -360,7 +360,7 @@ metadata:
     2019-05-01:
     - title: Décret gouvernemental n°2019-454 du 28 mai 2019 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2020/Décret_2020_1069_fr.pdf
-    - title: امر حكومي عدد 1069 لسنة 2020 مؤرخ في 30 ديسمبر 2020 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
+    - title: امر حكومي عدد 454 لسنة 2019 مؤرخ في 28 ماي 2019 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2020/Décret_2020_1069_fr.pdf
     2020-10-01:
     - title: Décret gouvernemental n° 2020-1069 du 30 décembre 2020 fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
@@ -370,7 +370,7 @@ metadata:
     2022-10-01:
     - title: Décret gouvernemental n°2022-769 du 19 octobre 2022 , fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail.
       href: https://www.pist.tn/jort/2022/2022F/Jo1142022.pdf
-    - title: امر حكومي عدد 1069 لسنة 2020 مؤرخ في 30 ديسمبر 2020 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
+    - title: امر عدد 769 لسنة 2022 مؤرخ في 19 أكتوبر 2022 يتعلق بضبط الأجر الأدنى المضمون لمختلف المهن في القطاعات غير الفلاحية الخاضعة لمجلة الشغل
       href: https://www.pist.tn/jort/2022/2022A/Ja1142022.pdf
     2024-05-01:
     - title: Décret n°2024-419 du 09 juillet 2024 , fixant le salaire minimum interprofessionnel garanti dans les secteurs non agricoles régis par le code du travail

--- a/openfisca_tunisia/parameters/prelevements_sociaux/contribution_sociale_solidarite/entreprise/taux_is_10_pc/bareme.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/contribution_sociale_solidarite/entreprise/taux_is_10_pc/bareme.yaml
@@ -12,14 +12,14 @@ metadata:
   reference:
     2018-01-01:
     - title: loi n° 2017-66 du 18 décembre 2017, portant loi de finances pour l’année 2018 (Article 53 )
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2017/loi_2017_66_fr.pdf
+      href: https://www.pist.tn/jort/2017/2017F/Jo1012017.pdf
     - title: قانون عدد 66 لسنة 2017 مؤرخ في 18 ديسمبر 2017 يتعلق بقانون المالية لسنة 2018 (القصل53)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2017/loi_2017_66_ar.pdf
+      href: https://www.pist.tn/jort/2017/2017A/Ja1012017.pdf
     2022-01-01:
     - title: l’article 22 du décret-loi 79-2022 du 22 décembre 2022 relatif à la loi de finances pour l’année 2023
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2022/décret_loi_2022_79_fr.pdf
+      href: https://www.pist.tn/jort/2022/2022A/Ja1412022.pdf
     - title: مرسوم عدد 79 لسنة 2022 مؤرخ في 22 ديسمبر 2022 يتعلق بقانون المالية لسنة 2023 (الفصل22)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2022/décret_loi_2022_79_ar.pdf
+      href: https://www.pist.tn/jort/2022/2022A/Ja1412022.pdf
     - title: note commune 1/2018 du 26/01/2023
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2023/Note_Commune_1_2023.pdf
       note: taux CSS 2024 déclaré en 2025 est de 3 point de pourcentage

--- a/openfisca_tunisia/parameters/prelevements_sociaux/contribution_sociale_solidarite/entreprise/taux_is_10_pc/montant_minimum.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/contribution_sociale_solidarite/entreprise/taux_is_10_pc/montant_minimum.yaml
@@ -9,11 +9,11 @@ metadata:
   reference:
     2018-01-01:
     - title: Article 53 de la loi n° 2017-66 du 18 décembre 2017, portant loi de finances pour l’année 2018
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2017/loi_2017_66_fr.pdf
+      href: https://www.pist.tn/jort/2017/2017F/Jo1012017.pdf
     - title: قانون عدد 66 لسنة 2017 مؤرخ في 18 ديسمبر 2017 يتعلق بقانون المالية لسنة 2018 (القصل53)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2017/loi_2017_66_ar.pdf
+      href: https://www.pist.tn/jort/2017/2017A/Ja1012017.pdf
     2023-01-01:
     - title: l’article 22 du décret-loi 79-2022 du 22 décembre 2022 relatif à la loi de finances pour l’année 2023
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2022/décret_loi_2022_79_fr.pdf
+      href: https://www.pist.tn/jort/2022/2022A/Ja1412022.pdf
     - title: مرسوم عدد 79 لسنة 2022 مؤرخ في 22 ديسمبر 2022 يتعلق بقانون المالية لسنة 2023 (الفصل22)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2022/décret_loi_2022_79_ar.pdf
+      href: https://www.pist.tn/jort/2022/2022A/Ja1412022.pdf

--- a/openfisca_tunisia/parameters/prelevements_sociaux/contribution_sociale_solidarite/salarie.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/contribution_sociale_solidarite/salarie.yaml
@@ -16,18 +16,18 @@ metadata:
   reference:
     2018-01-01:
     - title: Article 53 de la loi n° 2017-66 du 18 décembre 2017, portant loi de finances pour l’année 2018
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2017/loi_2017_66_fr.pdf
+      href: https://www.pist.tn/jort/2017/2017F/Jo1012017.pdf
     - title: Note commune 2018/01
       href: https://jibaya.tn/docs/note-commune-numero-1-commentaire-des-dispositions-de-larticle-53-de-la-loi-n-2017-66-du-18-decembre-2017-portant-loi-de-finances-pour-lannee-2018-relatives-a-lins-2/
     - title: قانون عدد 66 لسنة 2017 مؤوخ في18 دسيمبر 2017 يتعلق بقانون المالة  لسنة 2018
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2017/loi_2017_66_ar.pdf
+      href: https://www.pist.tn/jort/2017/2017A/Ja1012017.pdf
     2023-01-01:
     - title: Décret-loi n° 2022-79 du 22 décembre 2022, portant loi de finances pour l’année 2023 (article 22- tiret 7)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2022/décret_loi_2022_79_fr.pdf
+      href: https://www.pist.tn/jort/2022/2022A/Ja1412022.pdf
     - title: note commune n1/2023 du 26/01/2023
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2023/Note_Commune_1_2023.pdf
     - title: مرسوم عدد 79 لسنة 2022 مؤرخ في 22 ديسمبر 2022 يتعلق بقانون المالية لسنة    2023  (الفصل22)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2022/décret_loi_2022_79_ar.pdf
+      href: https://www.pist.tn/jort/2022/2022A/Ja1412022.pdf
     2025-01-01:
     - title: Loi n° 2024-48 du 9 décembre 2024, portant loi de finances pour l'année 2025 (maintien à 0.5% de la retenue à la source)
       href: https://www.finances.gov.tn/fr/les-lois-de-finances

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_employeur/assurances_sociales/deces.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_employeur/assurances_sociales/deces.yaml
@@ -17,3 +17,13 @@ metadata:
     - title: "Loi n° 81-6 du 12 février 1981 organisant les régimes de sécurité sociale dans le secteur agricole, article 18"
       href: "https://www.pist.tn/jort/1981/1981F/Jo00981.pdf"
       note: "JORT n° 9, p. 265-273. Fixe le taux global du régime des salariés agricoles à 6,45 %. La loi n'énonce pas de date d'effet. Édition arabe : https://www.pist.tn/jort/1981/1981A/Ja00981.pdf"
+documentation: |
+  PART OBTENUE PAR SOLDE, SANS TEXTE. Le décret n° 81-224 répartit les 6,45 % du régime des
+  salariés agricoles en 1,20 % d'assurances sociales et 5,25 % de pensions, et s'arrête à
+  cette ligne globale. Le partage interne des 1,20 % — 0,91 de maladie, 0,24 de maternité,
+  0,05 de décès — n'est fixé par aucun texte identifié. Seule la part de maladie de 0,91 %
+  est attestée, et tardivement : par l'article 7 du décret n° 2007-1406, qui la reprend comme
+  le socle sur lequel s'ajoutent les cotisations supplémentaires d'assurance maladie.
+
+  Les 0,24 et les 0,05 sont donc obtenus par solde de 1,20 − 0,91 et d'une convention de
+  partage entre maternité et décès, à lire comme telle.

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_employeur/assurances_sociales/maternite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_employeur/assurances_sociales/maternite.yaml
@@ -17,3 +17,13 @@ metadata:
     - title: "Loi n° 81-6 du 12 février 1981 organisant les régimes de sécurité sociale dans le secteur agricole, article 18"
       href: "https://www.pist.tn/jort/1981/1981F/Jo00981.pdf"
       note: "JORT n° 9, p. 265-273. Fixe le taux global du régime des salariés agricoles à 6,45 %. La loi n'énonce pas de date d'effet. Édition arabe : https://www.pist.tn/jort/1981/1981A/Ja00981.pdf"
+documentation: |
+  PART OBTENUE PAR SOLDE, SANS TEXTE. Le décret n° 81-224 répartit les 6,45 % du régime des
+  salariés agricoles en 1,20 % d'assurances sociales et 5,25 % de pensions, et s'arrête à
+  cette ligne globale. Le partage interne des 1,20 % — 0,91 de maladie, 0,24 de maternité,
+  0,05 de décès — n'est fixé par aucun texte identifié. Seule la part de maladie de 0,91 %
+  est attestée, et tardivement : par l'article 7 du décret n° 2007-1406, qui la reprend comme
+  le socle sur lequel s'ajoutent les cotisations supplémentaires d'assurance maladie.
+
+  Les 0,24 et les 0,05 sont donc obtenus par solde de 1,20 − 0,91 et d'une convention de
+  partage entre maternité et décès, à lire comme telle.

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_salarie/assurances_sociales/deces.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_salarie/assurances_sociales/deces.yaml
@@ -17,3 +17,13 @@ metadata:
     - title: "Loi n° 81-6 du 12 février 1981 organisant les régimes de sécurité sociale dans le secteur agricole, article 18"
       href: "https://www.pist.tn/jort/1981/1981F/Jo00981.pdf"
       note: "JORT n° 9, p. 265-273. Fixe le taux global du régime des salariés agricoles à 6,45 %. La loi n'énonce pas de date d'effet. Édition arabe : https://www.pist.tn/jort/1981/1981A/Ja00981.pdf"
+documentation: |
+  PART OBTENUE PAR SOLDE, SANS TEXTE. Le décret n° 81-224 répartit les 6,45 % du régime des
+  salariés agricoles en 1,20 % d'assurances sociales et 5,25 % de pensions, et s'arrête à
+  cette ligne globale. Le partage interne des 1,20 % — 0,91 de maladie, 0,24 de maternité,
+  0,05 de décès — n'est fixé par aucun texte identifié. Seule la part de maladie de 0,91 %
+  est attestée, et tardivement : par l'article 7 du décret n° 2007-1406, qui la reprend comme
+  le socle sur lequel s'ajoutent les cotisations supplémentaires d'assurance maladie.
+
+  Les 0,24 et les 0,05 sont donc obtenus par solde de 1,20 − 0,91 et d'une convention de
+  partage entre maternité et décès, à lire comme telle.

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_salarie/assurances_sociales/maternite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_salarie/assurances_sociales/maternite.yaml
@@ -17,3 +17,13 @@ metadata:
     - title: "Loi n° 81-6 du 12 février 1981 organisant les régimes de sécurité sociale dans le secteur agricole, article 18"
       href: "https://www.pist.tn/jort/1981/1981F/Jo00981.pdf"
       note: "JORT n° 9, p. 265-273. Fixe le taux global du régime des salariés agricoles à 6,45 %. La loi n'énonce pas de date d'effet. Édition arabe : https://www.pist.tn/jort/1981/1981A/Ja00981.pdf"
+documentation: |
+  PART OBTENUE PAR SOLDE, SANS TEXTE. Le décret n° 81-224 répartit les 6,45 % du régime des
+  salariés agricoles en 1,20 % d'assurances sociales et 5,25 % de pensions, et s'arrête à
+  cette ligne globale. Le partage interne des 1,20 % — 0,91 de maladie, 0,24 de maternité,
+  0,05 de décès — n'est fixé par aucun texte identifié. Seule la part de maladie de 0,91 %
+  est attestée, et tardivement : par l'article 7 du décret n° 2007-1406, qui la reprend comme
+  le socle sur lequel s'ajoutent les cotisations supplémentaires d'assurance maladie.
+
+  Les 0,24 et les 0,05 sont donc obtenus par solde de 1,20 − 0,91 et d'une convention de
+  partage entre maternité et décès, à lire comme telle.

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/assurances_sociales/deces.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/assurances_sociales/deces.yaml
@@ -16,3 +16,15 @@ metadata:
       note: "JORT n° 10, p. 155. L'article 41 (nouveau) porte le taux global des régimes de la loi n° 60-30 à 18 %, réparti 13 % à la charge de l'employeur et 5 % à la charge du travailleur. La loi n'énonce pas de date d'effet pour ce taux : la seule date qu'elle fixe, le 1er octobre 1996, porte sur la réduction conventionnelle de deux points du paragraphe 2. La date retenue ici est celle de la publication. Édition arabe : https://www.pist.tn/jort/1997/1997A/Ja01097.pdf"
   official_journal_date:
     1997-02-04: "1997-02-04"
+documentation: |
+  PART OBTENUE PAR SOLDE, SANS TEXTE. Aucun texte lu n'établit cette part. Elle se déduit
+  du taux global de 18 % de l'article 41 (nouveau) de la loi n° 60-30, une fois retranchées
+  les quatre parts attestées : 18,00 − 7,25 (pensions) − 4,75 (assurance maladie)
+  − 1,00 (accidents du travail) − 0,40 (fonds spécial de l'État) = 4,60, que le modèle
+  répartit en 3,10 de prestations familiales, 0,85 d'indemnités de maladie et de maternité
+  et 0,65 de décès. Le dépouillement du JORT n'a rien trouvé qui fixe cette ventilation :
+  l'hypothèse la plus vraisemblable est une décision du conseil d'administration de la CNSS
+  ou un arrêté non recensé dans le corpus consulté.
+
+  Tant qu'un texte n'est pas produit, ces trois parts sont à lire comme une CONVENTION DE
+  RÉPARTITION, non comme une règle de droit sourcée. Leur somme, elle, est attestée.

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/assurances_sociales/maternite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/assurances_sociales/maternite.yaml
@@ -16,3 +16,15 @@ metadata:
       note: "JORT n° 10, p. 155. L'article 41 (nouveau) porte le taux global des régimes de la loi n° 60-30 à 18 %, réparti 13 % à la charge de l'employeur et 5 % à la charge du travailleur. La loi n'énonce pas de date d'effet pour ce taux : la seule date qu'elle fixe, le 1er octobre 1996, porte sur la réduction conventionnelle de deux points du paragraphe 2. La date retenue ici est celle de la publication. Édition arabe : https://www.pist.tn/jort/1997/1997A/Ja01097.pdf"
   official_journal_date:
     1997-02-04: "1997-02-04"
+documentation: |
+  PART OBTENUE PAR SOLDE, SANS TEXTE. Aucun texte lu n'établit cette part. Elle se déduit
+  du taux global de 18 % de l'article 41 (nouveau) de la loi n° 60-30, une fois retranchées
+  les quatre parts attestées : 18,00 − 7,25 (pensions) − 4,75 (assurance maladie)
+  − 1,00 (accidents du travail) − 0,40 (fonds spécial de l'État) = 4,60, que le modèle
+  répartit en 3,10 de prestations familiales, 0,85 d'indemnités de maladie et de maternité
+  et 0,65 de décès. Le dépouillement du JORT n'a rien trouvé qui fixe cette ventilation :
+  l'hypothèse la plus vraisemblable est une décision du conseil d'administration de la CNSS
+  ou un arrêté non recensé dans le corpus consulté.
+
+  Tant qu'un texte n'est pas produit, ces trois parts sont à lire comme une CONVENTION DE
+  RÉPARTITION, non comme une règle de droit sourcée. Leur somme, elle, est attestée.

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/famille.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/famille.yaml
@@ -17,3 +17,15 @@ metadata:
     - title: "Loi n° 97-4 du 3 février 1997 modifiant la loi n° 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale, article 41 (nouveau)"
       href: "https://www.pist.tn/jort/1997/1997F/Jo01097.pdf"
       note: "JORT n° 10, p. 155. L'article 41 (nouveau) porte le taux global des régimes de la loi n° 60-30 à 18 %, réparti 13 % à la charge de l'employeur et 5 % à la charge du travailleur. La loi n'énonce pas de date d'effet pour ce taux : la seule date qu'elle fixe, le 1er octobre 1996, porte sur la réduction conventionnelle de deux points du paragraphe 2. La date retenue ici est celle de la publication. Édition arabe : https://www.pist.tn/jort/1997/1997A/Ja01097.pdf"
+documentation: |
+  PART OBTENUE PAR SOLDE, SANS TEXTE. Aucun texte lu n'établit cette part. Elle se déduit
+  du taux global de 18 % de l'article 41 (nouveau) de la loi n° 60-30, une fois retranchées
+  les quatre parts attestées : 18,00 − 7,25 (pensions) − 4,75 (assurance maladie)
+  − 1,00 (accidents du travail) − 0,40 (fonds spécial de l'État) = 4,60, que le modèle
+  répartit en 3,10 de prestations familiales, 0,85 d'indemnités de maladie et de maternité
+  et 0,65 de décès. Le dépouillement du JORT n'a rien trouvé qui fixe cette ventilation :
+  l'hypothèse la plus vraisemblable est une décision du conseil d'administration de la CNSS
+  ou un arrêté non recensé dans le corpus consulté.
+
+  Tant qu'un texte n'est pas produit, ces trois parts sont à lire comme une CONVENTION DE
+  RÉPARTITION, non comme une règle de droit sourcée. Leur somme, elle, est attestée.

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/retraite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_employeur/retraite.yaml
@@ -17,3 +17,14 @@ metadata:
     - title: "Loi n° 97-4 du 3 février 1997 modifiant la loi n° 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale, article 41 (nouveau)"
       href: "https://www.pist.tn/jort/1997/1997F/Jo01097.pdf"
       note: "JORT n° 10, p. 155. L'article 41 (nouveau) porte le taux global des régimes de la loi n° 60-30 à 18 %, réparti 13 % à la charge de l'employeur et 5 % à la charge du travailleur. La loi n'énonce pas de date d'effet pour ce taux : la seule date qu'elle fixe, le 1er octobre 1996, porte sur la réduction conventionnelle de deux points du paragraphe 2. La date retenue ici est celle de la publication. Édition arabe : https://www.pist.tn/jort/1997/1997A/Ja01097.pdf"
+documentation: |
+  LE PARTAGE EMPLOYEUR/SALARIÉ DE CETTE BRANCHE N'EST PAS PROPORTIONNEL, ET L'ÉCART N'A PAS
+  DE TEXTE. L'article 41 (nouveau) de la loi n° 60-30 répartit le taux global de 18 % en
+  13 points d'employeur et 5 points de travailleur. Appliquée branche par branche, cette clé
+  donnerait 5,2361 / 2,0139 pour les pensions (7,25) et 2,2389 / 0,8611 pour les prestations
+  familiales (3,10). Le modèle porte 5,2639 / 1,9861 et 2,2111 / 0,8889 : 0,0278 point est
+  DÉPLACÉ des prestations familiales vers les pensions du côté de l'employeur, et en sens
+  inverse du côté du salarié. Les totaux par branche et le taux global sont inchangés.
+
+  Aucun texte lu n'établit ce déplacement. Il est conservé parce qu'il fait tomber les totaux
+  publiés par la CNSS, non parce qu'une source le fixe.

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/assurances_sociales/deces.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/assurances_sociales/deces.yaml
@@ -16,3 +16,15 @@ metadata:
       note: "JORT n° 10, p. 155. L'article 41 (nouveau) porte le taux global des régimes de la loi n° 60-30 à 18 %, réparti 13 % à la charge de l'employeur et 5 % à la charge du travailleur. La loi n'énonce pas de date d'effet pour ce taux : la seule date qu'elle fixe, le 1er octobre 1996, porte sur la réduction conventionnelle de deux points du paragraphe 2. La date retenue ici est celle de la publication. Édition arabe : https://www.pist.tn/jort/1997/1997A/Ja01097.pdf"
   official_journal_date:
     1997-02-04: "1997-02-04"
+documentation: |
+  PART OBTENUE PAR SOLDE, SANS TEXTE. Aucun texte lu n'établit cette part. Elle se déduit
+  du taux global de 18 % de l'article 41 (nouveau) de la loi n° 60-30, une fois retranchées
+  les quatre parts attestées : 18,00 − 7,25 (pensions) − 4,75 (assurance maladie)
+  − 1,00 (accidents du travail) − 0,40 (fonds spécial de l'État) = 4,60, que le modèle
+  répartit en 3,10 de prestations familiales, 0,85 d'indemnités de maladie et de maternité
+  et 0,65 de décès. Le dépouillement du JORT n'a rien trouvé qui fixe cette ventilation :
+  l'hypothèse la plus vraisemblable est une décision du conseil d'administration de la CNSS
+  ou un arrêté non recensé dans le corpus consulté.
+
+  Tant qu'un texte n'est pas produit, ces trois parts sont à lire comme une CONVENTION DE
+  RÉPARTITION, non comme une règle de droit sourcée. Leur somme, elle, est attestée.

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/assurances_sociales/maternite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/assurances_sociales/maternite.yaml
@@ -16,3 +16,15 @@ metadata:
       note: "JORT n° 10, p. 155. L'article 41 (nouveau) porte le taux global des régimes de la loi n° 60-30 à 18 %, réparti 13 % à la charge de l'employeur et 5 % à la charge du travailleur. La loi n'énonce pas de date d'effet pour ce taux : la seule date qu'elle fixe, le 1er octobre 1996, porte sur la réduction conventionnelle de deux points du paragraphe 2. La date retenue ici est celle de la publication. Édition arabe : https://www.pist.tn/jort/1997/1997A/Ja01097.pdf"
   official_journal_date:
     1997-02-04: "1997-02-04"
+documentation: |
+  PART OBTENUE PAR SOLDE, SANS TEXTE. Aucun texte lu n'établit cette part. Elle se déduit
+  du taux global de 18 % de l'article 41 (nouveau) de la loi n° 60-30, une fois retranchées
+  les quatre parts attestées : 18,00 − 7,25 (pensions) − 4,75 (assurance maladie)
+  − 1,00 (accidents du travail) − 0,40 (fonds spécial de l'État) = 4,60, que le modèle
+  répartit en 3,10 de prestations familiales, 0,85 d'indemnités de maladie et de maternité
+  et 0,65 de décès. Le dépouillement du JORT n'a rien trouvé qui fixe cette ventilation :
+  l'hypothèse la plus vraisemblable est une décision du conseil d'administration de la CNSS
+  ou un arrêté non recensé dans le corpus consulté.
+
+  Tant qu'un texte n'est pas produit, ces trois parts sont à lire comme une CONVENTION DE
+  RÉPARTITION, non comme une règle de droit sourcée. Leur somme, elle, est attestée.

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/famille.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/famille.yaml
@@ -17,3 +17,15 @@ metadata:
     - title: "Loi n° 97-4 du 3 février 1997 modifiant la loi n° 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale, article 41 (nouveau)"
       href: "https://www.pist.tn/jort/1997/1997F/Jo01097.pdf"
       note: "JORT n° 10, p. 155. L'article 41 (nouveau) porte le taux global des régimes de la loi n° 60-30 à 18 %, réparti 13 % à la charge de l'employeur et 5 % à la charge du travailleur. La loi n'énonce pas de date d'effet pour ce taux : la seule date qu'elle fixe, le 1er octobre 1996, porte sur la réduction conventionnelle de deux points du paragraphe 2. La date retenue ici est celle de la publication. Édition arabe : https://www.pist.tn/jort/1997/1997A/Ja01097.pdf"
+documentation: |
+  PART OBTENUE PAR SOLDE, SANS TEXTE. Aucun texte lu n'établit cette part. Elle se déduit
+  du taux global de 18 % de l'article 41 (nouveau) de la loi n° 60-30, une fois retranchées
+  les quatre parts attestées : 18,00 − 7,25 (pensions) − 4,75 (assurance maladie)
+  − 1,00 (accidents du travail) − 0,40 (fonds spécial de l'État) = 4,60, que le modèle
+  répartit en 3,10 de prestations familiales, 0,85 d'indemnités de maladie et de maternité
+  et 0,65 de décès. Le dépouillement du JORT n'a rien trouvé qui fixe cette ventilation :
+  l'hypothèse la plus vraisemblable est une décision du conseil d'administration de la CNSS
+  ou un arrêté non recensé dans le corpus consulté.
+
+  Tant qu'un texte n'est pas produit, ces trois parts sont à lire comme une CONVENTION DE
+  RÉPARTITION, non comme une règle de droit sourcée. Leur somme, elle, est attestée.

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/retraite.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/cotisations_salarie/retraite.yaml
@@ -17,3 +17,14 @@ metadata:
     - title: "Loi n° 97-4 du 3 février 1997 modifiant la loi n° 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale, article 41 (nouveau)"
       href: "https://www.pist.tn/jort/1997/1997F/Jo01097.pdf"
       note: "JORT n° 10, p. 155. L'article 41 (nouveau) porte le taux global des régimes de la loi n° 60-30 à 18 %, réparti 13 % à la charge de l'employeur et 5 % à la charge du travailleur. La loi n'énonce pas de date d'effet pour ce taux : la seule date qu'elle fixe, le 1er octobre 1996, porte sur la réduction conventionnelle de deux points du paragraphe 2. La date retenue ici est celle de la publication. Édition arabe : https://www.pist.tn/jort/1997/1997A/Ja01097.pdf"
+documentation: |
+  LE PARTAGE EMPLOYEUR/SALARIÉ DE CETTE BRANCHE N'EST PAS PROPORTIONNEL, ET L'ÉCART N'A PAS
+  DE TEXTE. L'article 41 (nouveau) de la loi n° 60-30 répartit le taux global de 18 % en
+  13 points d'employeur et 5 points de travailleur. Appliquée branche par branche, cette clé
+  donnerait 5,2361 / 2,0139 pour les pensions (7,25) et 2,2389 / 0,8611 pour les prestations
+  familiales (3,10). Le modèle porte 5,2639 / 1,9861 et 2,2111 / 0,8889 : 0,0278 point est
+  DÉPLACÉ des prestations familiales vers les pensions du côté de l'employeur, et en sens
+  inverse du côté du salarié. Les totaux par branche et le taux global sont inchangés.
+
+  Aucun texte lu n'établit ce déplacement. Il est conservé parce qu'il fait tomber les totaux
+  publiés par la CNSS, non parce qu'une source le fixe.

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_public/pensionne_cnrps/deces.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_public/pensionne_cnrps/deces.yaml
@@ -10,14 +10,15 @@ metadata:
   reference:
     1974-06-01:
     - title: décret 74-572 du 22 mai 1974 relatif au capital-décès
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1974/decret_74_572_fr.pdf
+      href: https://www.pist.tn/jort/1974/1974F/Jo03674.pdf
       note: امر عدد 572 لسنة 1974 مؤرخ في22 ماي 1974 بتعلق براس المال عند الوفاة
-    - title: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1974/decret_74_572_ar.pdf
+    - title: امر عدد 572 لسنة 1974 مؤرخ في 22 ماي 1974 يتعلق براس المال عند الوفاة
+      href: https://www.pist.tn/jort/1974/1974A/Ja03674.pdf
     - title: Décret n°93-308 du premier février 1993, relatif au régime du capital décès
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/decret__93_308_fr.pdf
+      href: https://www.pist.tn/jort/1993/1993F/Jo01393.pdf
       note: "Les principales dispositions du décret n°93-308 susvisé permettent aux agents publics d'opter pour 1'une des deux branches suivantes :  La branche générale où la cotisation est calculée sur la base de tous les éléments de la rémunération, soumis à retenue pour pension; La branche facultative transitoire où la cotisation est calculée uniquement sur le salaire de base."
     - title: أمر عدد 308 لسنة 1993 مؤرخ في 1 فيفري 1993 يتعلق بنظام رأس المال عند الوفاة
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/decret__93_308_ar.pdf
+      href: https://www.pist.tn/jort/1993/1993A/Ja01393.pdf
       note: "طبقا لمنشور الوزير الأول عدد 12 بتاريخ 15 فيفري 1993 حول تطبيق الأمر عدد 308 لسنة 1993 : يمكن الأعوان العموميين من اختيار أحد الفرعين التاليين : الفرع العام وهو فرع تحتسب فيه المساهمة على كافة عناصر المرتب الخاضعة للحجز بعنوان جراية التقاعد، الفرع الاختياري الانتقالي وهو فرع تحتسب فيه المساهمة على الأجر الأساسي فحسب"
     - title: Circulaire du premier ministre n°12  du 15 février 1993
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/circulaire_93_12_ar.pdf

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_public/regimes_speciaux/gouvernement_deputes_gouverneurs/cotisations_employeur/retraite
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_public/regimes_speciaux/gouvernement_deputes_gouverneurs/cotisations_employeur/retraite
@@ -32,98 +32,98 @@ metadata:
   reference:
     1983-04-01:
     - title: Loi 83-31 du 17 mars 1983, fixant le régime de retraite des membres du gouvernement (article 5).
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1983/loi_83_31_fr.pdf
+      href: https://www.pist.tn/jort/1983/1983F/Jo02383.pdf
     - title: القانون عدد 31 لسنة 1983 المؤرخ في  17 مارس 1983 المتعلق بضبط نظام التقاعد لأعضاء الحكومة
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1983/loi_83_31_ar.pdf
+      href: https://www.pist.tn/jort/1983/1983A/Ja02383.pdf
     1985-04-01:
     - title: Loi n°85-16 du 8 mars 1985, fixant le régime de retraite des députés
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1985/loi_85_16_fr.pdf
+      href: https://www.pist.tn/jort/1985/1985F/Jo02185.pdf
       note: "Les régimes spéciaux : le régime de retraite des membres du gouvernement, le régime de retraite des députés, le régime de retraite des gouverneurs régie par les lois suivants : Loi n 83-31 du 17 mars 1983fixant le régime de retraite des membres du gouvernement, loi n85-16 du 8 mars 1985 fixant le régime de retraite des députés, loi n88-16 du 17 mars 1988 fixant le régime de retraite des gouverneurs."
     - title: القانون عدد 16  لسنة 1985 المؤرخ في  8 مارس 1985 المتعلق بضبط نظام تقاعد أعضاء مجلس النواب
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1985/loi_85_16_ar.pdf
+      href: https://www.pist.tn/jort/1985/1985A/Ja02185.pdf
       note: "الأنظمة الخضوصية : نظام التقاعد لأعضاء الحكومة، الولاة، أعضاء مجلس النواب"
     1995-07-01:
     - title: loi n°94-71 du 27 juin 1994 Relative à la révision des taux de la contribution aux régimes de retraite dans le secteur public
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1994/loi_94_71_fr.pdf
+      href: https://www.pist.tn/jort/1994/1994F/Jo05094.pdf
     - title: القانون عدد 71 لسنة 1994 المؤرخ في 27 جوان 1994 بتعلق بتعديل نسب المساهمات في أنظمة التقاعد في القطاع العمومي
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1994/loi_94_71_ar.pdf
+      href: https://www.pist.tn/jort/1994/1994A/Ja05094.pdf
     - title: loi n°88-16 du 17 mars 1988 fixant le régime de retraite des gouverneurs
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/loi_88_16_fr.pdf
-    - title: القانون عدد 16 لسنة 1988 المؤرخ في  17 مارس 1988 المتعلق بنظام تقاعد الولاة
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/loi_88_16_ar.pdf
+      href: https://www.pist.tn/jort/1988/1988F/Jo02088.pdf
+    - title: قانون عدد 16 لسنة 1988 مؤرخ في 17 مارس 1988 يتعلق بضبط نظام تقاعد الولاة
+      href: https://www.pist.tn/jort/1988/1988A/Ja02088.pdf
     2002-07-01:
     - title: "Référence : loi n°2001-123 du 28 décembre 2001 portant loi de finances 2002 (article 85)"
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_fr.pdf
+      href: https://www.pist.tn/jort/2001/2001F/Jo1042001.pdf
       note: "Les taux de la contribution au régime des pensions civiles et militaires de retraite et des survivants dans le secteur public et des régimes de retraite des membres du gouvernement, des députés et des gouverneurs sont relevés comme suit :  de 1.5 point de pourcentage de la base de calcul de la contribution à la charge de l’employeur et ce comme suit :0.50 point de pourcentage à partir du 1er juillet 2002, 0.25 point de pourcentage à partir du 1er juillet 2003, 0.25 point de pourcentage à partir du 1er juillet 2004, 0.25 point de pourcentage à partir du 1er juillet 2005, 0.25 point de pourcentage à partir du 1er juillet 2006"
     - title: قانون عدد 123 لسنــة 2001 مؤرخ في 28 ديسمبر 2001 يتعلق بقانون المالية لسنة 2002 (الفصل 85)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_ar.pdf
+      href: https://www.pist.tn/jort/2001/2001A/Ja1042001.pdf
       note: "ترفع نسب المساهمات بنظام الجرايات المدنية والعسكرية للتقاعد والباقين على قيد الحياة في القطاع العمومي وبأنظمة التقاعد لأعضاء الحكومة وأعضاء مجلس النواب والولاّة كما يلي : 1.5 بالمائة من قاعدة احتساب الاشتراك على كاهل المؤجر وذلك على النــحو التالي :0.50 بالمائة ابتداء من غرة جويلية 2002، 0.25 بالمائة ابتداء من غرة جويلية 2003، 0.25 بالمائة ابتداء من غرة جويلية 2004، 0.25 بالمائة ابتداء من غرة جويلية 2005، 0.25 بالمائة ابتداء من غرة جويلية 2006"
     2003-07-01:
     - title: "Référence : loi n°2001-123 du 28 décembre 2001 portant loi de finances 2002 (article 85)"
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_fr.pdf
+      href: https://www.pist.tn/jort/2001/2001F/Jo1042001.pdf
       note: "Les taux de la contribution au régime des pensions civiles et militaires de retraite et des survivants dans le secteur public et des régimes de retraite des membres du gouvernement, des députés et des gouverneurs sont relevés comme suit :  de 1.5 point de pourcentage de la base de calcul de la contribution à la charge de l’employeur et ce comme suit :0.50 point de pourcentage à partir du 1er juillet 2002, 0.25 point de pourcentage à partir du 1er juillet 2003, 0.25 point de pourcentage à partir du 1er juillet 2004, 0.25 point de pourcentage à partir du 1er juillet 2005, 0.25 point de pourcentage à partir du 1er juillet 2006"
     - title: قانون عدد 123 لسنــة 2001 مؤرخ في 28 ديسمبر 2001 يتعلق بقانون المالية لسنة 2002 (الفصل 85)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_ar.pdf
+      href: https://www.pist.tn/jort/2001/2001A/Ja1042001.pdf
       note: "ترفع نسب المساهمات بنظام الجرايات المدنية والعسكرية للتقاعد والباقين على قيد الحياة في القطاع العمومي وبأنظمة التقاعد لأعضاء الحكومة وأعضاء مجلس النواب والولاّة كما يلي : 1.5 بالمائة من قاعدة احتساب الاشتراك على كاهل المؤجر وذلك على النــحو التالي :0.50 بالمائة ابتداء من غرة جويلية 2002، 0.25 بالمائة ابتداء من غرة جويلية 2003، 0.25 بالمائة ابتداء من غرة جويلية 2004، 0.25 بالمائة ابتداء من غرة جويلية 2005، 0.25 بالمائة ابتداء من غرة جويلية 2006"
     2004-07-01:
     - title: "Référence : loi n°2001-123 du 28 décembre 2001 portant loi de finances 2002 (article 85)"
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_fr.pdf
+      href: https://www.pist.tn/jort/2001/2001F/Jo1042001.pdf
       note: "Les taux de la contribution au régime des pensions civiles et militaires de retraite et des survivants dans le secteur public et des régimes de retraite des membres du gouvernement, des députés et des gouverneurs sont relevés comme suit :  de 1.5 point de pourcentage de la base de calcul de la contribution à la charge de l’employeur et ce comme suit :0.50 point de pourcentage à partir du 1er juillet 2002, 0.25 point de pourcentage à partir du 1er juillet 2003, 0.25 point de pourcentage à partir du 1er juillet 2004, 0.25 point de pourcentage à partir du 1er juillet 2005, 0.25 point de pourcentage à partir du 1er juillet 2006"
     - title: قانون عدد 123 لسنــة 2001 مؤرخ في 28 ديسمبر 2001 يتعلق بقانون المالية لسنة 2002 (الفصل 85)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_ar.pdf
+      href: https://www.pist.tn/jort/2001/2001A/Ja1042001.pdf
       note: "ترفع نسب المساهمات بنظام الجرايات المدنية والعسكرية للتقاعد والباقين على قيد الحياة في القطاع العمومي وبأنظمة التقاعد لأعضاء الحكومة وأعضاء مجلس النواب والولاّة كما يلي : 1.5 بالمائة من قاعدة احتساب الاشتراك على كاهل المؤجر وذلك على النــحو التالي :0.50 بالمائة ابتداء من غرة جويلية 2002، 0.25 بالمائة ابتداء من غرة جويلية 2003، 0.25 بالمائة ابتداء من غرة جويلية 2004، 0.25 بالمائة ابتداء من غرة جويلية 2005، 0.25 بالمائة ابتداء من غرة جويلية 2006"
     2005-07-01:
     - title: "Référence : loi n°2001-123 du 28 décembre 2001 portant loi de finances 2002 (article 85)"
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_fr.pdf
+      href: https://www.pist.tn/jort/2001/2001F/Jo1042001.pdf
       note: "Les taux de la contribution au régime des pensions civiles et militaires de retraite et des survivants dans le secteur public et des régimes de retraite des membres du gouvernement, des députés et des gouverneurs sont relevés comme suit :  de 1.5 point de pourcentage de la base de calcul de la contribution à la charge de l’employeur et ce comme suit :0.50 point de pourcentage à partir du 1er juillet 2002, 0.25 point de pourcentage à partir du 1er juillet 2003, 0.25 point de pourcentage à partir du 1er juillet 2004, 0.25 point de pourcentage à partir du 1er juillet 2005, 0.25 point de pourcentage à partir du 1er juillet 2006"
     - title: قانون عدد 123 لسنــة 2001 مؤرخ في 28 ديسمبر 2001 يتعلق بقانون المالية لسنة 2002
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_ar.pdf
+      href: https://www.pist.tn/jort/2001/2001A/Ja1042001.pdf
       note: "ترفع نسب المساهمات بنظام الجرايات المدنية والعسكرية للتقاعد والباقين على قيد الحياة في القطاع العمومي وبأنظمة التقاعد لأعضاء الحكومة وأعضاء مجلس النواب والولاّة كما يلي : 1.5 بالمائة من قاعدة احتساب الاشتراك على كاهل المؤجر وذلك على النــحو التالي :0.50 بالمائة ابتداء من غرة جويلية 2002، 0.25 بالمائة ابتداء من غرة جويلية 2003، 0.25 بالمائة ابتداء من غرة جويلية 2004، 0.25 بالمائة ابتداء من غرة جويلية 2005، 0.25 بالمائة ابتداء من غرة جويلية 2006"
     2006-07-01:
     - title: "Référence : loi n°2001-123 du 28 décembre 2001 portant loi de finances 2002 (article 85)"
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_fr.pdf
+      href: https://www.pist.tn/jort/2001/2001F/Jo1042001.pdf
       note: "Les taux de la contribution au régime des pensions civiles et militaires de retraite et des survivants dans le secteur public et des régimes de retraite des membres du gouvernement, des députés et des gouverneurs sont relevés comme suit :  de 1.5 point de pourcentage de la base de calcul de la contribution à la charge de l’employeur et ce comme suit :0.50 point de pourcentage à partir du 1er juillet 2002, 0.25 point de pourcentage à partir du 1er juillet 2003, 0.25 point de pourcentage à partir du 1er juillet 2004, 0.25 point de pourcentage à partir du 1er juillet 2005, 0.25 point de pourcentage à partir du 1er juillet 2006"
     - title: قانون عدد 123 لسنــة 2001 مؤرخ في 28 ديسمبر 2001 يتعلق بقانون المالية لسنة 2002
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_ar.pdf
+      href: https://www.pist.tn/jort/2001/2001A/Ja1042001.pdf
       note: "ترفع نسب المساهمات بنظام الجرايات المدنية والعسكرية للتقاعد والباقين على قيد الحياة في القطاع العمومي وبأنظمة التقاعد لأعضاء الحكومة وأعضاء مجلس النواب والولاّة كما يلي : 1.5 بالمائة من قاعدة احتساب الاشتراك على كاهل المؤجر وذلك على النــحو التالي :0.50 بالمائة ابتداء من غرة جويلية 2002، 0.25 بالمائة ابتداء من غرة جويلية 2003، 0.25 بالمائة ابتداء من غرة جويلية 2004، 0.25 بالمائة ابتداء من غرة جويلية 2005، 0.25 بالمائة ابتداء من غرة جويلية 2006"
     2008-07-01:
       title: Loi n° 2007-43 du 25 juin 2007, modifiant et complétant les lois régissant les pensions servies au titre des régimes de retraite, d’invalidité et de survivants dans les secteurs public et privé et des régimes spéciaux
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/loi_2007_43_fr.pdf
+      href: https://www.pist.tn/jort/2007/2007F/Jo0512007.pdf
       note: "Les taux des contributions au régime des pensions civiles et militaires de retraite et de survivants dans le secteur public et aux régimes de retraite des membres du gouvernement, de la chambre des députés, de la chambre des conseillers et des gouverneurs sont relevés à raison de : 1,8 point de pourcentage de l’assiette de calcul de cotisation, à la charge de l’employeur, et ce, comme suit: 0,60 point de pourcentage à partir du 1er janvier 200,  0,60 point de pourcentage à partir du 1er janvier 2008, 0,60 point de pourcentage à partir du 1er janvier 2009."
     2009-07-01:
     - title: Loi n° 2007-43 du 25 juin 2007, modifiant et complétant les lois régissant les pensions servies au titre des régimes de retraite, d’invalidité et de survivants dans les secteurs public et privé et des régimes spéciaux
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/loi_2007_43_fr.pdf
+      href: https://www.pist.tn/jort/2007/2007F/Jo0512007.pdf
       note: "Les taux des contributions au régime des pensions civiles et militaires de retraite et de survivants dans le secteur public et aux régimes de retraite des membres du gouvernement, de la chambre des députés, de la chambre des conseillers et des gouverneurs sont relevés à raison de : 1,8 point de pourcentage de l’assiette de calcul de cotisation, à la charge de l’employeur, et ce, comme suit: 0,60 point de pourcentage à partir du 1er janvier 200,  0,60 point de pourcentage à partir du 1er janvier 2008, 0,60 point de pourcentage à partir du 1er janvier 2009."
     - title: قانون عدد 43 لسنة 2007 مؤرخ في 25 جوان 2007 يتعلق بتنقيح وإتمام القوانين المنظمة للجرايات المسندة بعنوان أنظمة التقاعد والعجز والباقين على قيد الحياة في القطاعين العمومي والخاص والأنظمة الخصوصية
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/loi_2007_43_ar.pdf
+      href: https://www.pist.tn/jort/2007/2007A/Ja0512007.pdf
       note: "ترفع نسب المساهمات بنظام الجرايات المدنية والعسكرية للتقاعد وللباقين على قيد الحياة في القطاع العمومي وبأنظمة التقاعد لأعضاء الحكومة وأعضاء مجلس النواب وأعضاء مجلس المستشارين والولاة كما يلي : 1,8 بالمائة من قاعدة احتساب الاشتراك على كاهل المؤجر وذلك على النحو التالي : 0,60 بالمائة ابتداء من أوّل جانفي 2007،  0,60 بالمائة ابتداء من أوّل جانفي 2008،  0,60 بالمائة ابتداء من أوّل جانفي 2009،"
     2011-07-01:
     - title: Décret-loi n° 2011-48 du 4 juin 2011, modifiant les lois régissant les pensions civiles et militaires de retraite et des survivants dans le secteur public, le régime de retraite des membres du gouvernement et le régime de retraite des gouverneurs.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2011/décret_loi_2011_48_fr.pdf
+      href: https://www.pist.tn/jort/2011/2011F/Jo0412011.pdf
     - title: مرسوم عدد 48 لسنة 2011 مؤرخ في 4 جوان 2011 يتعلق بتنقيح القوانين المنظمة للجرايات المدنية والعسكرية للتقاعد وللباقين على قيد الحياة في القطاع العمومي ولنظام تقاعد أعضاء الحكومة ولنظام تقاعد الولاة.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2011/décret_loi_2011_48_ar.pdf
+      href: https://www.pist.tn/jort/2011/2011A/Ja0412011.pdf
     2019-06-01:
     - title: Loi 2019-37 du 30 avril 2019, modifiant et complétant la loi n°85-12 du 5 mars 1985, relative au régime des pensions civiles et militaires de retraite et des survivants dans le secteur public.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2019/loi_2019_37__fr.pdf
+      href: https://www.pist.tn/jort/2019/2019F/Jo0352019.pdf
       note: Majoration de 2 points de pourcentage au titre de l’employeur à partir du premier jour du mois qui suit la date d’entrée en vigueur de la loi 2019-37. Applicable aux régimes spéciaux.
   notes:
     2005-07-01:
     - title: loi 2005-54 du 18 juillet 2005, étendant les régimes spéciaux applicables aux  membres de la chambre des députés, aux membres de la chambre des conseillers
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2005/loi_2005_54_fr.pdf
+      href: https://www.pist.tn/jort/2005/2005F/Jo0572005.pdf
       note: Les dispositions de la loi n° 85-16 du 8 mars 1985, fixant le régime de retraite des députés sont étendues aux membres de la chambre des conseillers et aux membres de l’assemblé nationale constituante par la loi 2005-54 du 18 juillet 2005, étendant les régimes spéciaux applicables aux  membres de la chambre des députés, aux membres de la chambre des conseillers
     - title: القانون عدد 54 لسنة 2005 مؤرخ في 18 جويلية 2005 يتعلق بسحب الأنظمة الخاصة المنطبقة على أعضاء مجلس النواب على أعضاء مجلس المستشارين
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2005/loi_2005_54_ar.pdf
+      href: https://www.pist.tn/jort/2005/2005A/Ja0572005.pdf
       note: تنسحب على أعضاء مجلس المستشارين أحكام القانون عدد 16 لسنة 1985 المؤرخ في 8 مارس 1985 المتعلق بضبط نظام تقاعد أعضاء مجلس النواب
     2008-07-01:
     - title: قانون عدد 43 لسنة 2007 مؤرخ في 25 جوان 2007 يتعلق بتنقيح وإتمام القوانين المنظمة للجرايات المسندة بعنوان أنظمة التقاعد والعجز والباقين على قيد الحياة في القطاعين العمومي والخاص والأنظمة الخصوصية
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/loi_2007_43_ar.pdf
+      href: https://www.pist.tn/jort/2007/2007A/Ja0512007.pdf
       note: "ترفع نسب المساهمات بنظام الجرايات المدنية والعسكرية للتقاعد وللباقين على قيد الحياة في القطاع العمومي وبأنظمة التقاعد لأعضاء الحكومة وأعضاء مجلس النواب وأعضاء مجلس المستشارين والولاة كما يلي : 1,8 بالمائة من قاعدة احتساب الاشتراك على كاهل المؤجر وذلك على النحو التالي : 0,60 بالمائة ابتداء من أوّل جانفي 2007،  0,60 بالمائة ابتداء من أوّل جانفي 2008،  0,60 بالمائة ابتداء من أوّل جانفي 2009،"
     2011-07-01:
     - title: loi 2015-39 du 22 septembre 2015, relative à l’extension des dispositions de la loi n° 85-16 du 8 mars 1985, fixant le régime de retraite des députés aux membres de l’assemblé nationale constituante
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2015/loi_2015_39_fr.pdf
+      href: https://www.pist.tn/jort/2015/2015F/Jo0792015.pdf
       note: "Les régimes spéciaux : le régime de retraite des membres du gouvernement, le régime de retraite des députés, le régime de retraite des gouverneurs régie par les lois suivants : Loi n 83-31 du 17 mars 1983fixant le régime de retraite des membres du gouvernement, loi n85-16 du 8 mars 1985 fixant le régime de retraite des députés, loi n88-16 du 17 mars 1988 fixant le régime de retraite des gouverneurs.  Ce régime est étendu aux : aux membres de la chambre des conseillers et aux membres de l’assemblé nationale constituante par la loi 2005-54 du 18 juillet 2005, étendant les régimes spéciaux applicables aux  membres de la chambre des députés, aux membres de la chambre des conseillers et la loi 2015-39 du 22 septembre 2015, relative à l’extension des dispositions de la loi n° 85-16 du 8 mars 1985, fixant le régime de retraite des députés aux membres de l’assemblé nationale constituante"
     - title: قانون عدد 39 لسنة 2015 مؤرخ في 22 سبتمبر 2015 يتعلق بسحب أحكام القانون عدد 16 لسنة 1985 المؤرخ في 8 مارس 1985 المتعلق بضبط نظام تقاعد أعضاء مجلس النواب على أعضاء المجلس الوطني التأسيسي
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2015/loi_2015_39_ar.pdf
+      href: https://www.pist.tn/jort/2015/2015A/Ja0792015.pdf
       note: تنسحب أحكام القانون عدد 16 لسنة 1985 المؤرخ في 8 مارس 1985 المتعلق بضبط نظام تقاعد أعضاء مجلس النواب على أعضاء المجلس الوطني التأسيسي
   rate_unit: /1
   threshold_unit: currency

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_public/regimes_speciaux/gouvernement_deputes_gouverneurs/cotisations_salarie/retraite
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_public/regimes_speciaux/gouvernement_deputes_gouverneurs/cotisations_salarie/retraite
@@ -30,73 +30,73 @@ metadata:
   reference:
     1983-04-01:
     - title: Loi 83-31 du 17 mars 1983, fixant le régime de retraite des membres du gouvernement (article 5).
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1983/loi_83_31_fr.pdf
+      href: https://www.pist.tn/jort/1983/1983F/Jo02383.pdf
     - title: القانون عدد 31 لسنة 1983 المؤرخ في  17 مارس 1983 المتعلق بضبط نظام التقاعد لأعضاء الحكومة
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1983/loi_83_31_ar.pdf
+      href: https://www.pist.tn/jort/1983/1983A/Ja02383.pdf
     1985-04-01:
     - title: loi n°88-16 du 17 mars 1988 fixant le régime de retraite des gouverneurs
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/loi_88_16_fr.pdf
+      href: https://www.pist.tn/jort/1988/1988F/Jo02088.pdf
       note: "Les régimes spéciaux : le régime de retraite des membres du gouvernement, le régime de retraite des députés, le régime de retraite des gouverneurs régie par les lois suivants : Loi n 83-31 du 17 mars 1983fixant le régime de retraite des membres du gouvernement, loi n85-16 du 8 mars 1985 fixant le régime de retraite des députés, loi n88-16 du 17 mars 1988 fixant le régime de retraite des gouverneurs."
-    - title: القانون عدد 16 لسنة 1988 المؤرخ في  17 مارس 1983 المتعلق بنظام تقاعد الولاة
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1988/loi_88_16_ar.pdf
+    - title: قانون عدد 16 لسنة 1988 مؤرخ في 17 مارس 1988 يتعلق بضبط نظام تقاعد الولاة
+      href: https://www.pist.tn/jort/1988/1988A/Ja02088.pdf
       note: "الأنظمة الخضوصية : نظام التقاعد لأعضاء الحكومة، الولاة، أعضاء مجلس النواب"
     - title: Loi n°85-16 du 8 mars 1985, fixant le régime de retraite des députés
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1985/loi_85_16_fr.pdf
+      href: https://www.pist.tn/jort/1985/1985F/Jo02185.pdf
       note: "Les régimes spéciaux : le régime de retraite des membres du gouvernement, le régime de retraite des députés, le régime de retraite des gouverneurs régie par les lois suivants : Loi n 83-31 du 17 mars 1983fixant le régime de retraite des membres du gouvernement, loi n85-16 du 8 mars 1985 fixant le régime de retraite des députés, loi n88-16 du 17 mars 1988 fixant le régime de retraite des gouverneurs."
     - title: القانون عدد 16  لسنة 1985 المؤرخ في  8 مارس 1985 المتعلق بضبط نظام تقاعد أعضاء مجلس النواب
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1985/loi_85_16_ar.pdf
+      href: https://www.pist.tn/jort/1985/1985A/Ja02185.pdf
       note: "الأنظمة الخضوصية : نظام التقاعد لأعضاء الحكومة، الولاة، أعضاء مجلس النواب"
     1994-07-01:
     - title: "Référence : la loi n°94-71 du 27 juin 1994 Relative à la révision des taux de la contribution aux régimes de retraite dans le secteur public"
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1994/loi_94_71_fr.pdf
+      href: https://www.pist.tn/jort/1994/1994F/Jo05094.pdf
       note: l'article 5 de la loi  83-31 du 17 mars 1983 fixant le régime de retraite des membres du gouvernement,  l'article 5 de la loi 85-16 du 8 mars 1985 fixant le régime de retraite des députés,  l'article 5 de la loi  88-16 du 17 mars 1988 fixant le régime de retraite des gouverneurs,
     - title: القانون عدد 71 لسنة 1994 المؤرخ في 17 جوان 1994 المتعلق بتعديل نسب المساهمات في أنظمة التقاعد في القطاع العمومي
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1994/loi_94_71_ar.pdf
+      href: https://www.pist.tn/jort/1994/1994A/Ja05094.pdf
     2002-07-01:
     - title: loi 2001-123 du 28 décembre 2001 portant loi de finances 2002 (article 85)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_fr.pdf
+      href: https://www.pist.tn/jort/2001/2001F/Jo1042001.pdf
       note: "Les taux de la contribution au régime des pensions civiles et militaires de retraite et des survivants dans le secteur public et des régimes de retraite des membres du gouvernement, des députés et des gouverneurs sont relevés comme suit :  de 1 point de pourcentage de la base de calcul de la contribution à la charge de l’assuré social et ce comme suit :0.50 point de pourcentage à partir du 1er juillet 2002, 0.25 point de pourcentage à partir du 1er juillet 2003, 0.25 point de pourcentage à partir du 1er juillet 2004"
     - title: القانون عدد 123 لسنة 2001 المؤرخ في 28 ديسمبر 2001 المتعلق بقانون المالية لسنة 2002
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_ar.pdf
+      href: https://www.pist.tn/jort/2001/2001A/Ja1042001.pdf
       note: "ترفع نسب المساهمات بنظام الجرايات المدنية والعسكرية للتقاعد والباقين على قيد الحياة في القطاع العمومي وبأنظمة التقاعد لأعضاء الحكومة وأعضاء مجلس النواب والولاّة كما يلي : 1 بالمائة من قاعدة احتساب الاشتراك على كاهل المضمون الاجتماعي وذلك على النحو التالي :0.50 بالمائة ابتداء من غرة جويلية ‏2002‏‏-  0.25 بالمائة ابتداء من غرة جويلية 2003 -0.25 بالمائة ابتداء من غرة جويلية 2004"
     2003-07-01:
     - title: loi 2001-123 du 28 décembre 2001 portant loi de finances 2002 (article 85)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_fr.pdf
+      href: https://www.pist.tn/jort/2001/2001F/Jo1042001.pdf
     - title: القانون عدد 123 لسنة 2001 المؤرخ في 28 ديسمبر 2001 المتعلق بقانون المالية لسنة 2002
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_ar.pdf
+      href: https://www.pist.tn/jort/2001/2001A/Ja1042001.pdf
     2004-07-01:
     - title: loi 2001-123 du 28 décembre 2001 portant loi de finances 2002 (article 85)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_fr.pdf
+      href: https://www.pist.tn/jort/2001/2001F/Jo1042001.pdf
       note: "Les taux de la contribution au régime des pensions civiles et militaires de retraite et des survivants dans le secteur public et des régimes de retraite des membres du gouvernement, des députés et des gouverneurs sont relevés comme suit :  de 1 point de pourcentage de la base de calcul de la contribution à la charge de l’assuré social et ce comme suit :0.50 point de pourcentage à partir du 1er juillet 2002, 0.25 point de pourcentage à partir du 1er juillet 2003, 0.25 point de pourcentage à partir du 1er juillet 2004"
     - title: القانون عدد 123 لسنة 2001 المؤرخ في 28 ديسمبر 2001 المتعلق بقانون المالية لسنة 2002
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2001/loi_2001_123_ar.pdf
+      href: https://www.pist.tn/jort/2001/2001A/Ja1042001.pdf
       note: "ترفع نسب المساهمات بنظام الجرايات المدنية والعسكرية للتقاعد والباقين على قيد الحياة في القطاع العمومي وبأنظمة التقاعد لأعضاء الحكومة وأعضاء مجلس النواب والولاّة كما يلي : 1 بالمائة من قاعدة احتساب الاشتراك على كاهل المضمون الاجتماعي وذلك على النحو التالي :0.50 بالمائة ابتداء من غرة جويلية ‏2002‏‏-  0.25 بالمائة ابتداء من غرة جويلية 2003 -0.25 بالمائة ابتداء من غرة جويلية 2004"
     2007-07-01:
     - title: Loi n° 2007-43 du 25 juin 2007, modifiant et complétant les lois régissant les pensions servies au titre des régimes de retraite, d’invalidité et de survivants dans les secteurs public et privé et des régimes spéciaux
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/loi_2007_43_fr.pdf
+      href: https://www.pist.tn/jort/2007/2007F/Jo0512007.pdf
       note: "Les taux des contributions au régime des pensions civiles et militaires de retraite et de survivants dans le secteur public et aux régimes de retraite des membres du gouvernement, de la chambre des députés, de la chambre des conseillers et des gouverneurs sont relevés à raison de : 1,2 point de pourcentage de l’assiette de calcul de cotisation, à la charge de l’assuré social, et ce, comme suit : 0,40 point de pourcentage à partir du 1er juillet 2007, 0,40 point de pourcentage à partir du 1er juillet 2008,  0,40 point de pourcentage à partir du 1er juillet 2009."
     - title: قانون عدد 43 لسنة 2007 المؤرخ في 25 جوان 2007 يتعلق بتنقيح وإتمام القوانين المنظمة للجرايات المسندة بعنوان أنظمة التقاعد والعجز والباقين على قيد الحياة في القطاعين العمومي والخاص والأنظمة الخصوصية
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/loi_2007_43_ar.pdf
+      href: https://www.pist.tn/jort/2007/2007A/Ja0512007.pdf
       note: "ترفع نسب المساهمات بنظام الجرايات المدنية والعسكرية للتقاعد وللباقين على قيد الحياة في القطاع العمومي وبأنظمة التقاعد لأعضاء الحكومة وأعضاء مجلس النواب وأعضاء مجلس المستشارين والولاة كما يلي :  1،2 بالمائة من قاعدة احتساب الاشتراك على كاهل المضمون الاجتماعي وذلك على النحو التالي : 0,40 بالمائة ابتداء من أوّل جويلية 2007، 0,40 بالمائة ابتداء من أوّل جويلية 2008،  0,40 بالمائة ابتداء من أوّل جويلية 2009،"
     - title: loi n° 2005-54 du 18 juillet 2005, étendant les régimes spéciaux applicables aux membres de la chambre des députés, aux membres de la chambre des conseillers
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2005/loi_2005_54_fr.pdf
+      href: https://www.pist.tn/jort/2005/2005F/Jo0572005.pdf
       note: Sont étendues aux membres de la chambre des conseillers, les dispositions de la loi n° 85-16 du 8 mars 1985, fixant le régime de retraite des députés.
     - title: قانون عدد 54 لسنة 2005 مؤرخ في 18 جويلية 2005 يتعلق بسحب الأنظمة الخاصة المنطبقة على أعضاء مجلس النواب على أعضاء مجلس المستشارين
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2005/loi_2005_54_ar.pdf
+      href: https://www.pist.tn/jort/2005/2005A/Ja0572005.pdf
       note: تنسحب على أعضاء مجلس المستشارين أحكام القانون عدد 16 لسنة 1985 المؤرخ في 8 مارس 1985 المتعلق بضبط نظام تقاعد أعضاء مجلس النواب
     2008-07-01:
     - title: loi n° 2007-43 du 25 juin 2007, modifiant et complétant les lois régissant les pensions servies au titre des régimes de retraite, d’invalidité et de survivants dans les secteurs public et privé et des régimes spéciaux
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/loi_2007_43_fr.pdf
+      href: https://www.pist.tn/jort/2007/2007F/Jo0512007.pdf
       note: "Les taux des contributions au régime des pensions civiles et militaires de retraite et de survivants dans le secteur public et aux régimes de retraite des membres du gouvernement, de la chambre des députés, de la chambre des conseillers et des gouverneurs sont relevés à raison de : 1,2 point de pourcentage de l’assiette de calcul de cotisation, à la charge de l’assuré social, et ce, comme suit : 0,40 point de pourcentage à partir du 1er juillet 2007, 0,40 point de pourcentage à partir du 1er juillet 2008,  0,40 point de pourcentage à partir du 1er juillet 2009"
     - title: قانون عدد 43 لسنة 2007 المؤرخ في 25 جوان 2007 يتعلق بتنقيح وإتمام القوانين المنظمة للجرايات المسندة بعنوان أنظمة التقاعد والعجز والباقين على قيد الحياة في القطاعين العمومي والخاص والأنظمة الخصوصية
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/loi_2007_43_fr.pdf
+      href: https://www.pist.tn/jort/2007/2007F/Jo0512007.pdf
       note: "ترفع نسب المساهمات بنظام الجرايات المدنية والعسكرية للتقاعد وللباقين على قيد الحياة في القطاع العمومي وبأنظمة التقاعد لأعضاء الحكومة وأعضاء مجلس النواب وأعضاء مجلس المستشارين والولاة كما يلي :  1،2 بالمائة من قاعدة احتساب الاشتراك على كاهل المضمون الاجتماعي وذلك على النحو التالي : 0,40 بالمائة ابتداء من أوّل جويلية 2007، 0,40 بالمائة ابتداء من أوّل جويلية 2008،  0,40 بالمائة ابتداء من أوّل جويلية 2009،"
     2009-07-01:
     - title: loi n° 2007-43 du 25 juin 2007, modifiant et complétant les lois régissant les pensions servies au titre des régimes de retraite, d’invalidité et de survivants dans les secteurs public et privé et des régimes spéciaux
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/loi_2007_43_fr.pdf
+      href: https://www.pist.tn/jort/2007/2007F/Jo0512007.pdf
       note: "Les taux des contributions au régime des pensions civiles et militaires de retraite et de survivants dans le secteur public et aux régimes de retraite des membres du gouvernement, de la chambre des députés, de la chambre des conseillers et des gouverneurs sont relevés à raison de : 1,2 point de pourcentage de l’assiette de calcul de cotisation, à la charge de l’assuré social, et ce, comme suit : 0,40 point de pourcentage à partir du 1er juillet 2007, 0,40 point de pourcentage à partir du 1er juillet 2008,  0,40 point de pourcentage à partir du 1er juillet 2009"
     - title: قانون عدد 43 لسنة 2007 المؤرخ في 25 جوان 2007 يتعلق بتنقيح وإتمام القوانين المنظمة للجرايات المسندة بعنوان أنظمة التقاعد والعجز والباقين على قيد الحياة في القطاعين العمومي والخاص والأنظمة الخصوصية
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/loi_2007_43_fr.pdf
+      href: https://www.pist.tn/jort/2007/2007F/Jo0512007.pdf
       note: "ترفع نسب المساهمات بنظام الجرايات المدنية والعسكرية للتقاعد وللباقين على قيد الحياة في القطاع العمومي وبأنظمة التقاعد لأعضاء الحكومة وأعضاء مجلس النواب وأعضاء مجلس المستشارين والولاة كما يلي :  1،2 بالمائة من قاعدة احتساب الاشتراك على كاهل المضمون الاجتماعي وذلك على النحو التالي : 0,40 بالمائة ابتداء من أوّل جويلية 2007، 0,40 بالمائة ابتداء من أوّل جويلية 2008،  0,40 بالمائة ابتداء من أوّل جويلية 2009،"
     2019-06-01:
     - title: Loi 2019-37 du 30 avril 2019, modifiant et complétant la loi 85-12 du 5 mars 1985, relative au régime des pensions civiles et militaires de retraite et des survivants dans le secteur public.

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_public/salarie_cnrps/cotisations_employeur/maladie.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_public/salarie_cnrps/cotisations_employeur/maladie.yaml
@@ -16,18 +16,18 @@ metadata:
   reference:
     2007-07-01:
     - title: Décret n° 2007-1406 du 18 juin 2007, fixant l’assiette de calcul des taux de cotisations dues au titre de régime de base d’assurance maladie et ses étapes d’application.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/décret_2007_1406_fr.pdf
+      href: https://www.pist.tn/jort/2007/2007F/Jo0492007.pdf
     - title: امر عدد 1406 لسنة 2007 مؤرخ في 18 جوان 2007 يتعلق بضبط قاعدة احتساب نسب الاشتراكات المستوجبة بعنوان النظام القاعدي للتأمين على المرض ومرحلية تطبيقها
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/Décret_2007_1406__ar.pdf
+      href: https://www.pist.tn/jort/2007/2007A/Ja0492007.pdf
     2008-07-01:
     - title: Décret n° 2007-1406 du 18 juin 2007, fixant l’assiette de calcul des taux de cotisations dues au titre de régime de base d’assurance maladie et ses étapes d’application.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/décret_2007_1406_fr.pdf
+      href: https://www.pist.tn/jort/2007/2007F/Jo0492007.pdf
     - title: امر عدد 1406 لسنة 2007 مؤرخ في 18 جوان 2007 يتعلق بضبط قاعدة احتساب نسب الاشتراكات المستوجبة بعنوان النظام القاعدي للتأمين على المرض ومرحلية تطبيقها
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/Décret_2007_1406__ar.pdf
+      href: https://www.pist.tn/jort/2007/2007A/Ja0492007.pdf
     2009-07-01:
     - title: Décret n° 2007-1406 du 18 juin 2007, fixant l’assiette de calcul des taux de cotisations dues au titre de régime de base d’assurance maladie et ses étapes d’application.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/décret_2007_1406_fr.pdf
+      href: https://www.pist.tn/jort/2007/2007F/Jo0492007.pdf
     - title: امر عدد 1406 لسنة 2007 مؤرخ في 18 جوان 2007 يتعلق بضبط قاعدة احتساب نسب الاشتراكات المستوجبة بعنوان النظام القاعدي للتأمين على المرض ومرحلية تطبيقها
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/Décret_2007_1406__ar.pdf
+      href: https://www.pist.tn/jort/2007/2007A/Ja0492007.pdf
   rate_unit: /1
   threshold_unit: currency

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_public/salarie_cnrps/cotisations_salarie/deces.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_public/salarie_cnrps/cotisations_salarie/deces.yaml
@@ -10,15 +10,15 @@ metadata:
   reference:
     1974-06-01:
     - title: décret 74-572 du 22 mai 1974 relatif au capital décès (article 7)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1974/decret_74_572_fr.pdf
+      href: https://www.pist.tn/jort/1974/1974F/Jo03674.pdf
     - title: الامر عدد 572 لسنة 1974 المؤرخ في 22 ماي 1974 يتعلق براس المال عند الوفاة (الفصل 7)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1974/decret_74_572_ar.pdf
+      href: https://www.pist.tn/jort/1974/1974A/Ja03674.pdf
     1993-01-01:
     - title: Décret n°93-308 du 1er février 1993, relatif au régime du capital décès (article 2).
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/decret__93_308_fr.pdf
+      href: https://www.pist.tn/jort/1993/1993F/Jo01393.pdf
       note: "Conformément au Circulaire du premier ministre n°12 du 15 février 1993, Les principales dispositions du décret n°93-308 susvisé permettent aux agents publics d'opter pour 1'une des deux branches suivantes : La branche générale où la cotisation est calculée sur la base de tous les éléments de la rémunération, soumis à retenue pour pension; La branche facultative transitoire où la cotisation est calculée uniquement sur le salaire de base."
     - title: أمر عدد 308 لسنة 1993 مؤرخ في 1 فيفري 1993 يتعلق بنطام رأس المال عند الوفاة
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/decret__93_308_ar.pdf
+      href: https://www.pist.tn/jort/1993/1993A/Ja01393.pdf
       note: "طبقا لمنشور الوزير الأول عدد 12 بتاريخ 15 فيفري 1993 حول تطبيق الأمر عدد 308 لسنة 1993 : يمكن الأعوان العموميين من اختيار أحد الفرعين التاليين : الفرع العام وهو فرع تحتسب فيه المساهمة على كافة عناصر المرتب الخاضعة للحجز بعنوان جراية التقاعد، الفرع الاختياري الانتقالي وهو فرع تحتسب فيه المساهمة على الأجر الأساسي فحسب"
     - title: Circulaire du premier ministre n°12 du 15 février 1993
       href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1993/circulaire_93_12_ar.pdf

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_public/salarie_cnrps/cotisations_salarie/maladie.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_public/salarie_cnrps/cotisations_salarie/maladie.yaml
@@ -14,19 +14,19 @@ metadata:
   reference:
     1973-04-01:
     - title: décret 73-91 du 12 mars 1973 portant organisation des régimes de prévoyance sociale (article 14)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1973/décret_73_91_fr.pdf
+      href: https://www.pist.tn/jort/1973/1973F/Jo01073.pdf
       note: le décret du 12 avril 1951 a institué un régime de prévoyance sociale en faveur des personnels de l'Etat et des collectivités publiques
     - title: الامر عدد 91 لسنة 1973 المؤرخ في 12  مارس 1973 بتعلق بضبط الانظمة المتعلقة بالحيطة الاجتماعية (الفصل 14)
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/1973/decret__73_91_ar.pdf
+      href: https://www.pist.tn/jort/1973/1973A/Ja01073.pdf
     2008-07-01:
     - title: Décret n° 2007-1406 du 18 juin 2007, fixant l’assiette de calcul des taux de cotisations dues au titre de régime de base d’assurance maladie et ses étapes d’application.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/décret_2007_1406_fr.pdf
+      href: https://www.pist.tn/jort/2007/2007F/Jo0492007.pdf
     - title: امر عدد 1406 لسنة 2007 مؤرخ في 18 جوان 2007 يتعلق بضبط قاعدة احتساب نسب الاشتراكات المستوجبة بعنوان النظام القاعدي للتأمين على المرض ومرحلية تطبيقها
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/décret_2007_1406__ar.pdf
+      href: https://www.pist.tn/jort/2007/2007A/Ja0492007.pdf
     2009-07-01:
     - title: Décret n° 2007-1406 du 18 juin 2007, fixant l’assiette de calcul des taux de cotisations dues au titre de régime de base d’assurance maladie et ses étapes d’application.
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/décret_2007_1406_fr.pdf
+      href: https://www.pist.tn/jort/2007/2007F/Jo0492007.pdf
     - title: امر عدد 1406 لسنة 2007 مؤرخ في 18 جوان 2007 يتعلق بضبط قاعدة احتساب نسب الاشتراكات المستوجبة بعنوان النظام القاعدي للتأمين على المرض ومرحلية تطبيقها
-      href: https://gitlab.com/benjello/tunisia-legislative-references/-/blob/main/lois/2007/décret_2007_1406__ar.pdf
+      href: https://www.pist.tn/jort/2007/2007A/Ja0492007.pdf
   rate_unit: /1
   threshold_unit: currency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-Tunisia"
-version = "0.82"
+version = "0.82.1"
 description = "OpenFisca Rules as Code model for Tunisia."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "tunisia"]

--- a/uv.lock
+++ b/uv.lock
@@ -2064,7 +2064,7 @@ web-api = [
 
 [[package]]
 name = "openfisca-tunisia"
-version = "0.82"
+version = "0.82.1"
 source = { editable = "." }
 dependencies = [
     { name = "openfisca-core", extra = ["web-api"] },


### PR DESCRIPTION
Trois défauts de référence et de documentation, **sans aucun effet sur les résultats** : aucune ligne `value`, `rate` ou `threshold` n'est touchée, et la suite de tests rend le même décompte avant et après (163).

## Ce que ça corrige

### #409 — le titre arabe de la loi n° 88-16 la datait de 1983

Le fichier `cotisations_salarie/retraite` portait « القانون عدد 16 لسنة 1988 المؤرخ في 17 مارس **1983** ». Le texte est de 1988. Le titre est repris sur le **fascicule arabe** du JORT n° 20 du 22 mars 1988, p. 427 (`/jort/1988/1988A/Ja02088.pdf`, sommaire) :

> قانون عدد 16 لسنة 1988 مؤرخ في 17 مارس 1988 يتعلق بضبط نظام تقاعد الولاة

Les deux fichiers — employeur et salarié — portaient deux libellés différents ; ils portent désormais celui du fascicule. La lecture du fascicule confirme au passage l'article 5 : retenue de 10 % sur les éléments permanents du traitement du gouverneur, contribution de l'État de 15 %.

### #411 — trois parts du régime général sont obtenues par solde

Les parts **prestations familiales 3,10 %**, **indemnités de maladie et de maternité 0,85 %** et **décès 0,65 %** ne sont fixées par aucun texte lu : elles se déduisent du taux global de 18 % une fois retranchées les quatre parts attestées (18,00 − 7,25 − 4,75 − 1,00 − 0,40 = 4,60). C'est désormais écrit dans la `documentation` des six paramètres concernés. **Aucune source n'est inventée** : la documentation dit que la source manque.

Les deux points voisins que l'issue cite sont traités de même :

- **le déplacement de 0,0278 point** (documenté dans `rsna/*/retraite.yaml`). Ce qui est **vérifiable sans hypothèse** : la clé 13/5 de l'article 41 (nouveau) donnerait 2,2389 / 0,8611 aux prestations familiales, et `famille.yaml` porte littéralement 2,2111 / 0,8889 — la part patronale est donc 0,0278 point **en dessous** de sa part proportionnelle, et le point compensateur doit se trouver dans une autre branche. Les pensions sont la seule qui équilibre.

  **Réserve à porter au débit de cette PR.** Le couple 5,2639 / 1,9861 que citent les deux blocs `documentation:` n'est porté par **aucun paramètre** : `retraite.yaml` contient 0,077639 et 0,047361, qui agrègent les 7,25 points venus du taux global de 18 % et les 5,25 points du décret n° 97-555. Le partage 5,2639 / 1,9861 (avec 2,50 / 2,75 pour le reste) est une **lecture déduite**, cohérente mais non unique : le partage proportionnel 5,2361 / 2,0139, avec 2,5278 / 2,7222 pour le reste, s'accorde aux mêmes paramètres et ne met alors aucun déplacement dans les pensions. Le fait établi est celui des prestations familiales ; la localisation du point compensateur est une inférence. **Qui fusionnera cette PR est invité à reformuler les deux blocs en ce sens** — le constat de fond, l'absence de texte, n'en est pas affecté.
- **le partage des 1,20 % du régime agricole** (documenté dans `rsa/*/assurances_sociales/{maternite,deces}.yaml`). Le décret n° 81-224 s'arrête à la ligne globale ; seule la part de maladie de 0,91 % est attestée, et tardivement, par l'article 7 du décret n° 2007-1406.

### #405 — 88 liens GitLab remplacés par les fascicules du JORT

Chaque cible vient de `jort_cache.db` (`pdf_fr` / `pdf_ar`), le numéro du texte étant pris dans l'**intitulé** et jamais dans le lien GitLab. Les 87 liens des 9 fichiers hors `marche_travail/` sont traités, plus un dans `marche_travail/`.

Trois défauts de `marche_travail/` que l'issue signale sont corrigés :

- **titre arabe du SMIG 2012** : `smig_48h_mensuel.yaml` portait le titre du décret n° 81-437 (indemnité complémentaire provisoire). Remplacé par celui du décret n° 2012-1981, lu au sommaire du fascicule arabe (JORT n° 77, p. 2579) et déjà présent dans les trois autres fichiers SMIG.
- **titre arabe du SMIG 2022** : le même fichier portait le titre du décret n° 2020-1069. Remplacé par celui du décret n° 2022-769, lu au fascicule arabe (JORT n° 114, p. 2835).
- **les deux liens qui pointent vers un autre texte** : le SMIG 40 h horaire de 1986 renvoyait à l'édition arabe du décret n° 86-690 (SMAG) alors que la valeur porte le décret n° **86-689**. Les deux décrets sont au même fascicule (JORT n° 41, p. 819) ; l'entrée pointe désormais vers l'édition arabe de ce fascicule, avec un intitulé qui nomme le bon décret. Le second — le SMIG 48 h mensuel au 1er mai 2019, qui renvoie au décret n° 2020-1069 — ne peut pas être réparé : voir plus bas.

**Deux corrections en plus de ce que l'issue demandait :**

- les **arrêtés SMAG de 1963 et 1965** sont résolus, contre la prémisse de l'issue. Ils sont dans `jort_cache.db` : arrêté du 24 décembre 1963 « modifiant l'arrêté du 30 avril 1956 relatif à la rémunération des travailleurs agricoles » (JORT n° 59, p. 1841) et arrêté du 31 décembre 1965 « portant relèvement du salaire minimum journalier des travailleurs agricoles » (JORT n° 66, p. 1742). Quatre liens de plus réparés.
- une **entrée malformée** dans `pensionne_cnrps/deces.yaml`, qui portait une URL GitLab en guise d'intitulé sans `href`, reçoit son titre arabe et son `href`.

## Comment c'est vérifié

- **Chaque URL posée répond** : `curl -k -I` → 200 sur les 40 adresses ajoutées.
- Les fascicules cités ont été cherchés dans le corpus local `PDFs-legislation-tunisie/PDFs/JORT/`. **Cette vérification porte sur l'existence du fichier, non sur son contenu** : elle ne prouve pas à elle seule qu'une adresse `…F/Jo…` sert bien l'édition française — le piège connu du dépôt (#397, et le cas `2017F` de cette issue même). Une exception connue : `2022/ar/Ja1412022.pdf`, absent du corpus local, dont seule la réponse 200 de pist.tn atteste.
- **Aucune valeur ne bouge** : `git diff -U0 | grep -E '^[+-]\s*(value|rate|threshold):'` est vide.
- `make test` : **163 passés** avant, **163 passés** après.

## Questions ouvertes

1. **Les deux fichiers `retraite` des régimes spéciaux n'ont pas d'extension `.yaml`, et OpenFisca ne les charge donc pas.** `cotisations_employeur/` et `cotisations_salarie/` du dossier `gouvernement_deputes_gouverneurs` ne rendent aucun enfant (`_children` est vide aux deux nœuds). Seconde raison, indépendante, de leur inertie : `TypesRegimeSecuriteSocialeCotisant` n'a pas de membre gouverneur, donc `compute_cotisation` ne pourrait pas les atteindre. **51 des 88 liens réparés ici vivent dans ces deux fichiers morts.** Les réparer reste utile — c'est le texte qu'un lecteur a sous les yeux — mais la question de fond appartient à la revue : les renommer en `.yaml` (et alors le modèle se met à charger des barèmes que rien ne lit), ou supprimer le sous-arbre comme `parameters/retraite/` l'a été en #402 ? Les deux dépassent le périmètre d'une PR de références.
2. **Ce qui reste sans URL fiable** (14 liens GitLab subsistent) :
   - **décrets gouvernementaux n° 2019-454 et n° 2019-455** (7 liens) : absents de `jort_cache.db`, donc sans adresse pist.tn connue. Règle du dépôt : pas d'URL plutôt qu'une URL devinée.
   - **le SMIG 48 h mensuel au 1er mai 2019** (2 de ces 7) : l'intitulé dit décret n° 2019-454, les deux `href` pointent vers le décret n° 2020-1069. Le texte visé par la valeur étant introuvable, les liens restent en l'état ; seul l'**intitulé arabe**, qui annonçait lui aussi le décret n° 2020-1069, est aligné sur le décret n° 2019-454 que porte l'intitulé français. La revue doit trancher : garder un lien faux, ou le retirer ?
   - **note commune n° 1/2023** (2 liens) et **circulaire du Premier ministre n° 12 du 15 février 1993** (2 liens) : ce ne sont pas des textes du JORT, ils n'ont pas de fascicule.
3. **Le décret-loi n° 2022-79 (loi de finances 2023) n'a pas d'édition française.** `jort_cache.db` ne donne que `pdf_ar` pour le fascicule n° 141, et `https://www.pist.tn/jort/2022/2022F/Jo1412022.pdf` répond **404** quand l'arabe répond 200. Les trois références pointent donc vers l'**édition arabe**, comme la référence de la perte d'emploi en #398. À confirmer par la revue.
4. **Le job CI `dbnomics` échoue pour une cause externe** — course sur le dépôt de données partagé, diagnostiquée en #394. Rien n'est fait ici pour le réparer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SNmAfUpcmPrZt2pKZKy8Z
