### PR TITLE
chore(outillage) : faire courir yamllint dans make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,13 @@ check-path-length:
 	$(UV) python openfisca_tunisia/scripts/check_path_length.py
 
 check-yaml:
-	.github/lint-changed-yaml-tests.sh
+	@# `uv run` fournit yamllint au script, qui appelle le binaire par son nom.
+	$(UV) .github/lint-changed-yaml-tests.sh
 
 check-all-yaml:
 	$(UV) yamllint openfisca_tunisia/parameters
 	$(UV) yamllint tests
 
-test: clean check-syntax-errors check-style
+test: clean check-syntax-errors check-style check-yaml
 	@echo "> Yaml tests..."
 	$(UV) openfisca test --country-package openfisca_tunisia tests


### PR DESCRIPTION
`make test` ne lançait pas `yamllint` : la cible `test` ne dépendait que de `check-syntax-errors` et `check-style`, tandis que `yamllint` vivait dans `check-yaml` / `check-all-yaml`. La CI, elle, exécute `.github/lint-changed-yaml-tests.sh` dans son job `lint-files`. Une PR verte en local pouvait donc échouer en CI sur un test YAML mal formé.

**Ce que fait cette PR**

Un seul fichier modifié, le `Makefile`. Le chemin de CI n'est pas touché.

- `test` dépend désormais de `check-yaml`, la cible qui appelle exactement le script que la CI exécute, sur exactement le même périmètre (les tests YAML modifiés depuis le dernier tag). La vérification par défaut du développeur couvre donc ce que la CI refuse, sans élargir le contrôle à des fichiers que la CI ne regarde pas.
- `check-yaml` lance ce script sous `$(UV)`, qui met `.venv/bin` sur le `PATH` et lui fournit donc `yamllint` ; le script continue d'appeler le binaire par son nom et reste **inchangé**. C'est la forme qu'emploient déjà les autres cibles du fichier, `check-style` en tête (`$(UV) ruff check .`). Sans cela la cible échoue en local avec `Failed to spawn: yamllint`, le binaire n'étant pas sur le `PATH`.
- `check-all-yaml` reste la cible complète (tous les paramètres et tous les tests). Elle n'est pas branchée sur `test` : elle échoue aujourd'hui sur des fichiers préexistants, ce qui sort du cadre de cette PR.

**Pourquoi ne pas modifier le script**

`.github/lint-changed-yaml-tests.sh` est exécuté par la CI de **toutes** les PR du dépôt. Le modifier pour un besoin de confort local ferait porter le risque d'une régression sur la PR d'un tiers, et aucune CI ne l'exercerait ici : le script ne contrôle que les tests YAML modifiés depuis le dernier tag, or cette PR n'en touche aucun — le job `lint-files` affiche « No changed YAML tests to lint ». Le correctif est donc entièrement local et n'entame en rien le chemin de CI.

**Vérifié en conditions réelles**

- Arbre propre : `make check-yaml` passe (« No changed YAML tests to lint »).
- Espaces en fin de ligne ajoutés dans `tests/formulas/age.yaml` : `make check-yaml` et `make test` échouent désormais tous deux, avec `7:18 error trailing spaces (trailing-spaces)` puis `make: *** [Makefile:41: check-yaml] Error 1`. Le code de sortie passe de 0 à 2.
- Ligne retirée : les deux repassent au vert.

Le contrôle porte ici sur les espaces en fin de ligne et non sur la longueur : le `.yamllint` de ce dépôt désactive `line-length`. Le défaut d'outillage est le même que dans `openfisca-tunisia-pension`, seule la règle qui le révèle diffère.

**Version et CHANGELOG**

Aucun changement de version ni d'entrée au CHANGELOG. `has-functional-changes.sh` ignore `Makefile`, seul fichier touché ; lancé sur cette branche, il répond « No functional changes detected. » Ce n'est pas une évolution du système socio-fiscal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SNmAfUpcmPrZt2pKZKy8Z
