### PR TITLE
Régime général : la réduction conventionnelle de deux points (1996-2007)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.85 - [#416](https://github.com/openfisca/openfisca-tunisia/pull/416)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : du 01/10/1996 au 30/06/2007.
+* Zones impactées : `variables/prelevements_obligatoires/cotisations_sociales`, `parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna`.
+* Détails :
+  - Modélise la **réduction conventionnelle de deux points** de la cotisation employeur du régime général. L'article 41 (nouveau) de la loi n° 60-30, issu de la **loi n° 97-4 du 3 février 1997** (JORT n° 10, p. 154), met 13 % à la charge de l'employeur et ouvre, à son paragraphe 2, une réduction aux employeurs « qui assurent à leurs salariés ainsi qu'à leurs ayants droit, une couverture totale ou partielle des soins de santé dans le cadre d'un régime conventionnel ». L'**article 2** l'applique à compter du **1er octobre 1996** ; le **décret n° 97-1645 du 25 août 1997** en fixe les conditions ; l'**article 16 du décret n° 2007-1406** l'abroge au **1er juillet 2007**.
+  - Trois ajouts : la variable d'entrée `couverture_maladie_conventionnelle` (booléenne, mensuelle, **fausse par défaut**), le paramètre daté `secteur_prive/rsna/reduction_conventionnelle` et la variable calculée `reduction_cotisation_conventionnelle_employeur`, retranchée de `cotisations_employeur`.
+  - **Aucun résultat existant ne change** : sans l'indicatrice, qui vaut faux par défaut, la cotisation patronale est celle de droit commun. Sur 1 000 dinars d'assiette en 2003 : 160 sans réduction, **140 avec**.
+  - La réduction est portée par un **paramètre propre** et non par une seconde série de taux par branche : le 13 % n'existe nulle part en un seul endroit du modèle, et le texte parle de « deux points du taux de cotisation », c'est-à-dire du total. Elle ne vaut que pour le **régime général**.
+  - Un **plancher** empêche la cotisation patronale de devenir négative. Il masque un défaut antérieur, signalé à la revue : la décomposition par branche du régime général n'étant renseignée qu'à partir du 1er janvier 2003 pour les pensions, le total patronal modélisé vaut 12,22 pour 1 000 dinars en 1996 contre 160 en 2003, quand les deux points en retranchent 20.
+  - Ce que le modèle **ne sait pas dire** : l'article 6 du décret n° 97-1645 fait prendre effet la réduction « à partir du premier jour du trimestre suivant celui au cours duquel la décision […] a été accordée ». Une indicatrice mensuelle n'exprime pas cette règle de trimestre.
+  - Sept cas de test couvrent les deux cas et les deux bornes de la période, plus un régime agricole qui vérifie que la réduction ne déborde pas.
+
+<!-- -->
+
 ## 0.84 - [#415](https://github.com/openfisca/openfisca-tunisia/pull/415)
 
 * Correction d'un bug.

--- a/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/reduction_conventionnelle.yaml
+++ b/openfisca_tunisia/parameters/prelevements_sociaux/cotisations_sociales/secteur_prive/rsna/reduction_conventionnelle.yaml
@@ -1,0 +1,46 @@
+description: Réduction du taux de cotisation accordée aux employeurs assurant une couverture maladie conventionnelle
+values:
+  1996-10-01:
+    value: 0.02
+  2007-07-01:
+    value: 0
+metadata:
+  short_label: Réduction conventionnelle
+  unit: /1
+  reference:
+    1996-10-01:
+    - title: "Loi n° 97-4 du 3 février 1997 modifiant la loi n° 60-30 du 14 décembre 1960 relative à l'organisation des régimes de sécurité sociale, article 41 (nouveau) § 2 et article 2"
+      href: "https://www.pist.tn/jort/1997/1997F/Jo01097.pdf"
+      note: "JORT n° 10, p. 154. L'article 41 (nouveau) met 13 % à la charge des employeurs, puis : « Une réduction du taux de cotisation prévue à l'article présent peut être accordée aux employeurs qui assurent à leurs salariés ainsi qu'à leurs ayants droit, une couverture totale ou partielle des soins de santé dans le cadre d'un régime conventionnel. » L'article 2 en fixe la date : « Les dispositions du paragraphe 2 de l'article 41 susvisé relatives à la réduction de deux points de la contribution mise à la charge de l'employeur sont applicables à compter du 1er octobre 1996. » Édition arabe : https://www.pist.tn/jort/1997/1997A/Ja01097.pdf"
+    - title: "Décret n° 97-1645 du 25 août 1997 relatif à la détermination des conditions et modalités de bénéfice de la réduction du taux de cotisation à la sécurité sociale pour les entreprises assurant à leurs salariés une couverture de soins de santé dans le cadre d'un régime conventionnel"
+      href: "https://www.pist.tn/jort/1997/1997F/Jo07197.pdf"
+      note: "JORT n° 71, pp. 1675-1676. Article premier : « Peuvent bénéficier d'une réduction de deux points du taux de cotisation au régime de sécurité sociale, prévu à l'article 41 de la loi susvisée n° 60-30 […], les employeurs assujettis à cette loi, assurant à leurs salariés ainsi qu'à leurs ayants droit […] une couverture en matière d'assurance maladie ordinaire et d'accouchement, dans le cadre d'un régime conventionnel. » Article 6 : « La réduction du taux de cotisation prend effet à partir du premier jour du trimestre suivant celui au cours duquel la décision du bénéfice de la réduction a été accordée. » Édition arabe : https://www.pist.tn/jort/1997/1997A/Ja07197.pdf"
+    2007-07-01:
+    - title: "Décret n° 2007-1406 du 18 juin 2007 fixant l'assiette de calcul des taux de cotisations dues au titre du régime de base d'assurance maladie et ses étapes d'application, article 16"
+      href: "https://www.pist.tn/jort/2007/2007F/Jo0492007.pdf"
+      note: "JORT n° 49, art. 16 p. 2162. « Le présent décret entre en vigueur à compter du premier juillet 2007, et sont abrogées dès lors toutes les dispositions qui lui sont contraires et notamment celles du décret n° 97-1645 du 25 août 1997 susvisé. » La réduction conventionnelle disparaît donc avec la mise en place de l'assurance maladie de base ; la valeur nulle traduit cette abrogation."
+documentation: |
+  RÉDUCTION DE DEUX POINTS, DU 1er OCTOBRE 1996 AU 30 JUIN 2007. L'article 41 (nouveau) de la
+  loi n° 60-30, issu de la loi n° 97-4, met 13 % à la charge de l'employeur du régime général et
+  ouvre, à son paragraphe 2, une réduction de deux points — soit 11 % — aux employeurs assurant
+  à leurs salariés une couverture maladie conventionnelle. Le décret n° 97-1645 en fixe les
+  conditions ; le décret n° 2007-1406, article 16, l'abroge au 1er juillet 2007.
+
+  LA RÉDUCTION EST PORTÉE PAR UN PARAMÈTRE PROPRE, et non par une seconde série de taux par
+  branche. Le taux de 13 % n'existe nulle part en un seul endroit du modèle : il est réparti
+  entre les branches, et la réduction, elle, porte sur le total. Un paramètre unique, appliqué à
+  l'assiette, est la traduction la plus fidèle du texte, qui parle bien de « deux points du taux
+  de cotisation ». La question de savoir s'il faudrait plutôt l'imputer branche par branche est
+  posée à la revue.
+
+  CE QUE LE MODÈLE NE SAIT PAS DIRE. L'article 6 du décret n° 97-1645 fait prendre effet la
+  réduction « à partir du premier jour du trimestre suivant celui au cours duquel la décision
+  […] a été accordée ». Une variable d'entrée mensuelle ne peut pas exprimer cette règle de
+  trimestre : elle dit, mois par mois, si l'employeur en bénéficie. C'est à l'utilisateur de
+  poser l'indicatrice à la bonne date.
+
+  LA DATE DE DÉBUT EST CELLE DU TEXTE, non celle de la structure. L'article 2 de la loi n° 97-4
+  fixe l'application au 1er octobre 1996, alors que les taux par branche du régime général ne
+  commencent qu'au 4 février 1997, date de publication de la loi. Du 1er octobre 1996 au
+  3 février 1997, la réduction s'applique donc à une assiette dont la décomposition par branche
+  n'est pas encore renseignée.

--- a/openfisca_tunisia/variables/prelevements_obligatoires/cotisations_sociales.py
+++ b/openfisca_tunisia/variables/prelevements_obligatoires/cotisations_sociales.py
@@ -156,6 +156,45 @@ class adhesion_cnss_regime_complementaire(Variable):
     set_input = set_input_dispatch_by_period
 
 
+class couverture_maladie_conventionnelle(Variable):
+    value_type = bool
+    default_value = False
+    entity = Individu
+    label = "L'employeur assure une couverture maladie conventionnelle ouvrant droit à la réduction de deux points"
+    definition_period = MONTH
+    set_input = set_input_dispatch_by_period
+    reference = "https://www.pist.tn/jort/1997/1997F/Jo07197.pdf"
+
+
+class reduction_cotisation_conventionnelle_employeur(Variable):
+    value_type = float
+    entity = Individu
+    label = "Réduction de deux points de la cotisation employeur pour couverture maladie conventionnelle"
+    definition_period = MONTH
+
+    def formula_1996_10_01(individu, period, parameters):
+        """Article 41 (nouveau) § 2 de la loi n° 60-30, issu de la loi n° 97-4.
+
+        « Une réduction du taux de cotisation prévue à l'article présent peut être accordée aux
+        employeurs qui assurent à leurs salariés ainsi qu'à leurs ayants droit, une couverture
+        totale ou partielle des soins de santé dans le cadre d'un régime conventionnel. »
+        L'article 2 de la même loi l'applique à compter du 1er octobre 1996 ; le décret
+        n° 97-1645 en fixe les modalités ; l'article 16 du décret n° 2007-1406 l'abroge au
+        1er juillet 2007, d'où un taux nul à partir de cette date.
+
+        La réduction ne vaut que pour le régime général : l'article 41 est celui de la loi
+        n° 60-30, et le décret n° 97-1645 vise « les employeurs assujettis à cette loi ».
+        """
+        assiette = individu("assiette_cotisations_sociales", period)
+        regime = individu("regime_securite_sociale_cotisant", period)
+        couverture = individu("couverture_maladie_conventionnelle", period)
+        taux = parameters(
+            period.start
+        ).prelevements_sociaux.cotisations_sociales.secteur_prive.rsna.reduction_conventionnelle
+        eligible = (regime == TypesRegimeSecuriteSocialeCotisant.rsna) * couverture
+        return eligible * taux * assiette
+
+
 class cotisations_sociales(Variable):
     value_type = float
     entity = Individu
@@ -187,9 +226,16 @@ class cotisations_employeur(Variable):
             "retraite_employeur",
             "retraite_complementaire_employeur",
         ]
-        return sum(
+        cotisations_brutes = sum(
             individu(f"{cotisation}", period) for cotisation in cotisations_employeur
         )
+        # La réduction conventionnelle de deux points (loi n° 97-4, art. 41 nouveau § 2) ne
+        # peut pas rendre la cotisation patronale négative. Le plancher n'est pas décoratif :
+        # la décomposition par branche du régime général n'est renseignée qu'à partir du
+        # 1er janvier 2003 pour les pensions, si bien qu'entre 1996 et 2002 le total patronal
+        # modélisé est inférieur aux deux points que le texte retranche.
+        reduction = individu("reduction_cotisation_conventionnelle_employeur", period)
+        return max_(cotisations_brutes - reduction, 0)
 
 
 class cotisations_salarie(Variable):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-Tunisia"
-version = "0.84"
+version = "0.85"
 description = "OpenFisca Rules as Code model for Tunisia."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "tunisia"]

--- a/tests/formulas/cotisations/reduction_conventionnelle.yaml
+++ b/tests/formulas/cotisations/reduction_conventionnelle.yaml
@@ -1,0 +1,98 @@
+# Réduction conventionnelle de deux points de la cotisation employeur (issue #410).
+#
+# Article 41 (nouveau) § 2 de la loi n° 60-30, issu de la loi n° 97-4 : une réduction peut être
+# accordée aux employeurs qui assurent à leurs salariés une couverture maladie conventionnelle.
+# Article 2 de la même loi : applicable à compter du 1er octobre 1996. Article 16 du décret
+# n° 2007-1406 : abrogation au 1er juillet 2007.
+#
+# Sans l'indicatrice, rien ne change : la valeur par défaut est « sans réduction ».
+
+- name: Régime général, sans couverture conventionnelle, cotisation patronale de droit commun
+  period: 2003-01
+  absolute_error_margin: .001
+  input:
+    regime_securite_sociale_cotisant: rsna
+    salaire_de_base: 1000
+  output:
+    cotisations_employeur: .16 * 1000
+    reduction_cotisation_conventionnelle_employeur: 0
+
+
+- name: Régime général, avec couverture conventionnelle, deux points en moins
+  period: 2003-01
+  absolute_error_margin: .001
+  input:
+    regime_securite_sociale_cotisant: rsna
+    salaire_de_base: 1000
+    couverture_maladie_conventionnelle: true
+  output:
+    reduction_cotisation_conventionnelle_employeur: .02 * 1000
+    cotisations_employeur: .16 * 1000 - .02 * 1000
+
+
+# Borne haute : le dispositif vit jusqu'au 30 juin 2007 et disparaît le 1er juillet.
+
+- name: Dernier mois du dispositif, la réduction s'applique encore
+  period: 2007-06
+  absolute_error_margin: .001
+  input:
+    regime_securite_sociale_cotisant: rsna
+    salaire_de_base: 1000
+    couverture_maladie_conventionnelle: true
+  output:
+    reduction_cotisation_conventionnelle_employeur: .02 * 1000
+    cotisations_employeur: .16 * 1000 - .02 * 1000
+
+
+- name: Premier mois après l'abrogation, la réduction ne s'applique plus
+  period: 2007-07
+  absolute_error_margin: .001
+  input:
+    regime_securite_sociale_cotisant: rsna
+    salaire_de_base: 1000
+    couverture_maladie_conventionnelle: true
+  output:
+    reduction_cotisation_conventionnelle_employeur: 0
+    cotisations_employeur: .1657 * 1000
+
+
+# Borne basse : rien avant le 1er octobre 1996, puis la réduction s'applique. Sur ces mois-là,
+# la décomposition par branche du régime général n'est pas encore renseignée — les pensions ne
+# commencent qu'au 1er janvier 2003 — et le plancher empêche une cotisation patronale négative.
+
+- name: Le mois précédant l'entrée en vigueur, aucune réduction
+  period: 1996-09
+  absolute_error_margin: .001
+  input:
+    regime_securite_sociale_cotisant: rsna
+    salaire_de_base: 1000
+    couverture_maladie_conventionnelle: true
+  output:
+    reduction_cotisation_conventionnelle_employeur: 0
+
+
+- name: Premier mois d'application, la réduction joue et la cotisation ne devient pas négative
+  period: 1996-10
+  absolute_error_margin: .001
+  input:
+    regime_securite_sociale_cotisant: rsna
+    salaire_de_base: 1000
+    couverture_maladie_conventionnelle: true
+  output:
+    reduction_cotisation_conventionnelle_employeur: .02 * 1000
+    cotisations_employeur: 0
+
+
+# La réduction est propre au régime général : l'article 41 est celui de la loi n° 60-30, et le
+# décret n° 97-1645 vise « les employeurs assujettis à cette loi ».
+
+- name: Régime des salariés agricoles, la couverture conventionnelle ne change rien
+  period: 2003-01
+  absolute_error_margin: .001
+  input:
+    regime_securite_sociale_cotisant: rsa
+    salaire_de_base: 1000
+    couverture_maladie_conventionnelle: true
+  output:
+    reduction_cotisation_conventionnelle_employeur: 0
+    cotisations_employeur: 43.975

--- a/uv.lock
+++ b/uv.lock
@@ -2064,7 +2064,7 @@ web-api = [
 
 [[package]]
 name = "openfisca-tunisia"
-version = "0.84"
+version = "0.85"
 source = { editable = "." }
 dependencies = [
     { name = "openfisca-core", extra = ["web-api"] },


### PR DESCRIPTION
Empilée sur #415, elle-même sur #414 et #413.

## Ce que ça ajoute — #410

L'article 41 (nouveau) de la loi n° 60-30, issu de la **loi n° 97-4 du 3 février 1997** (JORT n° 10, p. 154), met 13 % à la charge de l'employeur du régime général, puis :

> « Une réduction du taux de cotisation prévue à l'article présent peut être accordée aux employeurs qui assurent à leurs salariés ainsi qu'à leurs ayants droit, une couverture totale ou partielle des soins de santé dans le cadre d'un régime conventionnel. »

L'**article 2** de la même loi en fixe la date : « Les dispositions du paragraphe 2 de l'article 41 susvisé relatives à la **réduction de deux points** de la contribution mise à la charge de l'employeur sont applicables **à compter du 1er octobre 1996**. » Le **décret n° 97-1645 du 25 août 1997** (JORT n° 71, pp. 1675-1676) en fixe les conditions, et le **décret n° 2007-1406, article 16** (JORT n° 49, p. 2162) l'abroge : « Le présent décret entre en vigueur à compter du premier juillet 2007, et sont abrogées dès lors toutes les dispositions qui lui sont contraires et notamment celles du décret n° 97-1645 du 25 août 1997 susvisé. »

Le modèle ne portait que le taux de droit commun. Cette PR ajoute :

- **une variable d'entrée**, `couverture_maladie_conventionnelle` (booléenne, mensuelle, **`False` par défaut** — donc aucun résultat existant ne change) ;
- **un paramètre daté**, `secteur_prive/rsna/reduction_conventionnelle`, à 0,02 du 1er octobre 1996 et à zéro à partir du 1er juillet 2007 ;
- **une variable calculée**, `reduction_cotisation_conventionnelle_employeur`, retranchée de `cotisations_employeur`.

**La réduction est portée par un paramètre propre plutôt que par une seconde série de taux par branche.** Le 13 % n'existe nulle part en un seul endroit du modèle : il est réparti entre les branches, et le texte, lui, parle de « deux points du taux de cotisation » — c'est-à-dire du total. Un paramètre unique appliqué à l'assiette est la traduction la plus fidèle.

**Elle ne vaut que pour le régime général**, l'article 41 étant celui de la loi n° 60-30 et le décret n° 97-1645 visant « les employeurs assujettis à cette loi ».

## Comment c'est vérifié

Sept cas dans `tests/formulas/cotisations/reduction_conventionnelle.yaml` : les deux cas (avec et sans couverture) et les deux bornes de la période (1996-09 / 1996-10 d'un côté, 2007-06 / 2007-07 de l'autre), plus un cas de régime agricole qui vérifie que la réduction ne déborde pas.

Sur une assiette de 1 000 dinars en 2003 : **160 sans réduction, 140 avec**. Au 1er juillet 2007, l'indicatrice reste sans effet : 165,70 dans les deux cas.

`make test` : **184 passés** (177 à la base de la pile, plus sept).

## Questions ouvertes

1. **De 1996 à 2002, poser l'indicatrice fait rendre au modèle une cotisation patronale NULLE — c'est un artefact, pas une règle.** C'est la question la plus importante de cette PR, et elle mérite d'être lue avant les autres. La **décomposition par branche du régime général n'est renseignée qu'à partir du 1er janvier 2003** pour les pensions : sur une assiette de 1 000 dinars, le total patronal modélisé vaut 12,22 en 1996 et 15,11 en 1997, contre 160 en 2003 — quand les deux points en retranchent 20. Sans plancher, `cotisations_employeur` rendait **−7,78** en octobre 1996 ; avec lui, elle rend **0**. Deux conséquences à assumer :
   - **les deux variables se contredisent sur cette plage** : `reduction_cotisation_conventionnelle_employeur` rapporte les deux points théoriques (20), tandis que la réduction réellement appliquée est plafonnée à 12,22. Qui recalculerait `brut − réduction` en aval retomberait sur −7,78 ;
   - le cas de test de 1996-10 **pin donc un artefact** de la décomposition d'avant 2003, et non un résultat de droit. Son intitulé le dit, mais la valeur `0` pourrait se lire, dans quelques mois, comme une règle modélisée : elle ne l'est pas.

   Le défaut de fond est **antérieur à cette PR** — entre 1997 et 2002, le total patronal du régime général est très en deçà des 13 % de la loi n° 97-4 — et n'est pas dangereux en pratique, l'indicatrice valant faux par défaut. Deux décisions pour la revue : **faut-il ouvrir une issue** sur la datation des pensions du régime général avant 2003, et **faut-il plafonner à l'intérieur de la variable de réduction** plutôt que dans `cotisations_employeur`, pour que les deux variables cessent de diverger ?

2. **Pourquoi le plancher a été posé là.** Ce n'est pas un détail défensif : **la décomposition par branche du régime général n'est renseignée qu'à partir du 1er janvier 2003** pour les pensions. Sur une assiette de 1 000 dinars, le total patronal modélisé vaut 12,22 en 1996 et 15,11 en 1997, contre 160 en 2003 — alors que les deux points en retranchent 20. Sans plancher, `cotisations_employeur` rendait **−7,78** en octobre 1996. Le plancher (`max_(brut − réduction, 0)`) évite l'absurde, mais **il masque un trou de modélisation antérieur à cette PR** : entre 1997 et 2002, le total patronal du régime général est très en deçà des 13 % que la loi n° 97-4 énonce. Faut-il ouvrir une issue sur la datation des pensions du régime général avant 2003 ?
3. **La date de début retenue est celle du texte, pas celle de la structure.** L'article 2 de la loi n° 97-4 dit le 1er octobre 1996 ; les taux par branche du régime général, eux, ne commencent qu'au 4 février 1997, date de publication de la loi — le choix fait en #398, dont la note dans `rsna/.../famille.yaml` signale déjà que la loi « n'énonce pas de date d'effet pour ce taux : la seule date qu'elle fixe, le 1er octobre 1996, porte sur la réduction conventionnelle ». La réduction est donc datée du texte et la structure de la publication, ce qui est cohérent avec les deux lectures mais laisse quatre mois où la réduction s'applique à une assiette dont la décomposition n'existe pas. La revue peut préférer aligner le début sur le 4 février 1997.
4. **La règle de trimestre de l'article 6 n'est pas modélisée.** « La réduction du taux de cotisation prend effet à partir du premier jour du trimestre suivant celui au cours duquel la décision du bénéfice de la réduction a été accordée. » Une indicatrice mensuelle ne sait pas exprimer cette règle : elle dit, mois par mois, si l'employeur en bénéficie, et c'est à l'utilisateur de la poser à la bonne date. Faut-il une variable de date de décision qui en dérive le trimestre ?
5. **Faut-il imputer la réduction branche par branche ?** Elle est ici retranchée du total patronal. Si un réutilisateur a besoin du détail par branche — pour une ventilation comptable, par exemple —, la forme actuelle ne le lui donne pas.
6. **Le job CI `dbnomics` échoue pour une cause externe** (#394). Rien n'est fait ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SNmAfUpcmPrZt2pKZKy8Z
