### PR TITLE
IRPP : deux corrections de code, et deux issues qu'il ne faut pas corriger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 0.84 - [#415](https://github.com/openfisca/openfisca-tunisia/pull/415)
+
+* Correction d'un bug.
+* Périodes concernées : à partir des revenus du 01/01/2020.
+* Zones impactées : `variables/prelevements_obligatoires/contribution_sociale_solidarite`, `parameters/impot_revenu/exoneration`.
+* Détails :
+  - Rend la **contribution sociale de solidarité de nouveau calculable** à partir des revenus 2020. `contribution_sociale_solidarite.formula_2020_01_01` lisait `bareme` et `revenu_net_imposable` **avant de les définir** et levait une `NameError` : la variable annuelle ne rendait aucun résultat sur toute la période. Aucun test ne couvrait ces années, d'où la survie du défaut.
+  - Fait **dériver du barème** le seuil de non-application de la contribution, au lieu de le lire dans `impot_revenu.exoneration.seuil`. Ce paramètre porte l'exonération catégorielle de l'article 73-1 de la loi de finances 2014, **abrogée aux revenus de 2017** par l'article 14-5 de la loi de finances 2017, qui lui substitue précisément la tranche à 0 % du barème. Les deux valeurs coïncidant à 5 000 dinars, le résultat n'était juste que par coïncidence ; il aurait cessé de l'être au premier déplacement de la tranche à 0 %. Le seuil retenu est le premier dont le taux n'est pas nul.
+  - **Clôture `impot_revenu/exoneration/seuil` aux revenus de 2017**, à la date de son abrogation. C'était impossible tant que les formules de la contribution le lisaient : la clôture y provoquait une `ParameterNotFoundError`.
+  - La **formule 2018 n'est pas touchée** : contrairement à ce qu'indiquait l'issue, elle ne lit pas ce paramètre. Les deux lecteurs étaient les formules 2020 de `contribution_sociale_solidarite` et de `contribution_sociale_solidarite_prelevee_a_la_source`. Les cas de la note commune 2018/01 rendent les mêmes valeurs qu'avant.
+  - Six cas de test sont ajoutés dans `tests/formulas/impot_revenu/contribution_sociale_solidarite.yaml` — trois annuels, trois de retenue à la source —, les premiers à couvrir la période.
+
+<!-- -->
+
+## 0.84 - [#415](https://github.com/openfisca/openfisca-tunisia/pull/415)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : les revenus de 1990 à 1996.
+* Zones impactées : `variables/prelevements_obligatoires/impot_revenu/irpp`, `parameters/impot_revenu/deductions/assurance_vie`.
+* Détails :
+  - Borne la **majoration du plafond d'assurance-vie aux quatre premiers enfants à charge** jusqu'aux revenus de 1996. L'article 39 § I-2 du code, dans sa rédaction d'origine, la réserve à « chacun des quatre premiers enfants à charge » (JORT n° 1 des 2-5 janvier 1990, p. 8) ; la formule utilisait `nb_enf` sans borne. La limite disparaît avec l'article 52 de la loi de finances pour 1998.
+  - La limite est portée par un paramètre daté, `assurance_vie/nb_enfants_max`, plutôt que par une constante en dur. La valeur retenue à partir de 1997 est une **sentinelle**, non un chiffre de droit : le texte ne pose alors aucune limite, et un paramètre daté ne sait pas dire « pas de limite ».
+  - **Effet** : un foyer marié de six enfants déduisait 600 dinars là où le texte en donne 500. La question devient sans objet à compter des revenus 2013, la loi de finances 2014 ayant remplacé le plafond majoré par un plafond unique.
+  - Cinq cas de test encadrent la limite de rang en 1995, 1996 et 1998.
+
+<!-- -->
+
+## 0.84 - [#415](https://github.com/openfisca/openfisca-tunisia/pull/415)
+
+* Changement mineur.
+* Détails :
+  - Consigne dans la documentation de `impot_revenu/tspr/smig_ext` **pourquoi l'issue #390 ne peut pas être corrigée** : le paramètre vaut zéro, ce qui rend inerte la branche qui le lit, et il n'existe qu'à partir du 1er janvier 2011 — l'ajouter à la formule d'avant 2011 lèverait une `ParameterNotFoundError` de 2004 à 2010. Trancher demanderait le texte qui institue ce seuil, que le dépouillement n'a pas trouvé ; antidater une valeur reviendrait à inventer une source.
+  - L'issue **#389 n'est pas traitée** non plus : elle ne relève aucun défaut de comportement — « seuls les noms induisent en erreur » —, le renommage qu'elle propose est cassant, donc d'incrément majeur, et l'avertissement qu'elle réclame figure déjà en tête des deux paramètres depuis la PR #385. Le renommage et le retrait de `interets_comptes_speciaux_epargne_cent` appellent une PR majeure distincte.
+
+<!-- -->
+
 ## 0.83 - [#414](https://github.com/openfisca/openfisca-tunisia/pull/414)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_tunisia/parameters/impot_revenu/deductions/assurance_vie/nb_enfants_max.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/deductions/assurance_vie/nb_enfants_max.yaml
@@ -1,0 +1,30 @@
+description: Nombre d'enfants à charge ouvrant droit à la majoration du plafond
+values:
+  1990-01-01:
+    value: 4
+  1997-01-01:
+    value: 99
+metadata:
+  unit: /1
+  reference:
+    1990-01-01:
+      title: Article 39 § I-2 du code de l'IRPP et de l'IS annexé à la loi n° 89-114 du 30 décembre 1989, JORT n° 1 des 2-5 janvier 1990, p. 8
+      href: https://www.pist.tn/jort/1990/1990F/Jo00190.pdf
+    1997-01-01:
+      title: Article 52 de la loi n° 97-88 du 29 décembre 1997 portant loi de finances pour l'année 1998, JORT n° 104 des 30-31 décembre 1997, p. 2439, sous l'intitulé « Encouragement de l'épargne dans le cadre des contrats d'assurance-vie »
+documentation: |
+  LIMITE DE RANG DE LA MAJORATION POUR ENFANTS À CHARGE. Le texte d'origine réserve la
+  majoration aux QUATRE PREMIERS enfants : « majorés de : 100 dinars au titre du conjoint ;
+  50 dinars au titre de chacun des quatre premiers enfants à charge » (JORT n° 1 des
+  2-5 janvier 1990, page 8). La limite disparaît avec l'article 52 de la loi de finances pour
+  1998, qui vise « chacun des enfants à charge au sens des paragraphes II et III de
+  l'article 40 », sans limite de rang.
+
+  LA VALEUR DE 99 EST UNE SENTINELLE, NON UN CHIFFRE DE DROIT : à partir de 1997 le texte ne
+  pose aucune limite, et un paramètre daté ne sait pas dire « pas de limite ». Elle est choisie
+  hors de portée d'un foyer réel. Le point est signalé à la revue, qui peut lui préférer une
+  autre forme.
+
+  La question devient sans objet à compter des revenus 2013 : l'article 24 § 1 de la loi de
+  finances pour 2014 remplace le plafond majoré par un plafond unique, et `enf_plaf` est
+  clôturé à zéro.

--- a/openfisca_tunisia/parameters/impot_revenu/exoneration/seuil.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/exoneration/seuil.yaml
@@ -2,6 +2,8 @@ description: Seuil de revenu net imposable pour l'exonération catégorielle des
 values:
   2014-01-01:
     value: 5000
+  2017-01-01:
+    value: null
 metadata:
   unit: currency
   reference:
@@ -13,14 +15,12 @@ documentation: |
   Exonération catégorielle des salariés et pensionnés dont le revenu net imposable
   n'excède pas 5 000 dinars, instituée par l'article 73-1 de la loi de finances pour 2014.
 
-  ATTENTION — ce paramètre est juridiquement ABROGÉ à compter des revenus de 2017 par
-  l'article 14-5 de la loi n° 2016-78 (loi de finances pour 2017), qui lui substitue la
-  tranche à 0 % du barème jusqu'à 5 000 dinars. La variable `exoneration` respecte cette
-  borne (`end = "2016-12-31"`).
+  CE PARAMÈTRE EST CLÔTURÉ AUX REVENUS DE 2017, date de son abrogation par l'article 14-5
+  de la loi n° 2016-78 (loi de finances pour 2017), qui lui substitue la tranche à 0 % du
+  barème jusqu'à 5 000 dinars. La variable `exoneration` respecte la même borne
+  (`end = "2016-12-31"`).
 
-  Il n'est pas clôturé ici (pas de `value: null` en 2017) parce que les formules de la
-  contribution sociale de solidarité (`contribution_sociale_solidarite`, formules 2018 et
-  2020) le lisent encore pour des années postérieures à l'abrogation. Elles devraient
-  vraisemblablement s'appuyer sur le seuil de la première tranche imposée du barème plutôt
-  que sur ce paramètre. Clôturer ce paramètre sans corriger d'abord ces formules provoque
-  une ParameterNotFoundError. Voir la discussion dans la PR qui a introduit cette note.
+  Il restait ouvert jusqu'ici parce que les formules de la contribution sociale de solidarité
+  le lisaient pour des années postérieures à l'abrogation — le résultat n'étant juste que par
+  coïncidence, les deux seuils valant 5 000 dinars. Ces formules dérivent désormais le seuil
+  du barème lui-même (première tranche imposée), ce qui lève l'obstacle à la clôture.

--- a/openfisca_tunisia/parameters/impot_revenu/tspr/smig_ext.yaml
+++ b/openfisca_tunisia/parameters/impot_revenu/tspr/smig_ext.yaml
@@ -4,3 +4,23 @@ values:
     value: 0
 metadata:
   unit: /1
+documentation: |
+  PARAMÈTRE SANS SOURCE ET SANS EFFET, CONSERVÉ EN L'ÉTAT (issue #390).
+
+  Il est censé étendre aux salaires légèrement supérieurs au salaire minimum la déduction
+  supplémentaire de `abattement_pour_salaire_minimum`. Deux faits le privent de portée :
+
+  1. IL VAUT ZÉRO. La formule qui le consomme teste `revenu_assimile_salaire <= smig_ext` ;
+     avec un seuil nul, la condition est fausse pour tout revenu positif. La branche est donc
+     inerte, y compris sur les années où elle existe.
+  2. IL N'EXISTE QU'À PARTIR DU 1er JANVIER 2011, et n'a aucune référence. C'est pourquoi la
+     formule applicable avant 2011 ne peut pas recevoir la même branche : la lire en 2010
+     lève une `ParameterNotFoundError`.
+
+  L'issue #390 se demandait si l'absence de cette branche avant 2011 était une lacune ou une
+  règle étendue en 2011. La question ne peut pas être tranchée sans le texte qui institue le
+  seuil, que le dépouillement n'a pas trouvé ; et tant que la valeur est nulle, les deux
+  rédactions de la formule donnent le même résultat. Antidater une valeur reviendrait à
+  inventer une source. Le dispositif lui-même — l'ancien paragraphe V de l'article 40 — est
+  de toute façon abrogé à compter des revenus 2014.
+

--- a/openfisca_tunisia/variables/prelevements_obligatoires/contribution_sociale_solidarite.py
+++ b/openfisca_tunisia/variables/prelevements_obligatoires/contribution_sociale_solidarite.py
@@ -4,6 +4,28 @@ from openfisca_tunisia.variables.prelevements_obligatoires.impot_revenu.irpp imp
 )
 
 
+def seuil_de_la_premiere_tranche_imposee(parameters, period):
+    """Seuil au-delà duquel le barème de l'article 44 du code commence à imposer.
+
+    La contribution sociale de solidarité ne s'applique pas aux personnes physiques dont le
+    revenu annuel net ne dépasse pas ce seuil (article 39 de la loi de finances 2020). Ce seuil
+    était lu jusqu'ici dans `impot_revenu.exoneration.seuil`, qui porte l'exonération
+    catégorielle des salariés et pensionnés de l'article 73-1 de la loi de finances 2014 —
+    ABROGÉE à compter des revenus de 2017 par l'article 14-5 de la loi de finances 2017, qui lui
+    substitue précisément la tranche à 0 % du barème. Les deux valeurs coïncidaient à 5 000
+    dinars, de sorte que le résultat était juste par coïncidence ; il aurait cessé de l'être au
+    premier déplacement de la tranche à 0 %.
+
+    Le seuil est dérivé du barème plutôt que lu dans une constante : c'est le premier seuil dont
+    le taux n'est pas nul, ce qui reste vrai quel que soit le nombre de tranches non imposées.
+    """
+    bareme = parameters(period.start).impot_revenu.bareme
+    for seuil, taux in zip(bareme.thresholds, bareme.rates):
+        if taux > 0:
+            return seuil
+    return bareme.thresholds[-1]
+
+
 class contribution_sociale_solidarite(Variable):
     value_type = float
     entity = FoyerFiscal
@@ -11,20 +33,23 @@ class contribution_sociale_solidarite(Variable):
     definition_period = YEAR
 
     def formula_2020_01_01(foyer_fiscal, period, parameters):
-        impot_revenu_brut = bareme.calc(revenu_net_imposable)
+        """Article 39 de la loi de finances 2020.
+
+        La contribution ne s'applique pas aux personnes physiques dont le revenu annuel net
+        ne dépasse pas le seuil de la première tranche imposée du barème.
+        """
         revenu_net_imposable = foyer_fiscal("revenu_net_imposable", period=period)
         bareme_irpp = parameters(period.start).impot_revenu.bareme.copy()
+        impot_revenu_brut = bareme_irpp.calc(revenu_net_imposable)
         bareme_css = parameters(
             period.start
         ).prelevements_sociaux.contribution_sociale_solidarite.salarie
         bareme_irpp.add_tax_scale(bareme_css)
-        non_exonere_css = (
-            revenu_net_imposable
-            > parameters(period.start).impot_revenu.exoneration.seuil
+        non_exonere_css = revenu_net_imposable > seuil_de_la_premiere_tranche_imposee(
+            parameters, period
         )
         return non_exonere_css * (
-            non_exonere_irpp * bareme_irpp.calc(revenu_net_imposable)
-            - impot_revenu_brut
+            bareme_irpp.calc(revenu_net_imposable) - impot_revenu_brut
         )
 
     def formula_2018_01_01(foyer_fiscal, period, parameters):
@@ -87,7 +112,7 @@ class contribution_sociale_solidarite_prelevee_a_la_source(Variable):
         bareme_irpp.add_tax_scale(bareme_css)
         non_exonere_css = (
             12 * revenu_assimile_salaire_apres_abattement - deduction_famille_annuelle
-        ) > parameters(period.start).impot_revenu.exoneration.seuil
+        ) > seuil_de_la_premiere_tranche_imposee(parameters, period)
         return non_exonere_css * (
             non_exonere_irpp
             * bareme_irpp.calc(

--- a/openfisca_tunisia/variables/prelevements_obligatoires/impot_revenu/irpp.py
+++ b/openfisca_tunisia/variables/prelevements_obligatoires/impot_revenu/irpp.py
@@ -226,11 +226,16 @@ class deduction_assurance_vie(Variable):
         marie = foyer_fiscal.declarant_principal("statut_marital", period=period)
         nb_enf = foyer_fiscal("nb_enf", period=period)
         assurance_vie = parameters(period.start).impot_revenu.deductions.assurance_vie
+        # Article 39 § I-2 du code, rédaction d'origine : la majoration est réservée à
+        # « chacun des quatre premiers enfants à charge ». La limite de rang disparaît avec
+        # l'article 52 de la loi de finances pour 1998, qui vise « chacun des enfants à
+        # charge ». D'où un rang maximal daté plutôt qu'un nombre en dur.
+        nb_enf_majores = min_(nb_enf, assurance_vie.nb_enfants_max)
         deduction = min_(
             somme_primes_assurance_vie,
             assurance_vie.plaf
             + marie * assurance_vie.conj_plaf
-            + nb_enf * assurance_vie.enf_plaf,
+            + nb_enf_majores * assurance_vie.enf_plaf,
         )
         return deduction
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-Tunisia"
-version = "0.83"
+version = "0.84"
 description = "OpenFisca Rules as Code model for Tunisia."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "tunisia"]

--- a/tests/formulas/impot_revenu/contribution_sociale_solidarite.yaml
+++ b/tests/formulas/impot_revenu/contribution_sociale_solidarite.yaml
@@ -1,0 +1,65 @@
+# La contribution sociale de solidarité à partir des revenus 2020 (issue #387).
+#
+# Ces cas échouent sans la correction : la formule 2020 de `contribution_sociale_solidarite`
+# lisait `bareme` et `revenu_net_imposable` avant de les définir, et levait une NameError —
+# la variable était donc incalculable sur toute la période. Le seuil de non-application est
+# désormais dérivé du barème (première tranche imposée) et non plus lu dans le paramètre
+# d'exonération catégorielle, abrogé aux revenus de 2017.
+
+- name: Revenu net imposable sous le seuil de la première tranche imposée, pas de contribution
+  period: 2021
+  absolute_error_margin: .1
+  input:
+    salaire_imposable: 5000
+  output:
+    revenu_net_imposable: 4500
+    contribution_sociale_solidarite: 0
+
+
+- name: Revenu net imposable au-dessus du seuil, contribution due
+  period: 2021
+  absolute_error_margin: .1
+  input:
+    salaire_imposable: 6000
+  output:
+    revenu_net_imposable: 5400
+    contribution_sociale_solidarite: 54
+
+
+- name: Contribution d'un revenu net imposable de 28 000 dinars
+  period: 2021
+  absolute_error_margin: .1
+  input:
+    salaire_imposable: 30000
+  output:
+    revenu_net_imposable: 28000
+    contribution_sociale_solidarite: 280
+
+
+# Retenue à la source : elle lisait, elle aussi, le paramètre d'exonération abrogé.
+
+- name: Retenue à la source nulle sous le seuil
+  period: 2021-06
+  absolute_error_margin: .1
+  input:
+    salaire_imposable: 400
+  output:
+    contribution_sociale_solidarite_prelevee_a_la_source: 0
+
+
+- name: Retenue à la source au-dessus du seuil
+  period: 2021-06
+  absolute_error_margin: .1
+  input:
+    salaire_imposable: 500
+  output:
+    contribution_sociale_solidarite_prelevee_a_la_source: 4.5
+
+
+- name: Retenue à la source sur un salaire de 2 500 dinars par mois
+  period: 2021-06
+  absolute_error_margin: .1
+  input:
+    salaire_imposable: 2500
+  output:
+    contribution_sociale_solidarite_prelevee_a_la_source: 23.333

--- a/tests/formulas/impot_revenu/deduction_assurance_vie.yaml
+++ b/tests/formulas/impot_revenu/deduction_assurance_vie.yaml
@@ -1,0 +1,63 @@
+# Majoration du plafond d'assurance-vie et limite de rang (issue #388).
+#
+# Article 39 § I-2 du code, rédaction d'origine : « dans la limite de 200 dinars par an,
+# majorés de : 100 dinars au titre du conjoint ; 50 dinars au titre de chacun des QUATRE
+# PREMIERS enfants à charge » (JORT n° 1 des 2-5 janvier 1990, p. 8). L'article 52 de la loi
+# de finances pour 1998 supprime la limite de rang.
+#
+# `statut_marital: 1` vaut « marié » ; la formule lit ce code entier là où un booléen est
+# attendu, aussi le cas est-il posé explicitement.
+
+- name: Deux enfants en 1995, en deçà de la limite de rang
+  period: 1995
+  absolute_error_margin: .1
+  input:
+    statut_marital: 1
+    nb_enf: 2
+    prime_assurance_vie: 100000
+  output:
+    deduction_assurance_vie: 200 + 100 + 2 * 50
+
+
+- name: Quatre enfants en 1995, à la limite de rang
+  period: 1995
+  absolute_error_margin: .1
+  input:
+    statut_marital: 1
+    nb_enf: 4
+    prime_assurance_vie: 100000
+  output:
+    deduction_assurance_vie: 200 + 100 + 4 * 50
+
+
+- name: Six enfants en 1995, la majoration s'arrête au quatrième
+  period: 1995
+  absolute_error_margin: .1
+  input:
+    statut_marital: 1
+    nb_enf: 6
+    prime_assurance_vie: 100000
+  output:
+    deduction_assurance_vie: 200 + 100 + 4 * 50
+
+
+- name: Six enfants en 1996, dernière année de la limite de rang
+  period: 1996
+  absolute_error_margin: .1
+  input:
+    statut_marital: 1
+    nb_enf: 6
+    prime_assurance_vie: 100000
+  output:
+    deduction_assurance_vie: 200 + 100 + 4 * 50
+
+
+- name: Six enfants en 1998, la limite de rang a disparu
+  period: 1998
+  absolute_error_margin: .1
+  input:
+    statut_marital: 1
+    nb_enf: 6
+    prime_assurance_vie: 100000
+  output:
+    deduction_assurance_vie: 800 + 400 + 6 * 200

--- a/uv.lock
+++ b/uv.lock
@@ -2064,7 +2064,7 @@ web-api = [
 
 [[package]]
 name = "openfisca-tunisia"
-version = "0.83"
+version = "0.84"
 source = { editable = "." }
 dependencies = [
     { name = "openfisca-core", extra = ["web-api"] },


### PR DESCRIPTION
Empilée sur #414, elle-même sur #413.

Quatre issues étaient au programme. **Deux sont corrigées, deux ne le sont pas** — et ne pas les corriger est, à la lecture du code, la bonne réponse. Le détail est plus bas.

## #387 — le minimum d'impôt de la CSS lisait un paramètre d'IRPP abrogé ✔ corrigé

Les formules de la contribution sociale de solidarité lisaient `impot_revenu.exoneration.seuil`, qui porte l'exonération catégorielle de l'article 73-1 de la loi de finances 2014, **abrogée aux revenus de 2017** par l'article 14-5 de la loi de finances 2017 — laquelle lui substitue précisément la tranche à 0 % du barème. Le résultat n'était juste que par coïncidence, les deux valeurs étant à 5 000 dinars.

Les deux formules dérivent désormais le seuil **du barème lui-même** : le premier seuil dont le taux n'est pas nul. Le paramètre peut alors être **clôturé à la date de son abrogation**, ce que l'issue donnait pour impossible sans cette correction.

**Un défaut plus grave a été trouvé au passage, et corrigé dans le même mouvement.** `contribution_sociale_solidarite.formula_2020_01_01` était **incalculable** : sa première ligne lisait `bareme` et `revenu_net_imposable` avant de les définir, et levait une `NameError`. La variable annuelle ne rendait donc aucun résultat à partir des revenus 2020 — ce qui explique que personne n'ait vu le paramètre abrogé : aucun test ne couvrait la période.

Précision utile à la revue : l'issue attribue la lecture fautive aux formules 2018 et 2020 de `contribution_sociale_solidarite`. En réalité les deux lecteurs sont `contribution_sociale_solidarite.formula_2020_01_01` et `contribution_sociale_solidarite_prelevee_a_la_source.formula_2020_01_01`. **La formule 2018 ne lit pas ce paramètre et n'est pas touchée** : les cas de la note commune 2018/01 rendent les mêmes valeurs qu'avant.

**Périodes concernées : à partir des revenus du 01/01/2020.**

## #388 — la majoration pour enfants ignorait la limite de rang d'avant 1997 ✔ corrigé

L'article 39 § I-2 du code, dans sa rédaction d'origine, réserve la majoration à « chacun des **quatre premiers** enfants à charge » (JORT n° 1 des 2-5 janvier 1990, p. 8) ; la limite disparaît avec l'article 52 de la loi de finances pour 1998. `nb_enf` était utilisé sans borne.

Un paramètre daté `assurance_vie/nb_enfants_max` porte la limite — 4 de 1990 à 1996 — plutôt qu'une constante en dur, et la formule borne le nombre d'enfants majorés.

**Périodes concernées : les revenus de 1990 à 1996**, pour les foyers de plus de quatre enfants. Un foyer marié de six enfants déduisait 600 dinars là où le texte en donne 500.

## #389 — non corrigé, et c'est délibéré

L'issue demande de renommer `interets_emprunts_obligataires` et `interets_comptes_speciaux_epargne_bancaires`. Trois raisons de ne pas le faire ici :

1. **Il n'y a pas de défaut de comportement.** L'issue le dit elle-même : « La structure du code est donc correcte ; seuls les noms induisent en erreur. » Aucun test ne peut échouer avant correction — or la consigne de cette PR est : une correction, un test qui échoue sans elle.
2. **C'est un changement cassant**, donc un incrément **majeur** au sens de CONTRIBUTING (« Renaming or removing a variable »), incompatible avec l'incrément mineur de cette PR. Il lui faut la sienne.
3. **L'avertissement que l'issue réclame existe déjà** : les deux `plaf.yaml` s'ouvrent sur « ATTENTION AU NOM… », posé par #385.

Le point annexe — `interets_comptes_speciaux_epargne_cent`, que plus aucune formule ne consomme — est du même ordre : le retirer est cassant. À traiter avec le renommage.

## #390 — non corrigé : le diagnostic ne tient pas à la lecture du code

L'issue suppose une lacune : la formule d'avant 2011 n'aurait pas la branche `smig_ext`. Deux faits, vérifiés, la privent d'objet :

1. **`tspr/smig_ext` vaut zéro.** La branche teste `revenu_assimile_salaire <= smig_ext` : avec un seuil nul, elle est fausse pour tout revenu positif. Elle est donc **inerte**, y compris sur 2011-2013 où elle existe. Les deux rédactions de la formule donnent, aujourd'hui, le même résultat.
2. **Le paramètre n'existe qu'à partir du 1er janvier 2011.** `parameters("2010-01-01").impot_revenu.tspr.smig_ext` lève une `ParameterNotFoundError`. Ajouter la branche à la formule d'avant 2011 ne comblerait donc pas une lacune : cela **casserait** le calcul de 2004 à 2010.

Trancher demanderait le texte qui institue ce seuil, et le paramètre n'a aucune référence. Antidater une valeur reviendrait à inventer une source. Le constat est consigné dans la `documentation` du paramètre, pour que le prochain lecteur ne reprenne pas l'enquête à zéro.

## Comment c'est vérifié

- **Tests ajoutés** : `tests/formulas/impot_revenu/contribution_sociale_solidarite.yaml` (six cas — trois annuels, trois de retenue à la source) et `tests/formulas/impot_revenu/deduction_assurance_vie.yaml` (cinq cas encadrant la limite de rang en 1995, 1996 et 1998). Les cas de CSS **échouent sans la correction** (`NameError`), et ceux de 1995-1996 rendraient 600 au lieu de 500.
- Les tests pinent des **valeurs**, non l'absence d'exception.
- `make test` : 163 passés à la base de la pile, 166 après #414, **177 ici**.

## Questions ouvertes

1. **Le renommage de #389 mérite sa propre PR, à incrément majeur**, avec le retrait de `interets_comptes_speciaux_epargne_cent`. Le découpage proposé : une PR « renommage des déductions d'épargne » qui fait les deux, puisque les deux cassent.
2. **`deduction_assurance_vie` lit `statut_marital` là où un booléen est attendu.** `marie = foyer_fiscal.declarant_principal("statut_marital", …)` rend un entier — 1 pour marié, **2 par défaut pour célibataire** —, puis la formule calcule `marie * conj_plaf`. Un foyer célibataire reçoit donc **deux fois** la majoration pour conjoint, et un foyer marié une seule. Le dépôt a pourtant une variable `marie`, booléenne, que `chef_de_famille` utilise correctement. C'est un défaut distinct de #388, non corrigé ici pour ne pas mélanger les sujets ; les tests ajoutés posent `statut_marital: 1` explicitement pour ne pas en dépendre. **Faut-il une issue ?**
3. **La valeur 99 de `nb_enfants_max` est une sentinelle**, pas un chiffre de droit : à partir de 1997 le texte ne pose aucune limite, et un paramètre daté ne sait pas dire « pas de limite ». La revue peut préférer une autre forme.
4. **Le découpage de l'issue #391** — quatre variables incalculables et deux formules fausses — n'est pas traité ici. Proposition, chaque point étant indépendant :
   - **PR A, « prestations familiales : rendre `af` calculable »**. `prestations_familiales_enfant_a_charge` lève `NameError: age_individu` ; la formule utilise `age_individu`, `salaire_individu` et `smig_48h_mensuel` sans les définir, et `condition_jeune_etudiant = ()` est un tuple vide. Dans le même fichier, `af_nbenf` applique `max_(…, 3)` là où `min_` était visé, et `af` lit `parameters.af.taux.enf1` au lieu de `pf.af.taux.enf1`, sur un nœud jamais évalué à une date. Un seul sujet : la chaîne des allocations familiales, aujourd'hui entièrement morte. Incrément mineur, sauf si la correction de `af_nbenf` change des résultats — auquel cas le paramètre `af/nb_enfants_max` (4 jusqu'aux revenus de 1988, 3 ensuite) doit être consommé dans le même mouvement.
   - **PR B, « AMEN social : les trois variables incalculables »**. `allocation_familiale_non_contributive` appelle `pnafn_eligible`, qui n'existe pas ; `transfert_monetaire_permanent` lit `supplements.amen_social_enfants_a_charge` quand le paramètre s'appelle `supplements.enfant_a_charge` ; `transfert_monetaire_permanent_eligible` appelle `amen_social_score_decile`, qui n'existe pas. La faute de frappe se corrige seule ; les deux variables manquantes sont à créer, et c'est là que des variables d'entrée nouvelles seront nécessaires.
   - **PR C, « la tranche 6-18 ans »**. `allocation_familiale_non_contributive_6_18` teste `(6 <= age) * (age >= 18)` au lieu de `<= 18`. Une ligne, un test, un incrément mineur — mais elle dépend de la PR B, la variable étant aujourd'hui inatteignable.
   - Les **paramètres non consommés** que l'issue liste (`amen_social/aides_ponctuelles/`, `pnafn/allocation`, `amg2`) se raccrochent naturellement à la PR B.
   La question pour la revue : **ce découpage convient-il**, et la PR A doit-elle créer les variables d'entrée qui manquent, ou s'en tenir à rendre calculable ce qui existe ?
5. **Le job CI `dbnomics` échoue pour une cause externe** (#394). Rien n'est fait ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SNmAfUpcmPrZt2pKZKy8Z
