### PR TITLE
Marché du travail : la rémunération minimale servie de 1989 à 1992

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.86 - [#417](https://github.com/openfisca/openfisca-tunisia/pull/417)
+
+* Évolution du système socio-fiscal.
+* Périodes concernées : à partir du 01/08/1989.
+* Zones impactées : `variables/marche_travail`.
+* Détails :
+  - Expose la **rémunération minimale effectivement servie** — salaire minimum légal **plus indemnité spéciale** — par trois variables calculées : `remuneration_minimale_servie_48h_mensuel`, `remuneration_minimale_servie_40h_mensuel` et `remuneration_minimale_servie_agricole_journaliere`. Les paramètres `marche_travail/indemnite_speciale_smig` et `indemnite_speciale_smag`, posés par la PR #404, n'étaient lus par **aucune formule** : d'août 1989 à avril 1992, une rémunération minimale simulée était inférieure de 3 à 5 dinars par mois à ce qui était servi.
+  - **Une variable calculée plutôt qu'une variable d'entrée** : la grandeur ne dépend d'aucune situation individuelle, elle se déduit entièrement de deux paramètres et de la date.
+  - **Ces variables ne sont branchées sur aucune assiette, et c'est le point.** L'article 5 du décret n° 89-1551 dispose qu'« à titre exceptionnel, l'indemnité spéciale n'est pas prise en compte pour la détermination de l'assiette des cotisations et des prestations de sécurité sociale », et son article 4 suspend à son titre les retenues d'impôt sur les traitements et salaires, de contribution personnelle d'État, de contribution de solidarité et au profit du FOPROLOS ; les décrets n° 89-1552, n° 91-1316 et n° 91-1317 disent la même chose. Les brancher sur `assiette_cotisations_sociales`, `salaire_imposable` ou `revenu_assimile_salaire` contredirait ces textes. **Aucun résultat existant ne change.**
+  - Les formules commencent au **1er août 1989**, faute de paramètre d'indemnité avant cette date. Le **décret n° 92-1299** (art. 3) et le **décret n° 92-1300** (art. 3) intègrent l'indemnité au SMIG et au SMAG au **1er mai 1992** : les paramètres valent alors zéro et la rémunération servie se confond avec le minimum légal.
+  - Six cas de test couvrent les quatre dates qui comptent, de la veille de l'institution au mois de l'intégration.
+
+<!-- -->
+
 ## 0.85 - [#416](https://github.com/openfisca/openfisca-tunisia/pull/416)
 
 * Évolution du système socio-fiscal.

--- a/openfisca_tunisia/variables/marche_travail.py
+++ b/openfisca_tunisia/variables/marche_travail.py
@@ -1,0 +1,62 @@
+"""Rémunération minimale effectivement servie, indemnités spéciales comprises."""
+
+from openfisca_tunisia.variables.base import *  # noqa analysis:ignore
+
+
+# Du 1er août 1989 au 30 avril 1992, le salaire minimum légal ne dit pas tout ce qui était
+# servi : une indemnité spéciale s'y ajoute, sans en faire partie. Les décrets n° 89-1551
+# (art. 4 et 5), n° 89-1552, n° 91-1316 et n° 91-1317 l'excluent expressément de l'assiette
+# des cotisations, de celle des prestations de sécurité sociale et de l'impôt. Le décret
+# n° 92-1299 (art. 3) l'intègre au SMIG au 1er mai 1992, et le décret n° 92-1300 (art. 3) fait
+# de même pour le SMAG ; les paramètres tombent alors à zéro.
+#
+# Ces variables exposent donc la rémunération minimale SERVIE, distincte du salaire minimum
+# LÉGAL que portent `marche_travail.smig_*` et `marche_travail.smag_journalier`. Elles ne sont
+# consommées par aucune assiette : les y brancher contredirait les textes qui les en excluent.
+# C'est précisément ce que demande l'issue #406 — rendre la grandeur lisible sans toucher aux
+# assiettes.
+#
+# Les formules commencent au 1er août 1989 parce que les paramètres d'indemnité n'existent pas
+# avant : les lire plus tôt lèverait une ParameterNotFoundError.
+
+
+class remuneration_minimale_servie_48h_mensuel(Variable):
+    value_type = float
+    entity = Individu
+    label = "Rémunération minimale mensuelle servie au régime de 48 heures, indemnité spéciale comprise"
+    definition_period = MONTH
+    reference = "https://www.pist.tn/jort/1989/1989F/Jo06989.pdf"
+
+    def formula_1989_08_01(individu, period, parameters):
+        marche_travail = parameters(period.start).marche_travail
+        return (
+            marche_travail.smig_48h_mensuel + marche_travail.indemnite_speciale_smig
+        ) * individu.filled_array(1.0)
+
+
+class remuneration_minimale_servie_40h_mensuel(Variable):
+    value_type = float
+    entity = Individu
+    label = "Rémunération minimale mensuelle servie au régime de 40 heures, indemnité spéciale comprise"
+    definition_period = MONTH
+    reference = "https://www.pist.tn/jort/1989/1989F/Jo06989.pdf"
+
+    def formula_1989_08_01(individu, period, parameters):
+        marche_travail = parameters(period.start).marche_travail
+        return (
+            marche_travail.smig_40h_mensuel + marche_travail.indemnite_speciale_smig
+        ) * individu.filled_array(1.0)
+
+
+class remuneration_minimale_servie_agricole_journaliere(Variable):
+    value_type = float
+    entity = Individu
+    label = "Rémunération minimale journalière servie dans l'agriculture, indemnité spéciale comprise"
+    definition_period = MONTH
+    reference = "https://www.pist.tn/jort/1989/1989F/Jo06989.pdf"
+
+    def formula_1989_08_01(individu, period, parameters):
+        marche_travail = parameters(period.start).marche_travail
+        return (
+            marche_travail.smag_journalier + marche_travail.indemnite_speciale_smag
+        ) * individu.filled_array(1.0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "OpenFisca-Tunisia"
-version = "0.85"
+version = "0.86"
 description = "OpenFisca Rules as Code model for Tunisia."
 readme = "README.md"
 keywords = ["microsimulation", "tax", "benefit", "rac", "rules-as-code", "tunisia"]

--- a/tests/formulas/remuneration_minimale_servie.yaml
+++ b/tests/formulas/remuneration_minimale_servie.yaml
@@ -1,0 +1,55 @@
+# Rémunération minimale servie, indemnité spéciale comprise (issue #406).
+#
+# Décrets n° 89-1551 et n° 89-1552 : indemnité de 3 dinars par mois et de 115 millimes par
+# journée, à compter du 1er août 1989, exclue de l'assiette des cotisations, des prestations et
+# de l'impôt. Décrets n° 91-1316 et n° 91-1317 : 5 dinars et 215 millimes au 1er août 1991.
+# Décrets n° 92-1299 et n° 92-1300, article 3 : l'indemnité est intégrée au salaire minimum au
+# 1er mai 1992, et les paramètres tombent à zéro.
+
+- name: Avant l'institution de l'indemnité, la variable n'est pas définie
+  period: 1989-07
+  absolute_error_margin: .001
+  output:
+    remuneration_minimale_servie_48h_mensuel: 0
+    remuneration_minimale_servie_agricole_journaliere: 0
+
+
+- name: Premier mois de l'indemnité spéciale
+  period: 1989-08
+  absolute_error_margin: .001
+  output:
+    remuneration_minimale_servie_48h_mensuel: 110.032 + 3
+    remuneration_minimale_servie_40h_mensuel: 96.386 + 3
+    remuneration_minimale_servie_agricole_journaliere: 3.2 + 0.115
+
+
+- name: Le SMIG de 1990 ne comprend pas l'indemnité, qui subsiste à côté de lui
+  period: 1990-06
+  absolute_error_margin: .001
+  output:
+    remuneration_minimale_servie_48h_mensuel: 120.016 + 3
+    remuneration_minimale_servie_agricole_journaliere: 3.546 + 0.115
+
+
+- name: Relèvement de l'indemnité au 1er août 1991
+  period: 1991-08
+  absolute_error_margin: .001
+  output:
+    remuneration_minimale_servie_48h_mensuel: 120.016 + 5
+    remuneration_minimale_servie_agricole_journaliere: 3.546 + 0.215
+
+
+- name: Dernier mois avant l'intégration au salaire minimum
+  period: 1992-04
+  absolute_error_margin: .001
+  output:
+    remuneration_minimale_servie_48h_mensuel: 120.016 + 5
+    remuneration_minimale_servie_agricole_journaliere: 3.546 + 0.215
+
+
+- name: Au 1er mai 1992 l'indemnité est intégrée, la rémunération servie est le salaire minimum
+  period: 1992-05
+  absolute_error_margin: .001
+  output:
+    remuneration_minimale_servie_48h_mensuel: 132.912
+    remuneration_minimale_servie_agricole_journaliere: 3.961

--- a/uv.lock
+++ b/uv.lock
@@ -2064,7 +2064,7 @@ web-api = [
 
 [[package]]
 name = "openfisca-tunisia"
-version = "0.85"
+version = "0.86"
 source = { editable = "." }
 dependencies = [
     { name = "openfisca-core", extra = ["web-api"] },


### PR DESCRIPTION
Empilée sur #416, elle-même sur #415, #414 et #413. Dernière de la série.

## Ce que ça ajoute — #406

Depuis #404, `marche_travail/smig_*` et `smag_journalier` portent le salaire minimum **légal**, et les indemnités spéciales de 1989-1991 vivent dans `indemnite_speciale_smig` et `indemnite_speciale_smag`. Le partage est juste, mais **aucune formule ne lisait ces deux paramètres** : d'août 1989 à avril 1992, une rémunération minimale simulée était inférieure de 3 à 5 dinars par mois à ce qui était effectivement servi.

Trois variables calculées exposent désormais la **rémunération minimale servie** :

- `remuneration_minimale_servie_48h_mensuel`
- `remuneration_minimale_servie_40h_mensuel`
- `remuneration_minimale_servie_agricole_journaliere`

## Pourquoi une variable calculée, et non une variable d'entrée

L'issue laissait le choix. **Une variable d'entrée n'aurait rien apporté** : la grandeur ne dépend d'aucune situation individuelle, seulement de la date. Elle se déduit entièrement de deux paramètres, et c'est la définition d'une variable calculée.

**Et pourquoi elle n'est branchée sur aucune assiette.** Les textes l'interdisent, explicitement :

- décret n° 89-1551, **article 5** : « À titre exceptionnel, l'indemnité spéciale n'est pas prise en compte pour la détermination de l'assiette des cotisations et des prestations de sécurité sociale » ; **article 4** : les retenues d'impôt sur les traitements et salaires, de contribution personnelle d'État, de contribution de solidarité et au profit du FOPROLOS sont suspendues à son titre ;
- décret n° 89-1552, articles 3 et 4, pour le SMAG ; décrets n° 91-1316 et n° 91-1317, articles 4 et 5, à l'identique.

Les brancher sur `assiette_cotisations_sociales`, `salaire_imposable` ou `revenu_assimile_salaire` **contredirait donc les textes**. Ces variables sont volontairement consommées par rien : elles rendent la grandeur lisible — ce que demande l'issue — sans toucher à des assiettes dont le droit les exclut. **Aucun résultat existant ne change.**

Le décret n° 92-1299 (art. 3) intègre l'indemnité au SMIG au 1er mai 1992, le décret n° 92-1300 (art. 3) fait de même pour le SMAG : à partir de cette date, les paramètres valent zéro et la rémunération servie se confond avec le salaire minimum légal. La variable reste définie, ce qui est le comportement voulu — elle dit « le minimum servi », qui après 1992 est le minimum légal.

Les formules commencent au **1er août 1989** parce que les paramètres d'indemnité n'existent pas avant : les lire plus tôt lèverait une `ParameterNotFoundError`. Avant cette date, les variables valent zéro, ce qu'un cas de test pose explicitement.

## Comment c'est vérifié

Six cas dans `tests/formulas/remuneration_minimale_servie.yaml`, aux quatre dates qui comptent : avant l'institution (1989-07), au premier mois (1989-08 : 110,032 + 3), au relèvement du SMIG sans relèvement de l'indemnité (1990-06 : 120,016 + 3), au relèvement de l'indemnité (1991-08 : 120,016 + 5), au dernier mois du dispositif (1992-04) et après l'intégration (1992-05 : 132,912, l'indemnité ayant disparu dans le SMIG).

`make test` : **190 passés** (184 à la base de la pile, plus six).

## Questions ouvertes

1. **Seules les formes mensuelles et journalière sont exposées.** Les décrets fixent aussi des montants **horaires** — 17 millimes en 40 heures, 14 millimes en 48 heures en 1989 ; 29 et 24 millimes en 1991 — mais `indemnite_speciale_smig` ne porte que le montant **mensuel**. Exposer `remuneration_minimale_servie_*_horaire` supposerait d'ajouter ces montants aux paramètres, avec la curiosité que le fascicule de 1991 imprime « 45 heures » là où on attend 48. À faire dans une PR de paramètres, si le besoin existe.
2. **La variable reste définie après mai 1992**, où elle se confond avec le salaire minimum légal. C'est cohérent avec son nom, mais on peut préférer la clôturer au 30 avril 1992 pour que son existence même signale la période où les deux notions divergent.
3. **Un montant journalier dans une variable mensuelle.** `remuneration_minimale_servie_agricole_journaliere` porte une valeur **par journée de travail** alors que sa `definition_period` est le MOIS, comme ses deux sœurs. Rien ne la consomme et aucun `set_input` n'est déclaré, donc il n'y a pas de bug vivant ; mais un appel avec `options=[ADD]` sur une année **additionnerait douze montants journaliers**, ce qui ne veut rien dire. Trois issues possibles : la convertir en montant mensuel (ce qui suppose un nombre de journées travaillées que les décrets ne fixent pas), la déclarer en `definition_period = ETERNITY` ou `YEAR`, ou la laisser telle quelle en assumant que son nom porte l'unité. La même remarque vaut, à moindre degré, pour les deux variables mensuelles, dont le montant est bien mensuel.

4. **L'entité retenue est `Individu` et la période le mois.** La grandeur ne dépend d'aucune caractéristique individuelle ; l'entité n'est là que parce qu'OpenFisca en exige une. Si le dépôt préfère réserver les variables aux grandeurs vraiment individuelles, l'alternative est de ne rien exposer et de documenter les paramètres — la seconde branche que proposait l'issue.
5. **Le job CI `dbnomics` échoue pour une cause externe** (#394). Rien n'est fait ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SNmAfUpcmPrZt2pKZKy8Z
