### PR TITLE
CI : ne plus tenir l'outillage pour un changement fonctionnel

### DIFF
--- a/.github/has-functional-changes.sh
+++ b/.github/has-functional-changes.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-IGNORE_DIFF_ON="README.md CONTRIBUTING.md Makefile .gitignore .github/*"
+IGNORE_DIFF_ON="README.md CONTRIBUTING.md Makefile .gitignore .github/* scripts/* reports/*"
 
 last_tagged_commit=`git describe --tags --abbrev=0 --first-parent`  # --first-parent ensures we don't follow tags not published in master through an unlikely intermediary merge commit
 


### PR DESCRIPTION
`check-version-and-changelog` échoue sur toute proposition qui n'ajoute qu'un outil.

## Le faux positif

`.github/has-functional-changes.sh` tient pour **fonctionnel** tout fichier absent de `IGNORE_DIFF_ON`, qui ne couvre aujourd'hui que `README.md`, `CONTRIBUTING.md`, `Makefile`, `.gitignore` et `.github/*`. Un script d'outillage ou un rapport engendré exige donc un incrément de version et une entrée de journal — alors qu'il ne touche ni un paramètre, ni une formule, ni un résultat de calcul, et qu'il n'a rien à annoncer aux réutilisateurs du paquet.

C'est ce qui bloque [#422](https://github.com/openfisca/openfisca-tunisia/pull/422), qui n'ajoute qu'un script d'audit et son rapport.

## Le correctif

`scripts/*` et `reports/*` rejoignent la liste.

## La vérification

Sur la branche de #422, qui ne touche exactement que ces deux répertoires :

| Filtre | Réponse | Code |
|---|---|---:|
| actuel | « The functional files above were changed » | 0 |
| élargi | « No functional changes detected » | 1 |

Contre-épreuve sur `master` : le script répond toujours « No functional changes detected », rien n'ayant changé depuis le tag.

Ce fichier étant lui-même dans `.github/*`, cette proposition ne réclame ni version ni entrée de journal.

## Ce que cela ne change pas

Un changement de paramètre, de formule ou de test reste fonctionnel et continue d'exiger sa version. Le filtre ne s'élargit qu'à ce qui ne sort pas du dépôt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SNmAfUpcmPrZt2pKZKy8Z
