### PR TITLE
Régime agricole : les deux premiers paliers d'assurance maladie sur l'article 7 du décret n° 2007-1406

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.83 - [#414](https://github.com/openfisca/openfisca-tunisia/pull/414)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : du 01/07/2007 au 30/06/2009.
+* Zones impactées : `parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa`.
+* Détails :
+  - Aligne les **deux premiers paliers d'assurance maladie du régime des salariés agricoles** sur l'article 7 du **décret n° 2007-1406 du 18 juin 2007** (JORT n° 49, p. 2159), lu au fascicule. Le texte fixe le taux à **1,58 %** au 1er juillet 2007 et à **2,88 %** au 1er juillet 2008 ; les paramètres portaient 1,53 et 2,86. Les trois paliers suivants étaient exacts et ne sont pas touchés.
+  - La **répartition employeur/salarié** que l'article énonce est respectée à la lettre : le point supplémentaire de 2007 est intégralement patronal (« 0,67 % au titre des cotisations supplémentaires à la charge de l'employeur »), celui de 2008 se partage en 0,67 employeur et 0,63 salarié. Seule la part employeur bouge donc : 1,30 → **1,35 %** puis 2,00 → **2,02 %**, la part salariale restant à 0,23 puis 0,86 %.
+  - La correction **se referme sur des valeurs déjà exactes** : le palier du 1er juillet 2009 vaut 2,68 / 1,49, et l'article 7 § 3 le construit en ajoutant 0,66 à l'employeur et 0,63 au salarié. Avec les valeurs corrigées de 2008, l'enchaînement tombe juste ; avec les anciennes, il ne tombait pas.
+  - Trois cas de test sont ajoutés dans `tests/formulas/cotisations/cotisation_maladie.yaml`, un par palier ; les deux premiers échouent sans la correction.
+
+<!-- -->
+
 ### 0.82.1 - [#413](https://github.com/openfisca/openfisca-tunisia/pull/413)
 
 * Amélioration technique.

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_employeur/assurances_sociales/maladie.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_employeur/assurances_sociales/maladie.yaml
@@ -7,9 +7,9 @@ brackets:
     1981-02-24:
       value: 0.0068
     2007-07-01:
-      value: 0.013
+      value: 0.0135
     2008-07-01:
-      value: 0.020
+      value: 0.0202
     2009-07-01:
       value: 0.0268
     2010-07-01:
@@ -20,6 +20,14 @@ metadata:
   rate_unit: /1
   threshold_unit: currency
   reference:
+    2007-07-01:
+    - title: "Décret n° 2007-1406 du 18 juin 2007 fixant l'assiette de calcul des taux de cotisations dues au titre du régime de base d'assurance maladie et ses étapes d'application, article 7"
+      href: "https://www.pist.tn/jort/2007/2007F/Jo0492007.pdf"
+      note: "JORT n° 49, art. 7 p. 2159. « À compter du 1er juillet 2007, le taux de cotisations dues est fixé à 1,58 % de l'assiette des cotisations prévue au premier article du présent décret, et se répartit à raison de : 0,91 % prélevé sur le taux global des cotisations prévues par la loi n° 81-6 du 12 février 1981 susvisée ; 0,67 % au titre des cotisations supplémentaires à la charge de l'employeur. » Le point supplémentaire est donc intégralement patronal : la part de l'employeur passe de 0,68 à 1,35 %, celle du salarié reste à 0,23 %. Édition arabe : https://www.pist.tn/jort/2007/2007A/Ja0492007.pdf"
+    2008-07-01:
+    - title: "Décret n° 2007-1406 du 18 juin 2007 fixant l'assiette de calcul des taux de cotisations dues au titre du régime de base d'assurance maladie et ses étapes d'application, article 7"
+      href: "https://www.pist.tn/jort/2007/2007F/Jo0492007.pdf"
+      note: "JORT n° 49, art. 7 p. 2159. « À compter du 1er juillet 2008, le taux de cotisations prévu au sous paragraphe 1er du présent article est relevé de 1,58 % à 2,88 %, le taux de cotisations supplémentaires, fixé à 1,3 %, se répartit comme suit : 0,67 % à la charge de l'employeur ; 0,63 % à la charge du salarié. » La part de l'employeur passe donc de 1,35 à 2,02 %, celle du salarié de 0,23 à 0,86 %. Édition arabe : https://www.pist.tn/jort/2007/2007A/Ja0492007.pdf"
     1981-02-24:
     - title: "Décret n° 81-224 du 24 février 1981 fixant la répartition des cotisations de sécurité sociale dans le secteur agricole"
       href: "https://www.pist.tn/jort/1981/1981F/Jo01381.pdf"
@@ -27,3 +35,15 @@ metadata:
     - title: "Loi n° 81-6 du 12 février 1981 organisant les régimes de sécurité sociale dans le secteur agricole, article 18"
       href: "https://www.pist.tn/jort/1981/1981F/Jo00981.pdf"
       note: "JORT n° 9, p. 265-273. Fixe le taux global du régime des salariés agricoles à 6,45 %. La loi n'énonce pas de date d'effet. Édition arabe : https://www.pist.tn/jort/1981/1981A/Ja00981.pdf"
+documentation: |
+  LES DEUX PREMIERS PALIERS ONT ÉTÉ CORRIGÉS SUR LE TEXTE (issue #412). L'article 7 du décret
+  n° 2007-1406 donne 1,58 % au 1er juillet 2007 et 2,88 % au 1er juillet 2008 ; les paramètres
+  portaient 1,53 % (1,30 + 0,23) et 2,86 % (2,00 + 0,86). La part patronale passe de 1,30 à
+  1,35 % puis de 2,00 à 2,02 %, la part salariale étant inchangée, comme l'article le prescrit :
+  le point supplémentaire de 2007 est intégralement patronal, celui de 2008 se partage en
+  0,67 employeur et 0,63 salarié.
+
+  LA CORRECTION SE REFERME SUR LES VALEURS DÉJÀ EXACTES. Le palier du 1er juillet 2009, que rien
+  n'a touché ici, vaut 4,17 % réparti 2,68 / 1,49. Il s'obtient exactement du palier corrigé de
+  2008 par les incréments que l'article énonce : 2,02 + 0,66 = 2,68 et 0,86 + 0,63 = 1,49. Avec
+  les anciennes valeurs, l'enchaînement ne tombait pas juste.

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_salarie/assurances_sociales/maladie.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsa/cotisations_salarie/assurances_sociales/maladie.yaml
@@ -20,6 +20,14 @@ metadata:
   rate_unit: /1
   threshold_unit: currency
   reference:
+    2007-07-01:
+    - title: "Décret n° 2007-1406 du 18 juin 2007 fixant l'assiette de calcul des taux de cotisations dues au titre du régime de base d'assurance maladie et ses étapes d'application, article 7"
+      href: "https://www.pist.tn/jort/2007/2007F/Jo0492007.pdf"
+      note: "JORT n° 49, art. 7 p. 2159. Le point supplémentaire du 1er juillet 2007 est intégralement à la charge de l'employeur : la part salariale reste à 0,23 %. Édition arabe : https://www.pist.tn/jort/2007/2007A/Ja0492007.pdf"
+    2008-07-01:
+    - title: "Décret n° 2007-1406 du 18 juin 2007 fixant l'assiette de calcul des taux de cotisations dues au titre du régime de base d'assurance maladie et ses étapes d'application, article 7"
+      href: "https://www.pist.tn/jort/2007/2007F/Jo0492007.pdf"
+      note: "JORT n° 49, art. 7 p. 2159. Au 1er juillet 2008 les cotisations supplémentaires, fixées à 1,3 %, se répartissent en 0,67 employeur et 0,63 salarié : la part salariale passe de 0,23 à 0,86 %. Édition arabe : https://www.pist.tn/jort/2007/2007A/Ja0492007.pdf"
     1981-02-24:
     - title: "Décret n° 81-224 du 24 février 1981 fixant la répartition des cotisations de sécurité sociale dans le secteur agricole"
       href: "https://www.pist.tn/jort/1981/1981F/Jo01381.pdf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-Tunisia"
-version = "0.82.1"
+version = "0.83"
 description = "OpenFisca Rules as Code model for Tunisia."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "tunisia"]

--- a/tests/formulas/cotisations/cotisation_maladie.yaml
+++ b/tests/formulas/cotisations/cotisation_maladie.yaml
@@ -7,3 +7,40 @@
     salaire_de_base: 1000
     maladie_salarie: .027494 * 1000
     maladie_employeur: .040006 * 1000
+
+
+# Régime des salariés agricoles : les deux paliers corrigés sur l'article 7 du
+# décret n° 2007-1406 (JORT n° 49, p. 2159), puis le palier suivant, déjà exact,
+# qui vérifie que la correction se referme sur lui.
+
+- name: Salarié agricole 1000 DT maladie au premier palier (1er juillet 2007)
+  period: 2007-10
+  absolute_error_margin: .001
+  input:
+    regime_securite_sociale_cotisant: rsa
+    salaire_de_base: 1000
+  output:
+    maladie_employeur: .0135 * 1000
+    maladie_salarie: .0023 * 1000
+
+
+- name: Salarié agricole 1000 DT maladie au deuxième palier (1er juillet 2008)
+  period: 2008-10
+  absolute_error_margin: .001
+  input:
+    regime_securite_sociale_cotisant: rsa
+    salaire_de_base: 1000
+  output:
+    maladie_employeur: .0202 * 1000
+    maladie_salarie: .0086 * 1000
+
+
+- name: Salarié agricole 1000 DT maladie au troisième palier (1er juillet 2009)
+  period: 2009-10
+  absolute_error_margin: .001
+  input:
+    regime_securite_sociale_cotisant: rsa
+    salaire_de_base: 1000
+  output:
+    maladie_employeur: .0268 * 1000
+    maladie_salarie: .0149 * 1000

--- a/uv.lock
+++ b/uv.lock
@@ -2064,7 +2064,7 @@ web-api = [
 
 [[package]]
 name = "openfisca-tunisia"
-version = "0.82.1"
+version = "0.83"
 source = { editable = "." }
 dependencies = [
     { name = "openfisca-core", extra = ["web-api"] },


### PR DESCRIPTION
Empilée sur #413, dont elle reprend la base.

## Ce que ça corrige — #412

Dans le régime des salariés agricoles, les deux premiers paliers d'assurance maladie ne correspondaient pas à l'**article 7 du décret n° 2007-1406 du 18 juin 2007**, lu au fascicule (JORT n° 49, p. 2159) :

> « 1) A compter du 1er juillet 2007, le taux de cotisations dues est fixé à **1,58 %** de l'assiette des cotisations prévue au premier article du présent décret, et se répartit à raison de : — **0,91 %** prélevé sur le taux global des cotisations prévues par la loi n° 81-6 du 12 février 1981 susvisée ; — **0,67 %** au titre des cotisations supplémentaires à la charge de l'employeur.
>
> 2) A compter du 1er juillet 2008, le taux de cotisations prévu au sous paragraphe 1er du présent article est relevé de 1,58 % à **2,88 %**, le taux de cotisations supplémentaires, fixé à 1,3 %, se répartit comme suit : — **0,67 % à la charge de l'employeur** ; — **0,63 % à la charge du salarié**. »

La répartition que le texte énonce est donc respectée à la lettre : le point supplémentaire de 2007 est **intégralement patronal**, celui de 2008 se partage. Seule la part employeur bouge :

| Depuis | Texte | Employeur | Salarié | Total |
|---|---:|---|---|---:|
| 1er juillet 2007 | 1,58 % | 1,30 → **1,35** | 0,23 (inchangé) | 1,53 → **1,58** |
| 1er juillet 2008 | 2,88 % | 2,00 → **2,02** | 0,86 (inchangé) | 2,86 → **2,88** |

## Comment c'est vérifié

**La correction se referme sur des valeurs déjà exactes, qui ne sont pas touchées.** Le palier du 1er juillet 2009 vaut 4,17 %, réparti 2,68 / 1,49, et l'article 7 § 3 le construit en ajoutant 0,66 à l'employeur et 0,63 au salarié. Avec les valeurs corrigées de 2008, l'enchaînement tombe juste : **2,02 + 0,66 = 2,68** et **0,86 + 0,63 = 1,49**. Avec les anciennes valeurs, il ne tombait pas. C'est la meilleure preuve disponible que les deux corrections sont les bonnes : elles se raccordent exactement à des valeurs que personne ne conteste.

**Tests ajoutés** — trois cas dans `tests/formulas/cotisations/cotisation_maladie.yaml`, un par palier de 2007, 2008 et 2009. Les deux premiers **échouent sans la correction** (vérifié en remettant l'ancien fichier de paramètres), le troisième pin l'enchaînement.

`make test` : **163 passés** avant, **166 passés** après.

## Questions ouvertes

1. **Le décret est du 18 juin 2007, non du 4 juin.** L'issue le date du 4 juin ; `jort_cache.db` et le fascicule donnent le **18 juin 2007**, publié au JORT n° 49 du 19 juin 2007, pp. 2154-2163. La date de signature retenue ici est celle du fascicule. À confirmer.
2. **Les paliers de 2010 et 2011 n'ont pas de référence propre.** Ils sont exacts, mais leur `reference` s'arrête à 1981 ; seuls 2007 et 2008 en reçoivent une ici, l'article 7 § 4 et § 5 les couvrant pourtant tout autant. Faut-il compléter dans la foulée, ou dans une PR de références distincte ?
3. **La part salariale de 0,23 % de 1981 reste sans texte qui la fixe.** L'article 7 du décret de 2007 atteste le socle global de 0,91 %, pas son partage employeur/salarié en 0,68 / 0,23. Ce point est documenté par #413 et n'est pas tranché ici.
4. **La PR #258, « Alignement des cotisations maladie sur le décret 2007 », touche le même décret — mais pas les mêmes fichiers.** Ouverte le 5 août 2025, mise à jour le 18 septembre 2025, toujours ouverte sur `master`. Trois constats, à la disposition de son auteur :
   - **Aucun recouvrement de fichiers.** Elle modifie `secteur_prive/{rsna,rsaa,rtns,rtte}/…/maladie.yaml` ; celle-ci ne touche que `rsa/`. Les deux sont disjointes, et peuvent être reprises indépendamment.
   - **Ses valeurs RSNA contredisent l'article 6 du décret.** L'article 6, lu au même fascicule (JORT n° 49, p. 2158), fixe pour le régime général 5,32 % au 1er juillet 2007 — « 4,75 % prélevé sur le taux global des cotisations prévu par la loi n° 60-30 [et] 0,57 % au titre des cotisations supplémentaires à la charge de l'employeur » —, puis 6,04 % en 2008 et 6,75 % en 2009, le supplément étant alors « supporté, en totalité, par le salarié ». Les paramètres **actuels** tombent exactement dessus : 4,0006 + 1,3194 = 5,32 ; 4,0006 + 2,0394 = 6,04 ; 4,0006 + 2,7494 = 6,75. La PR #258 remplace le 0,040006 patronal par **0,04**, ce qui donne 5,3194, 6,0394 et 6,7494 — faux de six dix-millièmes à chaque palier —, et ferait de surcroît tomber le total patronal de 16,57 % que `tests/test_cotisations_secteur_prive.py` vérifie contre les chiffres publiés par la CNSS. Le RSNA est donc **déjà exact** et n'a pas besoin d'être aligné. Les régimes RSAA, RTNS et RTTE n'ont pas été vérifiés ici.
   - **Elle entrera en conflit de version avec cette pile.** Elle porte `pyproject.toml` à 0.57 et ajoute une entrée `## 0.57` au CHANGELOG, alors que `master` est à 0.81 ; elle glisse aussi une coquille dans une entrée existante (`github.0.com`).

   Rien n'est fait ici : ni modification, ni fermeture. La décision appartient à son auteur.
5. **Le job CI `dbnomics` échoue pour une cause externe** (#394). Rien n'est fait ici pour le réparer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SNmAfUpcmPrZt2pKZKy8Z
